### PR TITLE
test: migrate `stats/base/dists/erlang/entropy` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/entropy/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/entropy/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var entropy = require( './../lib' );
 
 
@@ -106,8 +105,6 @@ tape( 'if provided `lambda <= 0`, the function returns `NaN`', function test( t 
 tape( 'the function returns the differential entropy of an Erlang distribution', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -117,13 +114,7 @@ tape( 'the function returns the differential entropy of an Erlang distribution',
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 15000.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 22528 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/entropy/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/entropy/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -109,8 +108,6 @@ tape( 'if provided `lambda <= 0`, the function returns `NaN`', opts, function te
 tape( 'the function returns the differential entropy of an Erlang distribution', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -120,13 +117,7 @@ tape( 'the function returns the differential entropy of an Erlang distribution',
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 15000.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 22528 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `stats/base/dists/erlang/entropy` test fixtures from the old computed EPS-based tolerance idiom (`delta`/`tol`/`abs( delta ) <= tol`) to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   applies the change to both `test/test.js` and `test/test.native.js`.
-   the minimum ULP bound was determined empirically by running the JavaScript implementation against the full 200-value fixture set and measuring the exact ULP difference (via `@stdlib/number/float64/base/ulp-difference`) between each computed and expected value. The tightest passing bound is **`22528`** ULPs, driven by a handful of fixture entries where the expected entropy value is extremely close to zero (e.g. `k: 14, lambda: 15.118382880503544, expected: -0.0016827325793946635`), causing catastrophic cancellation in the entropy formula and correspondingly large ULP differences despite tiny absolute error. This is consistent with the original test's already-generous `15000 * EPS` relative tolerance, which was evidently chosen for the same reason. Verified deterministic by running the suite twice at this bound, and confirmed tight by observing 1 failure at `22527`.
-   `test/test.native.js` could not be exercised in the conversion environment (no compiled native add-on was available, so those tests are skipped via `tryRequire`), so the same `22528` bound was applied there for consistency with `test/test.js`, mirroring the convention observed in other already-converted packages with native counterparts (e.g. `math/base/special/acos`).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was generated by an automated Claude Code routine that discovers packages still using the old EPS-tolerance test idiom, converts them to `isAlmostSameValue`-based ULP assertions mirroring prior art from already-merged conversions in the same package family, and empirically determines the tightest passing ULP bound. Opened as a draft for maintainer review given the unusually large (though empirically verified and precedented) ULP bound.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_013RoSB6nnznotP52cG2gtyi)_