### PR TITLE
test: migrate `math/base/special/cflipsignf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cflipsignf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsignf/test/test.js
@@ -24,8 +24,7 @@ var tape = require( 'tape' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
@@ -48,13 +47,11 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function evaluates the flipsign function', function test( t ) {
-	var delta;
 	var ans;
 	var ere;
 	var eim;
 	var are;
 	var aim;
-	var tol;
 	var re;
 	var im;
 	var y;
@@ -72,18 +69,8 @@ tape( 'the function evaluates the flipsign function', function test( t ) {
 		ans = cflipsignf( z, y[ i ] );
 		are = real( ans );
 		aim = imag( ans );
-		if ( are === ere[ i ] && aim === eim[ i ] ) {
-			t.strictEqual( are, ere[ i ], 're: '+re[ i ]+'. Expected: '+ere[ i ] );
-			t.strictEqual( aim, eim[ i ], 'im: '+im[ i ]+'. Expected: '+eim[ i ] );
-		} else {
-			delta = absf( are - ere[ i ] );
-			tol = EPS * absf( ere[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[ i ]+'. im: '+im[ i ]+'. Actual re: '+are+'. Expected re: '+ere[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-
-			delta = absf( aim - eim[ i ] );
-			tol = EPS * absf( eim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[ i ]+'. im: '+im[ i ]+'. Actual im: '+aim+'. Expected im: '+eim[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( are, ere[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( aim, eim[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cflipsignf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsignf/test/test.native.js
@@ -25,8 +25,7 @@ var tape = require( 'tape' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
@@ -57,13 +56,11 @@ tape( 'main export is a function', opts, function test( t ) {
 });
 
 tape( 'the function evaluates the flipsign function', opts, function test( t ) {
-	var delta;
 	var ans;
 	var ere;
 	var eim;
 	var are;
 	var aim;
-	var tol;
 	var re;
 	var im;
 	var y;
@@ -81,18 +78,8 @@ tape( 'the function evaluates the flipsign function', opts, function test( t ) {
 		ans = cflipsignf( z, y[ i ] );
 		are = real( ans );
 		aim = imag( ans );
-		if ( are === ere[ i ] && aim === eim[ i ] ) {
-			t.strictEqual( are, ere[ i ], 're: '+re[ i ]+'. Expected: '+ere[ i ] );
-			t.strictEqual( aim, eim[ i ], 'im: '+im[ i ]+'. Expected: '+eim[ i ] );
-		} else {
-			delta = absf( are - ere[ i ] );
-			tol = EPS * absf( ere[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[ i ]+'. im: '+im[ i ]+'. Actual re: '+are+'. Expected re: '+ere[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-
-			delta = absf( aim - eim[ i ] );
-			tol = EPS * absf( eim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[ i ]+'. im: '+im[ i ]+'. Actual im: '+aim+'. Expected im: '+eim[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( are, ere[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( aim, eim[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `math/base/special/cflipsignf` from relative-tolerance (`EPS`-based) assertions to ULP-difference assertions via `@stdlib/number/float32/base/assert/is-almost-same-value`, following the precedent of previously merged single-precision complex packages (e.g., `math/base/special/csignumf`, `math/base/special/cinvf`).
-   removes the `delta`/`tol` computations, along with the now unused `absf` and `EPS` requires, and replaces the exact/tolerance branch in the fixture loop with `t.strictEqual( isAlmostSameValue( ..., 1 ), true, 'returns expected value' )` for the real and imaginary components.
-   uses a **minimum required ULP value of `1`** for both the JavaScript and native implementations. The value was measured by computing, for every fixture pair in `test/fixtures/julia/data.json` (2003 cases; 4006 component assertions), the smallest ULP argument for which `isAlmostSameValue` returns `true`, and taking the maximum. The measured minimum is `1`; at `0`, 4000 of the 4006 component assertions fail (with `maxULP = 0`, the assertion reduces to exact `SameValue` equality against the double-precision fixture values), so `1` cannot be tightened further.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   The native add-on was built locally (`make install-node-addons NODE_ADDONS_PATTERN=math/base/special/cflipsignf`) so that `test/test.native.js` was actually exercised rather than skipped, and the native implementation was independently confirmed to require the same minimum of `1` ULP.
-   `make test TESTS_FILTER=".*/math/base/special/cflipsignf/.*"` was run twice at the final ULP value to confirm determinism: 4038/4038 assertions passing in `test/test.js` and 4038/4038 in `test/test.native.js` on both runs.
-   ESLint is clean for both changed files using the project's test configuration (`etc/eslint/.eslintrc.tests.js`).
-   No files other than the two test files were changed. The remaining assertions in these files (signed zeros, infinities, `NaN`) were exact comparisons already and are left untouched.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This pull request was authored by an automated Claude Code agent running as a scheduled task, mirroring the conventions established in prior merged ULP-migration pull requests for #11352.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUWFzktc5jKe4bijfGmcz6)_