### PR TITLE
test: migrate `stats/base/dists/erlang/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/stdev/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -106,8 +105,6 @@ tape( 'if provided `lambda <= 0`, the function returns `NaN`', function test( t 
 tape( 'the function returns the standard deviation of an Erlang distribution', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -117,13 +114,7 @@ tape( 'the function returns the standard deviation of an Erlang distribution', f
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/stdev/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -109,8 +108,6 @@ tape( 'if provided `lambda <= 0`, the function returns `NaN`', opts, function te
 tape( 'the function returns the standard deviation of an Erlang distribution', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -120,13 +117,7 @@ tape( 'the function returns the standard deviation of an Erlang distribution', o
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `@stdlib/stats/base/dists/erlang/stdev` from computed EPS-based relative tolerance assertions to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, as described in #11352.
-   replaces the `if ( y === expected[i] ) { ... } else { delta/tol ... }` idiom in `test/test.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );`.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

Only test files are modified; no implementation changes.

### ULP bounds

Both `test/test.js` and `test/test.native.js` use a bound of **2 ULP**, which is the measured minimum over the full Julia fixture set:

| File | ULP | Notes |
| ---- | --- | ----- |
| `test/test.js` | `2` | max observed ULP difference over all 217 fixture values is 2 (worst case: `k = 19`, `lambda = 18.453885592489083`); a bound of `1` fails |
| `test/test.native.js` | `2` | native addon built locally and exercised; identical worst case, `1` fails |

Verification performed:

-   Started at `N = 64`, then tightened to the measured minimum by computing, for every fixture value, the smallest `N` for which `isAlmostSameValue` returns `true`.
-   Confirmed `N = 1` fails in both `test/test.js` and `test/test.native.js`, and `N = 2` passes.
-   Ran the full suite twice at `N = 2` for both files with identical results (217/217 and 215/215 passing), confirming determinism.
-   The native addon was compiled locally (`make install-node-addons`) so the `test.native.js` assertions actually executed rather than being skipped. This is expected, since both implementations compute `sqrt( k ) / lambda` with a correctly rounded square root and division, leaving no room for FMA-related divergence.
-   `eslint` (tests configuration) is clean for both files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Note that `make lint-editorconfig-files` could not be run in this environment, as it attempts to download the `editorconfig-checker` binary from a GitHub release which is not reachable here. The changed files were instead checked manually for tab indentation, absence of trailing whitespace, LF line endings, UTF-8 encoding, and a final newline.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended task. The test conversion mirrors the idiom already established in previously converted packages (e.g. `stats/base/dists/erlang/skewness`), and the ULP bound was determined empirically by measuring the maximum ULP difference across the fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_019jRBPgcXrkE2Agd5NAdifj)_