### PR TITLE
fix: avoid overflow in `stats/base/dists/wald/logpdf`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/factory.js
@@ -73,6 +73,7 @@ function factory( mu, lambda ) {
 	*/
 	function logpdf( x ) {
 		var v;
+		var z;
 		if ( isnan( x ) ) {
 			return NaN;
 		}
@@ -80,7 +81,8 @@ function factory( mu, lambda ) {
 			return NINF;
 		}
 		v = x - mu;
-		return 0.5 * ( ln( lambda ) - ( LN_TWO_PI + ( 3.0 * ln( x ) ) ) - ( ( ( lambda / x ) * ( v / mu ) ) * ( v / mu ) ) );
+		z = v / mu;
+		return 0.5 * ( ln( lambda ) - ( LN_TWO_PI + ( 3.0 * ln( x ) ) ) - ( ( ( lambda / x ) * z ) * z ) );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/factory.js
@@ -59,7 +59,7 @@ function factory( mu, lambda ) {
 	if ( lambda === 0.0 ) {
 		return degenerate( mu );
 	}
-	A = ln( lambda );
+	A = ln( lambda ) - LN_TWO_PI;
 	return logpdf;
 
 	/**
@@ -82,7 +82,7 @@ function factory( mu, lambda ) {
 			return NINF;
 		}
 		v = ( x - mu ) / mu;
-		return 0.5 * ( A - ( LN_TWO_PI + ( 3.0 * ln( x ) ) ) - ( ( ( lambda / x ) * v ) * v ) );
+		return 0.5 * ( A - ( 3.0 * ln( x ) ) - ( ( ( lambda / x ) * v ) * v ) );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/factory.js
@@ -73,16 +73,14 @@ function factory( mu, lambda ) {
 	*/
 	function logpdf( x ) {
 		var v;
-		var z;
 		if ( isnan( x ) ) {
 			return NaN;
 		}
 		if ( x <= 0.0 || x === PINF ) {
 			return NINF;
 		}
-		v = x - mu;
-		z = v / mu;
-		return 0.5 * ( ln( lambda ) - ( LN_TWO_PI + ( 3.0 * ln( x ) ) ) - ( ( ( lambda / x ) * z ) * z ) );
+		v = ( x - mu ) / mu;
+		return 0.5 * ( ln( lambda ) - ( LN_TWO_PI + ( 3.0 * ln( x ) ) ) - ( ( ( lambda / x ) * v ) * v ) );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/factory.js
@@ -80,7 +80,7 @@ function factory( mu, lambda ) {
 			return NINF;
 		}
 		v = x - mu;
-		return 0.5 * ( ln( lambda ) - ( LN_TWO_PI + ( 3.0 * ln( x ) ) ) - ( ( lambda * v * v ) / ( mu * mu * x ) ) );
+		return 0.5 * ( ln( lambda ) - ( LN_TWO_PI + ( 3.0 * ln( x ) ) ) - ( ( ( lambda / x ) * ( v / mu ) ) * ( v / mu ) ) );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/factory.js
@@ -47,6 +47,7 @@ var NINF = require( '@stdlib/constants/float64/ninf' );
 * // returns ~-0.129
 */
 function factory( mu, lambda ) {
+	var A;
 	if (
 		isnan( mu ) ||
 		isnan( lambda ) ||
@@ -58,6 +59,7 @@ function factory( mu, lambda ) {
 	if ( lambda === 0.0 ) {
 		return degenerate( mu );
 	}
+	A = ln( lambda );
 	return logpdf;
 
 	/**
@@ -80,7 +82,7 @@ function factory( mu, lambda ) {
 			return NINF;
 		}
 		v = ( x - mu ) / mu;
-		return 0.5 * ( ln( lambda ) - ( LN_TWO_PI + ( 3.0 * ln( x ) ) ) - ( ( ( lambda / x ) * v ) * v ) );
+		return 0.5 * ( A - ( LN_TWO_PI + ( 3.0 * ln( x ) ) ) - ( ( ( lambda / x ) * v ) * v ) );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/main.js
@@ -78,6 +78,7 @@ var NINF = require( '@stdlib/constants/float64/ninf' );
 */
 function logpdf( x, mu, lambda ) {
 	var v;
+	var z;
 	if (
 		isnan( x ) ||
 		isnan( mu ) ||
@@ -94,7 +95,8 @@ function logpdf( x, mu, lambda ) {
 		return NINF;
 	}
 	v = x - mu;
-	return 0.5 * ( ln( lambda ) - ( LN_TWO_PI + ( 3.0 * ln( x ) ) ) - ( ( ( lambda / x ) * ( v / mu ) ) * ( v / mu ) ) );
+	z = v / mu;
+	return 0.5 * ( ln( lambda ) - ( LN_TWO_PI + ( 3.0 * ln( x ) ) ) - ( ( ( lambda / x ) * z ) * z ) );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/main.js
@@ -94,7 +94,7 @@ function logpdf( x, mu, lambda ) {
 		return NINF;
 	}
 	v = x - mu;
-	return 0.5 * ( ln( lambda ) - ( LN_TWO_PI + ( 3.0 * ln( x ) ) ) - ( ( lambda * v * v ) / ( mu * mu * x ) ) );
+	return 0.5 * ( ln( lambda ) - ( LN_TWO_PI + ( 3.0 * ln( x ) ) ) - ( ( ( lambda / x ) * ( v / mu ) ) * ( v / mu ) ) );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/main.js
@@ -78,7 +78,6 @@ var NINF = require( '@stdlib/constants/float64/ninf' );
 */
 function logpdf( x, mu, lambda ) {
 	var v;
-	var z;
 	if (
 		isnan( x ) ||
 		isnan( mu ) ||
@@ -94,9 +93,8 @@ function logpdf( x, mu, lambda ) {
 	if ( x <= 0.0 || x === PINF ) {
 		return NINF;
 	}
-	v = x - mu;
-	z = v / mu;
-	return 0.5 * ( ln( lambda ) - ( LN_TWO_PI + ( 3.0 * ln( x ) ) ) - ( ( ( lambda / x ) * z ) * z ) );
+	v = ( x - mu ) / mu;
+	return 0.5 * ( ln( lambda ) - ( LN_TWO_PI + ( 3.0 * ln( x ) ) ) - ( ( ( lambda / x ) * v ) * v ) );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/src/main.c
@@ -37,7 +37,6 @@
 */
 double stdlib_base_dists_wald_logpdf( const double x, const double mu, const double lambda ) {
 	double v;
-	double z;
 
 	if (
 		stdlib_base_is_nan( x ) ||
@@ -54,7 +53,6 @@ double stdlib_base_dists_wald_logpdf( const double x, const double mu, const dou
 	if ( x <= 0.0 || x == STDLIB_CONSTANT_FLOAT64_PINF ) {
 		return STDLIB_CONSTANT_FLOAT64_NINF;
 	}
-	v = x - mu;
-	z = v / mu;
-	return 0.5 * ( stdlib_base_ln( lambda ) - ( STDLIB_CONSTANT_FLOAT64_LN_TWO_PI + ( 3.0 * stdlib_base_ln( x ) ) ) - ( ( ( lambda / x ) * z ) * z ) );
+	v = ( x - mu ) / mu;
+	return 0.5 * ( stdlib_base_ln( lambda ) - ( STDLIB_CONSTANT_FLOAT64_LN_TWO_PI + ( 3.0 * stdlib_base_ln( x ) ) ) - ( ( ( lambda / x ) * v ) * v ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/src/main.c
@@ -54,5 +54,5 @@ double stdlib_base_dists_wald_logpdf( const double x, const double mu, const dou
 		return STDLIB_CONSTANT_FLOAT64_NINF;
 	}
 	v = x - mu;
-	return 0.5 * ( stdlib_base_ln( lambda ) - ( STDLIB_CONSTANT_FLOAT64_LN_TWO_PI + ( 3.0 * stdlib_base_ln( x ) ) ) - ( ( lambda * v * v ) / ( mu * mu * x ) ) );
+	return 0.5 * ( stdlib_base_ln( lambda ) - ( STDLIB_CONSTANT_FLOAT64_LN_TWO_PI + ( 3.0 * stdlib_base_ln( x ) ) ) - ( ( ( lambda / x ) * ( v / mu ) ) * ( v / mu ) ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/src/main.c
@@ -37,6 +37,7 @@
 */
 double stdlib_base_dists_wald_logpdf( const double x, const double mu, const double lambda ) {
 	double v;
+	double z;
 
 	if (
 		stdlib_base_is_nan( x ) ||
@@ -54,5 +55,6 @@ double stdlib_base_dists_wald_logpdf( const double x, const double mu, const dou
 		return STDLIB_CONSTANT_FLOAT64_NINF;
 	}
 	v = x - mu;
-	return 0.5 * ( stdlib_base_ln( lambda ) - ( STDLIB_CONSTANT_FLOAT64_LN_TWO_PI + ( 3.0 * stdlib_base_ln( x ) ) ) - ( ( ( lambda / x ) * ( v / mu ) ) * ( v / mu ) ) );
+	z = v / mu;
+	return 0.5 * ( stdlib_base_ln( lambda ) - ( STDLIB_CONSTANT_FLOAT64_LN_TWO_PI + ( 3.0 * stdlib_base_ln( x ) ) ) - ( ( ( lambda / x ) * z ) * z ) );
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   provides follow-up fixes for commits merged to `develop` between 2026-08-18 17:33 PDT (`fd16a2f`) and 2026-08-19 05:08 PDT (`dd78acd`). An automated review of the 25 commits in that window (style-guide compliance audit plus two independent bug scans over the union diff) surfaced one validated, high-signal issue.

**`stats/base/dists/wald/logpdf`**

-   Fixes a numerical overflow in `47b5192`: the exponent term `(lambda*v*v)/(mu*mu*x)` overflows before dividing, so `logpdf(1.0, 1e155, 1.0)` returns NaN and `logpdf(1e155, 1.0, 1.0)` returns `-Infinity` instead of finite values, violating the documented NaN-only-on-invalid-input contract. Reassociated as `((lambda/x)*(v/mu))*(v/mu)` in `lib/main.js:97`, `lib/factory.js:83`, and `src/main.c:57`; all 100 Julia fixtures still pass at 2 ULP.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed on the commit window:

-   Style-guide compliance audit (two independent passes) of all changed code against `docs/style-guides` and established reference packages (e.g., the new `stats/base/dists/wald/*` packages against `stats/base/dists/wald/cdf` and `stats/base/dists/lognormal/*`): no violations found.
-   Bug scan (two independent passes) of the union diff: verified the Wald `quantile`/`logcdf`/`logpdf`/`stdev` formulas and documented example values numerically, JS↔C parity, and the `fromIndex` index-resolution logic in `blas/ext/base/ndarray/dfirst-index-less-than`. Only the overflow above survived validation.
-   Deliberately excluded: subjective concerns, style preferences not required by the style guides, and anything requiring changes outside the window's diff to validate.

The fix was verified by reproducing the failure on the shipped code, re-running the reassociated implementation, and confirming all 100 Julia fixture cases pass at the tests' 2-ULP tolerance for both `logpdf` and `logpdf.factory`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was produced by a scheduled automated commit-review run using Claude Code: agents reviewed the last 24 hours of commits merged to `develop`, and the fix in this PR was generated and validated by Claude Code. A human maintainer will audit before marking ready for review.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8V7HF1iWEmV52cnPiGgLD)_