### PR TITLE
feat: add `blas/ext/base/ndarray/dapx`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/README.md
@@ -1,0 +1,123 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# dapx
+
+> Add a scalar constant to each element in a one-dimensional double-precision floating-point ndarray.
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var dapx = require( '@stdlib/blas/ext/base/ndarray/dapx' );
+```
+
+#### dapx( arrays )
+
+Adds a scalar constant to each element in a one-dimensional double-precision floating-point ndarray.
+
+```javascript
+var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+
+var x = new Float64Vector( [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ] );
+
+var alpha = scalar2ndarray( 5.0, {
+    'dtype': 'float64'
+});
+
+dapx( [ x, alpha ] );
+// x => <ndarray>[ 3.0, 6.0, 8.0, 0.0, 9.0, 5.0, 4.0, 2.0 ]
+```
+
+The function has the following parameters:
+
+-   **arrays**: array-like object containing the following ndarrays:
+
+    -   a one-dimensional input ndarray.
+    -   a zero-dimensional ndarray containing the scalar constant to add.
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   The input ndarray is modified **in-place** (i.e., the input ndarray is **mutated**).
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var discreteUniform = require( '@stdlib/random/discrete-uniform' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var ndarraylike2scalar = require( '@stdlib/ndarray/ndarraylike2scalar' );
+var dapx = require( '@stdlib/blas/ext/base/ndarray/dapx' );
+
+var opts = {
+    'dtype': 'float64'
+};
+
+var x = discreteUniform( [ 10 ], -100, 100, opts );
+console.log( ndarray2array( x ) );
+
+var alpha = scalar2ndarray( 5.0, opts );
+console.log( 'Alpha: %d', ndarraylike2scalar( alpha ) );
+
+dapx( [ x, alpha ] );
+console.log( ndarray2array( x ) );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/README.md
@@ -41,10 +41,12 @@ var dapx = require( '@stdlib/blas/ext/base/ndarray/dapx' );
 Adds a scalar constant to each element in a one-dimensional double-precision floating-point ndarray.
 
 ```javascript
-var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
+var array = require( '@stdlib/ndarray/array' );
 var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 
-var x = new Float64Vector( [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ] );
+var x = array( [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ], {
+    'dtype': 'float64'
+});
 
 var alpha = scalar2ndarray( 5.0, {
     'dtype': 'float64'

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/benchmark/benchmark.js
@@ -1,0 +1,107 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/uniform' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var dapx = require( './../lib' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'float64'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - ndarray length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var alpha;
+	var x;
+
+	x = uniform( [ len ], -100.0, 100.0, options );
+	alpha = scalar2ndarray( 5.0, options );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var out;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			out = dapx( [ x, alpha ] );
+			if ( typeof out !== 'object' ) {
+				b.fail( 'should return an ndarray' );
+			}
+		}
+		b.toc();
+		if ( typeof out !== 'object' ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:len=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/docs/repl.txt
@@ -22,8 +22,8 @@
     Examples
     --------
     > var buf = [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ];
-    > var x = new {{alias:@stdlib/ndarray/vector/float64}}( buf );
     > var opts = { 'dtype': 'float64' };
+    > var x = {{alias:@stdlib/ndarray/array}}( buf, opts );
     > var alpha = {{alias:@stdlib/ndarray/from-scalar}}( 5.0, opts );
     > {{alias}}( [ x, alpha ] )
     <ndarray>[ 3.0, 6.0, 8.0, 0.0, 9.0, 5.0, 4.0, 2.0 ]

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/docs/repl.txt
@@ -1,0 +1,33 @@
+
+{{alias}}( arrays )
+    Adds a scalar constant to each element in a one-dimensional double-precision
+    floating-point ndarray.
+
+    The input ndarray is modified *in-place* (i.e., the input ndarray is
+    *mutated*).
+
+    Parameters
+    ----------
+    arrays: ArrayLikeObject<ndarray>
+        Array-like object containing the following ndarrays:
+
+        - a one-dimensional input ndarray.
+        - a zero-dimensional ndarray containing the scalar constant to add.
+
+    Returns
+    -------
+    out: ndarray
+        Input ndarray.
+
+    Examples
+    --------
+    > var buf = [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ];
+    > var x = new {{alias:@stdlib/ndarray/vector/float64}}( buf );
+    > var opts = { 'dtype': 'float64' };
+    > var alpha = {{alias:@stdlib/ndarray/from-scalar}}( 5.0, opts );
+    > {{alias}}( [ x, alpha ] )
+    <ndarray>[ 3.0, 6.0, 8.0, 0.0, 9.0, 5.0, 4.0, 2.0 ]
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/docs/types/index.d.ts
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { float64ndarray, typedndarray } from '@stdlib/types/ndarray';
+
+/**
+* Adds a scalar constant to each element in a one-dimensional double-precision floating-point ndarray.
+*
+* @param arrays - array containing a one-dimensional input ndarray and a zero-dimensional ndarray containing the scalar constant to add
+* @returns input ndarray
+*
+* @example
+* var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+*
+* var x = new Float64Vector( [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ] );
+*
+* var alpha = scalar2ndarray( 5.0, {
+*     'dtype': 'float64'
+* });
+*
+* var out = dapx( [ x, alpha ] );
+* // returns <ndarray>[ 3.0, 6.0, 8.0, 0.0, 9.0, 5.0, 4.0, 2.0 ]
+*/
+declare function dapx( arrays: [ float64ndarray, typedndarray<number> ] ): float64ndarray;
+
+
+// EXPORTS //
+
+export = dapx;

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/docs/types/index.d.ts
@@ -25,14 +25,23 @@ import { float64ndarray, typedndarray } from '@stdlib/types/ndarray';
 /**
 * Adds a scalar constant to each element in a one-dimensional double-precision floating-point ndarray.
 *
-* @param arrays - array containing a one-dimensional input ndarray and a zero-dimensional ndarray containing the scalar constant to add
+* ## Notes
+*
+* -   The function expects the following ndarrays:
+*
+*     -   a one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the scalar constant to add.
+*
+* @param arrays - array-like object containing ndarrays
 * @returns input ndarray
 *
 * @example
-* var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
+* var array = require( '@stdlib/ndarray/array' );
 * var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 *
-* var x = new Float64Vector( [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ] );
+* var x = array( [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ], {
+*     'dtype': 'float64'
+* });
 *
 * var alpha = scalar2ndarray( 5.0, {
 *     'dtype': 'float64'

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/docs/types/test.ts
@@ -39,15 +39,15 @@ import dapx = require( './index' );
 
 // The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
 {
-	dapx( '10' as any ); // $ExpectError
-	dapx( 5 as any ); // $ExpectError
-	dapx( true as any ); // $ExpectError
-	dapx( false as any ); // $ExpectError
-	dapx( null as any ); // $ExpectError
-	dapx( undefined as any ); // $ExpectError
-	dapx( [] as any ); // $ExpectError
-	dapx( {} as any ); // $ExpectError
-	dapx( ( ( x: number ): number => x ) as any ); // $ExpectError
+	dapx( '10' ); // $ExpectError
+	dapx( 5 ); // $ExpectError
+	dapx( true ); // $ExpectError
+	dapx( false ); // $ExpectError
+	dapx( null ); // $ExpectError
+	dapx( undefined ); // $ExpectError
+	dapx( [] ); // $ExpectError
+	dapx( {} ); // $ExpectError
+	dapx( ( ( x: number ): number => x ) ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided an unsupported number of arguments...

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/docs/types/test.ts
@@ -1,0 +1,64 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable space-in-parens */
+
+import zeros = require( '@stdlib/ndarray/zeros' );
+import scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+import dapx = require( './index' );
+
+
+// TESTS //
+
+// The function returns an ndarray...
+{
+	const x = zeros( [ 10 ], {
+		'dtype': 'float64'
+	});
+	const alpha = scalar2ndarray( 5.0, {
+		'dtype': 'float64'
+	});
+
+	dapx( [ x, alpha ] ); // $ExpectType float64ndarray
+}
+
+// The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
+{
+	dapx( '10' as any ); // $ExpectError
+	dapx( 5 as any ); // $ExpectError
+	dapx( true as any ); // $ExpectError
+	dapx( false as any ); // $ExpectError
+	dapx( null as any ); // $ExpectError
+	dapx( undefined as any ); // $ExpectError
+	dapx( [] as any ); // $ExpectError
+	dapx( {} as any ); // $ExpectError
+	dapx( ( ( x: number ): number => x ) as any ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const x = zeros( [ 10 ], {
+		'dtype': 'float64'
+	});
+	const alpha = scalar2ndarray( 5.0, {
+		'dtype': 'float64'
+	});
+
+	dapx(); // $ExpectError
+	dapx( [ x, alpha ], {} ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/examples/index.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var discreteUniform = require( '@stdlib/random/discrete-uniform' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var ndarraylike2scalar = require( '@stdlib/ndarray/ndarraylike2scalar' );
+var dapx = require( './../lib' );
+
+var opts = {
+	'dtype': 'float64'
+};
+
+var x = discreteUniform( [ 10 ], -100, 100, opts );
+console.log( ndarray2array( x ) );
+
+var alpha = scalar2ndarray( 5.0, opts );
+console.log( 'Alpha: %d', ndarraylike2scalar( alpha ) );
+
+dapx( [ x, alpha ] );
+console.log( ndarray2array( x ) );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/lib/index.js
@@ -1,0 +1,48 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Add a scalar constant to each element in a one-dimensional double-precision floating-point ndarray.
+*
+* @module @stdlib/blas/ext/base/ndarray/dapx
+*
+* @example
+* var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+* var dapx = require( '@stdlib/blas/ext/base/ndarray/dapx' );
+*
+* var x = new Float64Vector( [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ] );
+*
+* var alpha = scalar2ndarray( 5.0, {
+*     'dtype': 'float64'
+* });
+*
+* var out = dapx( [ x, alpha ] );
+* // returns <ndarray>[ 3.0, 6.0, 8.0, 0.0, 9.0, 5.0, 4.0, 2.0 ]
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/lib/index.js
@@ -24,11 +24,13 @@
 * @module @stdlib/blas/ext/base/ndarray/dapx
 *
 * @example
-* var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
+* var array = require( '@stdlib/ndarray/array' );
 * var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var dapx = require( '@stdlib/blas/ext/base/ndarray/dapx' );
 *
-* var x = new Float64Vector( [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ] );
+* var x = array( [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ], {
+*     'dtype': 'float64'
+* });
 *
 * var alpha = scalar2ndarray( 5.0, {
 *     'dtype': 'float64'

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/lib/main.js
@@ -1,0 +1,73 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
+var getStride = require( '@stdlib/ndarray/base/stride' );
+var getOffset = require( '@stdlib/ndarray/base/offset' );
+var getData = require( '@stdlib/ndarray/base/data-buffer' );
+var strided = require( '@stdlib/blas/ext/base/dapx' ).ndarray;
+var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
+
+
+// MAIN //
+
+/**
+* Adds a scalar constant to each element in a one-dimensional double-precision floating-point ndarray.
+*
+* ## Notes
+*
+* -   The function expects the following ndarrays:
+*
+*     -   a one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the scalar constant to add.
+*
+* @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
+* @returns {ndarray} input ndarray
+*
+* @example
+* var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+*
+* var x = new Float64Vector( [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ] );
+*
+* var alpha = scalar2ndarray( 5.0, {
+*     'dtype': 'float64'
+* });
+*
+* var out = dapx( [ x, alpha ] );
+* // returns <ndarray>[ 3.0, 6.0, 8.0, 0.0, 9.0, 5.0, 4.0, 2.0 ]
+*/
+function dapx( arrays ) {
+	var alpha;
+	var x;
+
+	x = arrays[ 0 ];
+	alpha = ndarraylike2scalar( arrays[ 1 ] );
+
+	strided( numelDimension( x, 0 ), alpha, getData( x ), getStride( x, 0 ), getOffset( x ) ); // eslint-disable-line max-len
+	return x;
+}
+
+
+// EXPORTS //
+
+module.exports = dapx;

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/lib/main.js
@@ -44,10 +44,12 @@ var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 * @returns {ndarray} input ndarray
 *
 * @example
-* var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
+* var array = require( '@stdlib/ndarray/array' );
 * var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 *
-* var x = new Float64Vector( [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ] );
+* var x = array( [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ], {
+*     'dtype': 'float64'
+* });
 *
 * var alpha = scalar2ndarray( 5.0, {
 *     'dtype': 'float64'

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@stdlib/blas/ext/base/ndarray/dapx",
+  "version": "0.0.0",
+  "description": "Add a scalar constant to each element in a one-dimensional double-precision floating-point ndarray.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
+    "blas",
+    "extended",
+    "ext",
+    "dapx",
+    "apx",
+    "add",
+    "scalar",
+    "constant",
+    "strided",
+    "array",
+    "ndarray",
+    "float64",
+    "double",
+    "double-precision"
+  ],
+  "__stdlib__": {}
+}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/test/test.js
@@ -81,9 +81,9 @@ tape( 'the function adds a scalar constant to each element', function test( t ) 
 });
 
 tape( 'the function returns the input ndarray', function test( t ) {
-	var out;
 	var alpha;
 	var xbuf;
+	var out;
 	var x;
 
 	xbuf = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
@@ -141,7 +141,7 @@ tape( 'the function supports an input ndarray with a non-unit stride', function 
 	var xbuf;
 	var x;
 
-	xbuf = new Float64Array( [
+	xbuf = new Float64Array([
 		2.0,  // 0
 		-3.0,
 		-5.0, // 1
@@ -155,7 +155,7 @@ tape( 'the function supports an input ndarray with a non-unit stride', function 
 
 	dapx( [ x, alpha ] );
 
-	expected = new Float64Array( [
+	expected = new Float64Array([
 		7.0,  // 0
 		-3.0,
 		0.0,  // 1
@@ -172,7 +172,7 @@ tape( 'the function supports an input ndarray with a negative stride', function 
 	var xbuf;
 	var x;
 
-	xbuf = new Float64Array( [
+	xbuf = new Float64Array([
 		2.0,  // 2
 		-3.0,
 		-5.0, // 1
@@ -186,7 +186,7 @@ tape( 'the function supports an input ndarray with a negative stride', function 
 
 	dapx( [ x, alpha ] );
 
-	expected = new Float64Array( [
+	expected = new Float64Array([
 		7.0,  // 2
 		-3.0,
 		0.0,  // 1
@@ -203,7 +203,7 @@ tape( 'the function supports an input ndarray with a non-zero offset', function 
 	var xbuf;
 	var x;
 
-	xbuf = new Float64Array( [
+	xbuf = new Float64Array([
 		1.0,
 		2.0, // 0
 		3.0,
@@ -218,7 +218,7 @@ tape( 'the function supports an input ndarray with a non-zero offset', function 
 
 	dapx( [ x, alpha ] );
 
-	expected = new Float64Array( [
+	expected = new Float64Array([
 		1.0,
 		7.0, // 0
 		3.0,

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dapx/test/test.js
@@ -1,0 +1,265 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Float64Array = require( '@stdlib/array/float64' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var dapx = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Returns a one-dimensional ndarray.
+*
+* @private
+* @param {Float64Array} buffer - underlying data buffer
+* @param {NonNegativeInteger} length - number of indexed elements
+* @param {integer} stride - stride length
+* @param {NonNegativeInteger} offset - index offset
+* @returns {ndarray} one-dimensional ndarray
+*/
+function vector( buffer, length, stride, offset ) {
+	return new ndarray( 'float64', buffer, [ length ], [ stride ], offset, 'row-major' );
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof dapx, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function adds a scalar constant to each element', function test( t ) {
+	var expected;
+	var alpha;
+	var xbuf;
+	var x;
+
+	xbuf = new Float64Array( [ 4.0, 2.0, -3.0, 5.0, -1.0, 2.0, -5.0, 6.0 ] );
+	x = vector( xbuf, 8, 1, 0 );
+	alpha = scalar2ndarray( 5.0, {
+		'dtype': 'float64'
+	});
+
+	dapx( [ x, alpha ] );
+
+	expected = new Float64Array( [ 9.0, 7.0, 2.0, 10.0, 4.0, 7.0, 0.0, 11.0 ] );
+	t.deepEqual( xbuf, expected, 'returns expected value' );
+
+	xbuf = new Float64Array( [ 1.0, 2.0 ] );
+	x = vector( xbuf, 2, 1, 0 );
+
+	dapx( [ x, alpha ] );
+
+	expected = new Float64Array( [ 6.0, 7.0 ] );
+	t.deepEqual( xbuf, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns the input ndarray', function test( t ) {
+	var out;
+	var alpha;
+	var xbuf;
+	var x;
+
+	xbuf = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+	x = vector( xbuf, 5, 1, 0 );
+	alpha = scalar2ndarray( 3.0, {
+		'dtype': 'float64'
+	});
+
+	out = dapx( [ x, alpha ] );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if the input ndarray is empty, the function returns the input ndarray unchanged', function test( t ) {
+	var expected;
+	var alpha;
+	var xbuf;
+	var x;
+
+	xbuf = new Float64Array( [ 3.0, -4.0, 1.0 ] );
+	x = vector( xbuf, 0, 1, 0 );
+	alpha = scalar2ndarray( 10.0, {
+		'dtype': 'float64'
+	});
+
+	dapx( [ x, alpha ] );
+
+	expected = new Float64Array( [ 3.0, -4.0, 1.0 ] );
+	t.deepEqual( xbuf, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if `alpha` equals `0`, the function returns the input ndarray unchanged', function test( t ) {
+	var expected;
+	var alpha;
+	var xbuf;
+	var x;
+
+	xbuf = new Float64Array( [ 3.0, -4.0, 1.0, 15.0, 4.0, 3.0 ] );
+	x = vector( xbuf, 6, 1, 0 );
+	alpha = scalar2ndarray( 0.0, {
+		'dtype': 'float64'
+	});
+
+	dapx( [ x, alpha ] );
+
+	expected = new Float64Array( [ 3.0, -4.0, 1.0, 15.0, 4.0, 3.0 ] );
+	t.deepEqual( xbuf, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports an input ndarray with a non-unit stride', function test( t ) {
+	var expected;
+	var alpha;
+	var xbuf;
+	var x;
+
+	xbuf = new Float64Array( [
+		2.0,  // 0
+		-3.0,
+		-5.0, // 1
+		7.0,
+		6.0   // 2
+	]);
+	x = vector( xbuf, 3, 2, 0 );
+	alpha = scalar2ndarray( 5.0, {
+		'dtype': 'float64'
+	});
+
+	dapx( [ x, alpha ] );
+
+	expected = new Float64Array( [
+		7.0,  // 0
+		-3.0,
+		0.0,  // 1
+		7.0,
+		11.0  // 2
+	]);
+	t.deepEqual( xbuf, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports an input ndarray with a negative stride', function test( t ) {
+	var expected;
+	var alpha;
+	var xbuf;
+	var x;
+
+	xbuf = new Float64Array( [
+		2.0,  // 2
+		-3.0,
+		-5.0, // 1
+		7.0,
+		6.0   // 0
+	]);
+	x = vector( xbuf, 3, -2, 4 );
+	alpha = scalar2ndarray( 5.0, {
+		'dtype': 'float64'
+	});
+
+	dapx( [ x, alpha ] );
+
+	expected = new Float64Array( [
+		7.0,  // 2
+		-3.0,
+		0.0,  // 1
+		7.0,
+		11.0  // 0
+	]);
+	t.deepEqual( xbuf, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports an input ndarray with a non-zero offset', function test( t ) {
+	var expected;
+	var alpha;
+	var xbuf;
+	var x;
+
+	xbuf = new Float64Array( [
+		1.0,
+		2.0, // 0
+		3.0,
+		4.0, // 1
+		5.0,
+		6.0  // 2
+	]);
+	x = vector( xbuf, 3, 2, 1 );
+	alpha = scalar2ndarray( 5.0, {
+		'dtype': 'float64'
+	});
+
+	dapx( [ x, alpha ] );
+
+	expected = new Float64Array( [
+		1.0,
+		7.0, // 0
+		3.0,
+		9.0, // 1
+		5.0,
+		11.0 // 2
+	]);
+	t.deepEqual( xbuf, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function efficiently adds a constant to each element (stride=1)', function test( t ) {
+	var expected;
+	var alpha;
+	var xbuf;
+	var x;
+	var i;
+
+	alpha = scalar2ndarray( 3.0, {
+		'dtype': 'float64'
+	});
+
+	xbuf = new Float64Array( 100 );
+	expected = new Float64Array( 100 );
+	for ( i = 0; i < xbuf.length; i++ ) {
+		xbuf[ i ] = i;
+		expected[ i ] = i + 3.0;
+	}
+	x = vector( xbuf, 100, 1, 0 );
+	dapx( [ x, alpha ] );
+	t.deepEqual( xbuf, expected, 'returns expected value' );
+
+	xbuf = new Float64Array( 240 );
+	expected = new Float64Array( 240 );
+	for ( i = 0; i < xbuf.length; i++ ) {
+		xbuf[ i ] = i;
+		expected[ i ] = i + 3.0;
+	}
+	x = vector( xbuf, 240, 1, 0 );
+	dapx( [ x, alpha ] );
+	t.deepEqual( xbuf, expected, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
Resolves a part of #14404

## Description

> What is the purpose of this pull request?

This pull request:

- Implements the `ndarray` API wrapper for `@stdlib/blas/ext/base/dapx` (adds a scalar constant to each element in a one-dimensional double-precision floating-point ndarray).
- Ensures consistency with the canonical scalar-operation examples and tests used across the `@stdlib/blas/ext/base` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #14404

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I used an AI assistant to research existing `ndarray` packages to ensure consistency with canonical example arrays (e.g., `[ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ]` for scalar operations) and to help scaffold the tests and benchmarks. All changes were manually verified and aligned with the `blas/ext/base/dapx` reference tests.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
