### PR TITLE
test: migrate `stats/base/dists/frechet/variance` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var variance = require( './../lib' );
 
 
@@ -97,8 +96,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', function test
 tape( 'the function returns the variance of a Fréchet distribution', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var y;
 	var i;
@@ -109,13 +106,7 @@ tape( 'the function returns the variance of a Fréchet distribution', function t
 	for ( i = 0; i < alpha.length; i++ ) {
 		y = variance( alpha[i], s[i], 0.0 );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'alpha:'+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 45.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. s: '+s[i]+'. m: 0. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 66 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -112,8 +111,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', opts, functio
 tape( 'the function returns the variance of a Fréchet distribution', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var y;
 	var i;
@@ -124,13 +121,7 @@ tape( 'the function returns the variance of a Fréchet distribution', opts, func
 	for ( i = 0; i < alpha.length; i++ ) {
 		y = variance( alpha[i], s[i], 0.0 );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'alpha:'+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 45.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. s: '+s[i]+'. m: 0. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 66 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/frechet/variance` from relative tolerance testing to ULP difference testing, per #11352.

Specifically, in both `test/test.js` and `test/test.native.js`, the `if ( y === expected[i] ) { ... } else { delta/tol ... }` branch in the fixture loop is replaced with a single assertion:

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], 66 ), true, 'returns expected value' );
```

The now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires are removed, and `@stdlib/assert/is-almost-same-value` is added. No other test cases were touched, and no non-test files were changed.

**ULP constant:** `66` in both `test/test.js` and `test/test.native.js`.

This is the measured minimum. Over the full Julia fixture set (63 non-`null` cases), the maximum observed ULP difference between the returned and expected values is exactly 66, attained at `alpha = 4.728181271575317`, `s = 3.0858597298664217` (returned `1.5059173686166538` vs. expected `1.5059173686166392`). The suite passes at `66` and fails at `65`, and passes across repeated runs. For reference, the previous relative tolerance was `45.0 * EPS`.

The same constant is used in `test/test.native.js`, matching the convention used by the already-migrated sibling packages in this distribution (e.g. `stats/base/dists/frechet/kurtosis`, `mode`, `entropy`).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

The native add-on was not built in the environment used to author this change, so `test/test.native.js` was skipped locally and the `66` bound there is inherited from the JavaScript measurement (as in the sibling `frechet` packages). Happy to adjust if CI shows a different bound is required for the C implementation.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed:

-   `make test TESTS_FILTER=".*/stats/base/dists/frechet/variance/.*"` — 78/78 passing, run twice with identical results.
-   `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/frechet/variance/.*"` — clean (the only remaining diagnostic is a pre-existing cspell warning on "Fréchet", which is also present in the already-migrated sibling packages).
-   `git status` confirms the only changed files are the two test files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task. It mirrored the migration idiom from previously merged `frechet` packages, determined the minimum ULP bound empirically by measuring the maximum ULP difference across the fixture set and confirming the suite passes at 66 and fails at 65, and ran the package test suite and test linter locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01DAB8dusjvSNbLfXnJoyYp3)_