### PR TITLE
docs: fix descriptions

### DIFF
--- a/lib/node_modules/@stdlib/strided/base/cmap/README.md
+++ b/lib/node_modules/@stdlib/strided/base/cmap/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # cmap
 
-> Apply a unary function to a single-precision floating-point strided input array and assign results to a single-precision floating-point strided output array.
+> Apply a unary function to a single-precision complex floating-point strided input array and assign results to a single-precision complex floating-point strided output array.
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/strided/base/cmap/lib/index.js
+++ b/lib/node_modules/@stdlib/strided/base/cmap/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Apply a unary function to a single-precision floating-point strided input array and assign results to a single-precision floating-point strided output array.
+* Apply a unary function to a single-precision complex floating-point strided input array and assign results to a single-precision complex floating-point strided output array.
 *
 * @module @stdlib/strided/base/cmap
 *

--- a/lib/node_modules/@stdlib/strided/base/dmskmap2/lib/main.js
+++ b/lib/node_modules/@stdlib/strided/base/dmskmap2/lib/main.js
@@ -27,7 +27,7 @@ var ndarray = require( './ndarray.js' );
 // MAIN //
 
 /**
-* Applies a binary function to double-precision floating-point strided input arrays and assigns results to a double-precision floating-point strided output array.
+* Applies a binary function to double-precision floating-point strided input arrays according to a strided mask array and assigns results to a double-precision floating-point strided output array.
 *
 * @param {NonNegativeInteger} N - number of indexed elements
 * @param {Float64Array} x - input array

--- a/lib/node_modules/@stdlib/strided/base/map-by2/lib/main.js
+++ b/lib/node_modules/@stdlib/strided/base/map-by2/lib/main.js
@@ -33,7 +33,7 @@ var accessors = require( './accessors.js' );
 // MAIN //
 
 /**
-* Applies a binary function to each element retrieved from a strided input array according to a callback function and assigns results to a strided output array.
+* Applies a binary function to each pair of elements retrieved from strided input arrays according to a callback function and assigns results to a strided output array.
 *
 * @private
 * @param {NonNegativeInteger} N - number of indexed elements

--- a/lib/node_modules/@stdlib/strided/base/map-by2/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/strided/base/map-by2/lib/ndarray.js
@@ -33,7 +33,7 @@ var accessors = require( './accessors.ndarray.js' );
 // MAIN //
 
 /**
-* Applies a binary function to each element retrieved from a strided input array according to a callback function and assigns results to a strided output array.
+* Applies a binary function to each pair of elements retrieved from strided input arrays according to a callback function and assigns results to a strided output array.
 *
 * @private
 * @param {NonNegativeInteger} N - number of indexed elements

--- a/lib/node_modules/@stdlib/strided/base/read-dataview/lib/main.js
+++ b/lib/node_modules/@stdlib/strided/base/read-dataview/lib/main.js
@@ -30,9 +30,9 @@ var ndarray = require( './ndarray.js' );
 * Copies elements from an input strided DataView to elements in an output strided array.
 *
 * @param {NonNegativeInteger} N - number of indexed elements
-* @param {DataView} view - output DataView
+* @param {DataView} view - input DataView
 * @param {integer} strideView - `view` stride length (in bytes)
-* @param {Collection} out - input array
+* @param {Collection} out - output array
 * @param {integer} strideOut - `out` stride length
 * @param {boolean} littleEndian - boolean indicating whether the data is stored in little-endian format
 * @returns {Collection} output array

--- a/lib/node_modules/@stdlib/strided/base/smskmap2/lib/main.js
+++ b/lib/node_modules/@stdlib/strided/base/smskmap2/lib/main.js
@@ -27,7 +27,7 @@ var ndarray = require( './ndarray.js' );
 // MAIN //
 
 /**
-* Applies a binary function to single-precision floating-point strided input arrays and assigns results to a single-precision floating-point strided output array.
+* Applies a binary function to single-precision floating-point strided input arrays according to a strided mask array and assigns results to a single-precision floating-point strided output array.
 *
 * @param {NonNegativeInteger} N - number of indexed elements
 * @param {Float32Array} x - input array

--- a/lib/node_modules/@stdlib/strided/base/zmap/README.md
+++ b/lib/node_modules/@stdlib/strided/base/zmap/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # zmap
 
-> Apply a unary function to a double-precision floating-point strided input array and assign results to a double-precision floating-point strided output array.
+> Apply a unary function to a double-precision complex floating-point strided input array and assign results to a double-precision complex floating-point strided output array.
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/strided/base/zmap/lib/index.js
+++ b/lib/node_modules/@stdlib/strided/base/zmap/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Apply a unary function to a double-precision floating-point strided input array and assign results to a double-precision floating-point strided output array.
+* Apply a unary function to a double-precision complex floating-point strided input array and assign results to a double-precision complex floating-point strided output array.
 *
 * @module @stdlib/strided/base/zmap
 *


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request corrects copy-paste documentation drift across six packages in the `@stdlib/strided/base` namespace. Each carried a summary or parameter description cloned from a sibling and never updated, so it contradicted the package's own `package.json` description and its other documentation surfaces. All changes are documentation-only: no source behavior, exported signatures, parameter names, parameter types, or test expectations change.

**Namespace summary.** 48 direct member packages analyzed. Features extracted: file tree, `package.json` key/`scripts`/`directories` sets, README section structure, JSDoc tag presence, error construction, and per-surface summary/parameter-description consistency. Features with a clear (≥75%) majority: file layout, `package.json` shape (47/48), empty `scripts` (48/48), `format`-based error construction, README `## Usage`/`## Examples` (48/48), and the convention that a package's `@module`, README, and JSDoc summaries mirror its `package.json` description (48/48). Features excluded for lacking a clear majority: README `## Notes` (37%), `## C APIs` (37%), `## See Also` (73%, and auto-populated), the `include`/`src`/`manifest.json` C-implementation triple, and public signatures / validation prologues (the namespace is functionally heterogeneous). The six corrected packages are the outliers on the summary-consistency convention.

### `cmap`

The `@module` summary in `lib/index.js` and the README title blockquote dropped "complex", describing `cmap` as operating on single-precision floating-point arrays. `cmap` operates on single-precision complex floating-point arrays (`Complex64Array`); the `package.json` description, the `main.js`/`ndarray.js` JSDoc, and the README API sections already state so. A leftover from the real-valued `smap` sibling.

### `zmap`

The same drift at double precision: the `@module` summary and README blockquote omitted "complex" while the package operates on `Complex128Array`. Both surfaces now match the package's own `package.json` description. A leftover from `dmap`.

### `dmskmap2`

The `lib/main.js` summary dropped the "according to a strided mask array" clause, omitting the package's defining masked behavior. The clause is present in the same package's `ndarray.js`, `index.js`, `package.json`, and README. Restored. A stale-template omission carried over from the non-masked `dmap2`.

### `smskmap2`

The identical mask-clause omission in `lib/main.js`, at single precision. Restored from the package's own `ndarray.js`/`index.js`/`package.json`. A leftover from `smap2`.

### `map-by2`

The `lib/main.js` and `lib/ndarray.js` summaries used unary phrasing — "each element retrieved from a strided input array" — for a binary package. `map-by2` applies a binary function to each pair of elements retrieved from two strided input arrays, per its `package.json`, `index.js`, and README. Both summaries corrected. A leftover from the unary `map-by`.

### `read-dataview`

The `lib/main.js` JSDoc documented `view` as the "output DataView" and `out` as the "input array" — reversed. The function copies from an input `DataView` into an output array, as its own summary line and `ndarray.js` both state. The two descriptions are swapped to match. A leftover from `write-dataview`, where the data flow is the reverse. Parameter names and types are unchanged.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

**Validation.** Structural features were extracted across all 48 members via filesystem and string inspection; per-surface summaries and parameter descriptions were extracted and diffed against each package's `package.json` description. Candidate outliers were reviewed by three independent agents (semantic, cross-reference, and structural) before advancing. Deliberately excluded: deviations on features without a ≥75% majority; `function-object`, whose absent benchmark, absent JSDoc parameter/return tags, and `browser` field are intentional consequences of exporting a constant header-directory path rather than a function; and the auto-populated README `## See Also` and signature-table sections. No test or example depends on any corrected string. A `reinterpret-complex` `@module` typo ("floating-point point array") was noted but left out of scope as a single-package typo rather than cross-package drift.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by an automated cross-package drift-detection routine running in Claude Code. The routine extracted the documentation conventions shared across the `strided/base` namespace, flagged the packages deviating from them, and applied the mechanical corrections. Every finding was verified against the deviating package's own existing documentation (its `package.json` description and other summary surfaces) before it was committed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_012d7Dszizgh5yTkvEet8JWk)_