### PR TITLE
build: restore `{{YEAR}}` copyright substitution in `@stdlib/blas/base/wasm` build scripts

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/wasm/isamax/scripts/build.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/isamax/scripts/build.js
@@ -26,6 +26,7 @@ var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
 var replace = require( '@stdlib/string/replace' );
+var currentYear = require( '@stdlib/time/current-year' );
 
 
 // VARIABLES //
@@ -39,6 +40,7 @@ var opts = {
 };
 
 var PLACEHOLDER = '{{WASM_BASE64}}';
+var YEAR = '{{YEAR}}';
 
 
 // MAIN //
@@ -55,6 +57,7 @@ function main() {
 	wasm = readFile( wpath );
 	tmpl = readFile( tpath, opts );
 
+	tmpl = replace( tmpl, YEAR, currentYear().toString() );
 	tmpl = replace( tmpl, PLACEHOLDER, wasm.toString( 'base64' ) );
 
 	writeFile( opath, tmpl, opts );

--- a/lib/node_modules/@stdlib/blas/base/wasm/isamax/scripts/template.txt
+++ b/lib/node_modules/@stdlib/blas/base/wasm/isamax/scripts/template.txt
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) {{YEAR}} The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/blas/base/wasm/sscal/scripts/build.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/sscal/scripts/build.js
@@ -26,6 +26,7 @@ var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
 var replace = require( '@stdlib/string/replace' );
+var currentYear = require( '@stdlib/time/current-year' );
 
 
 // VARIABLES //
@@ -39,6 +40,7 @@ var opts = {
 };
 
 var PLACEHOLDER = '{{WASM_BASE64}}';
+var YEAR = '{{YEAR}}';
 
 
 // MAIN //
@@ -55,6 +57,7 @@ function main() {
 	wasm = readFile( wpath );
 	tmpl = readFile( tpath, opts );
 
+	tmpl = replace( tmpl, YEAR, currentYear().toString() );
 	tmpl = replace( tmpl, PLACEHOLDER, wasm.toString( 'base64' ) );
 
 	writeFile( opath, tmpl, opts );

--- a/lib/node_modules/@stdlib/blas/base/wasm/sscal/scripts/template.txt
+++ b/lib/node_modules/@stdlib/blas/base/wasm/sscal/scripts/template.txt
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) {{YEAR}} The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/blas/base/wasm/zcopy/scripts/build.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zcopy/scripts/build.js
@@ -26,6 +26,7 @@ var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
 var replace = require( '@stdlib/string/replace' );
+var currentYear = require( '@stdlib/time/current-year' );
 
 
 // VARIABLES //
@@ -39,6 +40,7 @@ var opts = {
 };
 
 var PLACEHOLDER = '{{WASM_BASE64}}';
+var YEAR = '{{YEAR}}';
 
 
 // MAIN //
@@ -55,6 +57,7 @@ function main() {
 	wasm = readFile( wpath );
 	tmpl = readFile( tpath, opts );
 
+	tmpl = replace( tmpl, YEAR, currentYear().toString() );
 	tmpl = replace( tmpl, PLACEHOLDER, wasm.toString( 'base64' ) );
 
 	writeFile( opath, tmpl, opts );

--- a/lib/node_modules/@stdlib/blas/base/wasm/zcopy/scripts/template.txt
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zcopy/scripts/template.txt
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) {{YEAR}} The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/blas/base/wasm/zdrot/scripts/build.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zdrot/scripts/build.js
@@ -26,6 +26,7 @@ var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
 var replace = require( '@stdlib/string/replace' );
+var currentYear = require( '@stdlib/time/current-year' );
 
 
 // VARIABLES //
@@ -39,6 +40,7 @@ var opts = {
 };
 
 var PLACEHOLDER = '{{WASM_BASE64}}';
+var YEAR = '{{YEAR}}';
 
 
 // MAIN //
@@ -55,6 +57,7 @@ function main() {
 	wasm = readFile( wpath );
 	tmpl = readFile( tpath, opts );
 
+	tmpl = replace( tmpl, YEAR, currentYear().toString() );
 	tmpl = replace( tmpl, PLACEHOLDER, wasm.toString( 'base64' ) );
 
 	writeFile( opath, tmpl, opts );

--- a/lib/node_modules/@stdlib/blas/base/wasm/zdrot/scripts/template.txt
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zdrot/scripts/template.txt
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) {{YEAR}} The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/blas/base/wasm/zswap/scripts/build.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zswap/scripts/build.js
@@ -26,6 +26,7 @@ var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
 var replace = require( '@stdlib/string/replace' );
+var currentYear = require( '@stdlib/time/current-year' );
 
 
 // VARIABLES //
@@ -39,6 +40,7 @@ var opts = {
 };
 
 var PLACEHOLDER = '{{WASM_BASE64}}';
+var YEAR = '{{YEAR}}';
 
 
 // MAIN //
@@ -55,6 +57,7 @@ function main() {
 	wasm = readFile( wpath );
 	tmpl = readFile( tpath, opts );
 
+	tmpl = replace( tmpl, YEAR, currentYear().toString() );
 	tmpl = replace( tmpl, PLACEHOLDER, wasm.toString( 'base64' ) );
 
 	writeFile( opath, tmpl, opts );

--- a/lib/node_modules/@stdlib/blas/base/wasm/zswap/scripts/template.txt
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zswap/scripts/template.txt
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) {{YEAR}} The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Resolves None.

## Description

> What is the purpose of this pull request?

This pull request restores the `{{YEAR}}` copyright-year placeholder substitution to the WebAssembly build scripts of five `@stdlib/blas/base/wasm` packages so that their build tooling matches the convention used across the rest of the namespace.

Five packages — `isamax`, `sscal`, `zcopy`, `zdrot`, and `zswap` — had `scripts/build.js` and `scripts/template.txt` that hardcoded `Copyright (c) 2025` and omitted the year-substitution logic. The remaining 28 packages in the namespace, and all 10 packages in the sibling `@stdlib/blas/ext/base/wasm` namespace, instead template the year via `@stdlib/time/current-year`. Each of the five affected packages already required `@stdlib/time/current-year` in `scripts/postbuild.wat.js` and stamped the year dynamically there, so only `build.js` was left hardcoding the year — an internally inconsistent state.

Per package the change is mechanical and limited to two build-time files:

-   `scripts/build.js`: require `@stdlib/time/current-year`, add `var YEAR = '{{YEAR}}';`, and substitute `{{YEAR}}` in the license template before writing `lib/binary.browser.js`.
-   `scripts/template.txt`: replace the hardcoded `Copyright (c) 2025` with the `{{YEAR}}` placeholder.

After the change, each edited `build.js` and `template.txt` is byte-identical to the namespace majority. No WebAssembly artifacts are regenerated, so `lib/binary.browser.js`, `src/main.wat`, and `src/main.wasm` are untouched, matching the committed state of the majority packages.

### Namespace summary

-   **Namespace:** `@stdlib/blas/base/wasm`
-   **Members analyzed:** 33 (all non-autogenerated)
-   **Features with a clear majority (≥75%):** file tree, `package.json` shape, `manifest.json` shape, README section list and order, test/benchmark/example file names (all 100% conformant), and the `scripts/build.js` + `scripts/template.txt` year-substitution mechanism (85% conformant — the basis for this PR).
-   **Features without a clear majority (excluded):** `lib/binary.js`, `test/test.js`, `test/test.module.js`, `test/test.routine.js`, and `benchmark/benchmark.module.js` split 20/13 (≈61%), and `src/Makefile` splits 16/9/4/4 — both below the 75% threshold, so they were not treated as drift.

### Affected packages

Identical fix applied independently to each; one commit per package:

-   **`isamax`**, **`sscal`**, **`zcopy`**, **`zdrot`**, **`zswap`** — restored the `{{YEAR}}` substitution in `scripts/build.js` (present in 28/33 ≈ 85% of siblings, 100% of `blas/ext/base/wasm`) and replaced the hardcoded `Copyright (c) 2025` in `scripts/template.txt` with the `{{YEAR}}` placeholder.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed before proposing the corrections:

-   **Structural extraction** across all 33 members (file trees, `package.json`/`manifest.json` shapes, README sections, test/benchmark/example names) — fully conformant, no drift.
-   **Template extraction** — every per-package file was compared after normalizing the routine name; only the year-substitution mechanism showed a clear (≥75%) majority split.
-   **Three independent reviews** of the finding (semantic, cross-reference, structural), each confirming the deviation is unintentional drift, that no test/example/benchmark/doc depends on the hardcoded year, that the dependency is already present via `postbuild.wat.js`, and that the majority pattern is the one to apply.

Deliberately excluded: features without a clear ≥75% majority (the 20/13 template split and the `Makefile` split), and whitespace-only indentation differences in `src/exports.json` (`dsdot`, `scasum`) and `manifest.json` (`scasum`), which are cosmetic and low-signal. No WebAssembly binaries were regenerated and no observable behavior, public signature, or test expectation is changed.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was produced by an automated cross-package drift-detection routine running under Claude Code. The routine extracted structural and template features from every package in the namespace, identified the majority convention, and applied the majority pattern to the outliers; three independent AI reviews validated each correction before it was included. The diffs are mechanical (byte-identical to the namespace majority) and were reviewed for scope and correctness.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dd1EBcg2A9CxXy16oy7aHc)_