### PR TITLE
test: migrate `stats/base/dists/kumaraswamy/mode` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/mode/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/mode/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mode = require( './../lib' );
 
 
@@ -120,8 +119,6 @@ tape( 'if provided `b < 1`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function returns the mode of a Kumaraswamy\'s double bounded distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -133,13 +130,7 @@ tape( 'the function returns the mode of a Kumaraswamy\'s double bounded distribu
 
 	for ( i = 0; i < expected.length; i++ ) {
 		y = mode( a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 15.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i]+', Δ: '+delta+', tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/mode/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/mode/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -132,8 +131,6 @@ tape( 'if provided `b < 1`, the function returns `NaN`', opts, function test( t 
 
 tape( 'the function returns the mode of a Kumaraswamy\'s double bounded distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -145,13 +142,7 @@ tape( 'the function returns the mode of a Kumaraswamy\'s double bounded distribu
 
 	for ( i = 0; i < expected.length; i++ ) {
 		y = mode( a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 15.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i]+', Δ: '+delta+', tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/kumaraswamy/mode` from relative tolerance assertions to ULP-based assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   updates both `test/test.js` and `test/test.native.js`, replacing the `delta`/`tol` comparison against `15.0 * EPS * abs( expected[ i ] )` with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );`.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

The final ULP constant is **1** in both `test/test.js` and `test/test.native.js`.

This is the measured minimum. Over the full Julia fixture set (100 cases), the largest observed ULP difference between the returned and expected values is exactly 1 (worst case: `a = 4.650703332395438`, `b = 3.5899547415339503`, returned `0.7308091452905936`, expected `0.7308091452905935`). Lowering the bound to `0` fails 14 of the fixture cases in each test file, so `1` is the tightest bound which passes.

Both test files were run twice at the final bound to confirm determinism (the native tests were exercised locally after building the add-on): `test/test.js` 120/120 passing and `test/test.native.js` 121/121 passing on both runs. Only the two test files are modified.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, running unattended, which selected the package, mirrored the idiom used in previously merged migrations, measured the minimum ULP bound against the fixture set, and verified the tests and lint locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value


---
_Generated by [Claude Code](https://claude.ai/code/session_011WibBM4oH77MuRE74mGSbU)_