### PR TITLE
test: migrate `stats/base/dists/triangular/variance` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/variance/test/test.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var variance = require( './../lib' );
 
 
@@ -73,8 +72,6 @@ tape( 'if provided parameters not satisfying `a <= c <= b`, the function returns
 
 tape( 'the function returns the variance of a triangular distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var c;
@@ -87,13 +84,7 @@ tape( 'the function returns the variance of a triangular distribution', function
 	c = data.c;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = variance( a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/variance/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/variance/test/test.native.js
@@ -22,10 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -82,8 +81,6 @@ tape( 'if provided parameters not satisfying `a <= c <= b`, the function returns
 
 tape( 'the function returns the variance of a triangular distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var c;
@@ -96,13 +93,7 @@ tape( 'the function returns the variance of a triangular distribution', opts, fu
 	c = data.c;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = variance( a[i], b[i], c[i] );
-		if ( y.toFixed( 4 ) === expected[i].toFixed( 4 ) ) {
-			t.strictEqual( y.toFixed( 4 ), expected[i].toFixed( 4 ), 'a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Ref #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/triangular/variance` from computed floating-point tolerances to ULP-based assertions, per #11352.
-   replaces the `delta`/`tol` (`EPS * abs( expected[i] )`) comparison in `test/test.js` with `isAlmostSameValue( y, expected[ i ], 0 )`.
-   replaces the `toFixed( 4 )` string comparison and `delta`/`tol` fallback in `test/test.native.js` with `isAlmostSameValue( y, expected[ i ], 0 )`.
-   adds the `@stdlib/assert/is-almost-same-value` require and drops the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**Final ULP bound: `0` in both `test/test.js` and `test/test.native.js`.**

Measured minimum: starting from a high bound and tightening, the minimum integer bound which passes over the full fixture set is `0`, i.e. both implementations reproduce every fixture value bit-for-bit. Over all 500 Julia fixture values, the maximum ULP difference is `0` for the JavaScript implementation and `0` for the native implementation (the native add-on was built locally so that `test/test.native.js` actually executed rather than being skipped). The full suite (1018 assertions across both test files) was run twice at the final bound with identical results, so no FMA/arch-related nondeterminism was observed on this platform (Linux x86-64, gcc).

This is expected: the JavaScript and C implementations evaluate the identical expression `( (a*a) + (b*b) + (c*c) - (a*b) - (a*c) - (b*c) ) / 18.0`, so absent FMA contraction the two agree exactly with the reference values.

Only the two test files are modified; no source, documentation, benchmark, or fixture files are touched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

-   A bound of `0` means `isAlmostSameValue` falls back to `SameValue` semantics (as is the case elsewhere in the repository, where `0` is already used in a number of converted packages). If reviewers would prefer to retain a single ULP of headroom in `test/test.native.js` to guard against FMA contraction on architectures where the C compiler fuses the multiply-adds (e.g. arm64), the native bound can be relaxed to `1`. As measured on x86-64, `0` passes.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Verification performed: package tests green (1018/1018 assertions passing, run twice), lint clean via `make lint-javascript-files ESLINT_CONF=etc/eslint/.eslintrc.tests.js`, and `git status` confirms only the two test files changed.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was written primarily by Claude Code, which selected the package, mirrored the conversion idiom used in previously converted packages, measured the ULP bound against the fixture set, and verified tests and linting.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01PjUefgKYy3gQjkssALyEzH)_