### PR TITLE
feat: add `fft/base/fftpack/float64/decompose`

### DIFF
--- a/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/README.md
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/README.md
@@ -1,0 +1,147 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# decompose
+
+> Factorize a sequence length into a product of integers and store the results in a double-precision floating-point array.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var decompose = require( '@stdlib/fft/base/fftpack/float64/decompose' );
+```
+
+#### decompose( N, M, initial, si, oi, out, so, oo )
+
+Factorizes a sequence length into a product of integers and stores the results in a double-precision floating-point array.
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+var initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] ); // as found in FFTPACK
+var N = 630;
+var factors = new Float64Array( 7 );
+
+var numFactors = decompose( N, 4, initial, 1, 0, factors, 1, 0 );
+// returns 5
+
+console.log( factors );
+// => <Float64Array>[ 630.0, 5.0, 2.0, 3.0, 3.0, 5.0, 7.0 ]
+```
+
+The function accepts the following arguments:
+
+-   **N**: length of the sequence.
+-   **M**: number of trial divisors.
+-   **initial**: [`Float64Array`][@stdlib/array/float64] of initial trial divisors.
+-   **si**: stride length for `initial`.
+-   **oi**: starting index for `initial`.
+-   **out**: output [`Float64Array`][@stdlib/array/float64] for storing factorization results.
+-   **so**: stride length for `out`.
+-   **oo**: starting index for `out`.
+
+The function returns the number of factors into which `N` was decomposed.
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+## Notes
+
+-   Factorization results are stored in the output array as follows:
+
+    ```text
+    [ sequence_length | number_of_factors | integer_factors | unused_storage ]
+    ```
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+var decompose = require( '@stdlib/fft/base/fftpack/float64/decompose' );
+
+var initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] ); // as found in FFTPACK
+var factors = new Float64Array( 4 );
+
+var nf = decompose( 12, 4, initial, 1, 0, factors, 1, 0 );
+
+console.log( 'Sequence length: %d', 12 );
+console.log( 'Number of factors: %d', nf );
+
+console.log( 'Factors:' );
+var j;
+for ( j = 0; j < nf; j++ ) {
+    console.log( '  %d', factors[ j+2 ] );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/array/float64]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/float64
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/benchmark/benchmark.js
@@ -1,0 +1,107 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var floor = require( '@stdlib/math/base/special/floor' );
+var log2 = require( '@stdlib/math/base/special/log2' );
+var Float64Array = require( '@stdlib/array/float64' );
+var pkg = require( './../package.json' ).name;
+var decompose = require( './../lib' );
+
+
+// VARIABLES //
+
+var initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] ); // as found in FFTPACK
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} N - sequence length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( N ) {
+	var factors = new Float64Array( 2 + floor( log2( N ) ) );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var d;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			d = decompose( N, 4, initial, 1, 0, factors, 1, 0 );
+			if ( isnan( d ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( d ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var lengths;
+	var N;
+	var f;
+	var i;
+
+	lengths = [
+		12,
+		24,
+		36,
+		48,
+		60,
+		120
+	];
+
+	for ( i = 0; i < lengths.length; i++ ) {
+		N = lengths[ i ];
+		f = createBenchmark( N );
+		bench( format( '%s:N=%d', pkg, N ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/docs/repl.txt
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/docs/repl.txt
@@ -1,0 +1,56 @@
+
+{{alias}}( N, M, initial, si, oi, out, so, oo )
+    Factorizes a sequence length into a product of integers and stores the
+    results in a double-precision floating-point array.
+
+    Factorization results are stored in the output array sequentially, where
+    the first element contains the sequence length N, the second element
+    contains the number of factors into which N was decomposed, and subsequent
+    elements contain the individual integer factors.
+
+    Any remaining array space remains as unused storage.
+
+    Parameters
+    ----------
+    N: integer
+        Length of the sequence.
+
+    M: integer
+        Number of trial divisors.
+
+    initial: Float64Array
+        Array of initial trial divisors.
+
+    si: integer
+        Stride length for `initial`.
+
+    oi: integer
+        Starting index for `initial`.
+
+    out: Float64Array
+        Output array for storing factorization results.
+
+    so: integer
+        Stride length for `out`.
+
+    oo: integer
+        Starting index for `out`.
+
+    Returns
+    -------
+    numFactors: integer
+        Number of factors into which N was decomposed.
+
+    Examples
+    --------
+    > var N = 630;
+    > var initial = new {{alias:@stdlib/array/float64}}( [ 3.0, 4.0, 2.0, 5.0 ] );
+    > var factors = new {{alias:@stdlib/array/float64}}( 7 );
+    > var numFactors = {{alias}}( N, 4, initial, 1, 0, factors, 1, 0 )
+    5
+    > factors
+    <Float64Array>[ 630.0, 5.0, 2.0, 3.0, 3.0, 5.0, 7.0 ]
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/docs/types/index.d.ts
@@ -1,0 +1,48 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Factorizes a sequence length into a product of integers and stores the results in a double-precision floating-point array.
+*
+* @param N - length of the sequence
+* @param M - number of trial divisors
+* @param initial - array of initial trial divisors
+* @param si - stride length for `initial`
+* @param oi - starting index for `initial`
+* @param out - output array for storing factorization results
+* @param so - stride length for `out`
+* @param oo - starting index for `out`
+* @returns number of factors into which `N` was decomposed
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] );
+* var factors = new Float64Array( 4 );
+*
+* var numFactors = decompose( 12, 4, initial, 1, 0, factors, 1, 0 );
+* // returns 2
+*/
+declare function decompose( N: number, M: number, initial: Float64Array, si: number, oi: number, out: Float64Array, so: number, oo: number ): number;
+
+
+// EXPORTS //
+
+export = decompose;

--- a/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/docs/types/test.ts
@@ -1,0 +1,164 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import decompose = require( './index' );
+
+// TESTS //
+
+// The function returns a number...
+{
+	const initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] );
+	const out = new Float64Array( 7 );
+
+	decompose( 12, 4, initial, 1, 0, out, 1, 0 ); // $ExpectType number
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a number...
+{
+	const initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] );
+	const out = new Float64Array( 7 );
+
+	decompose( '12', 4, initial, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( true, 4, initial, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( false, 4, initial, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( null, 4, initial, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( void 0, 4, initial, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( [], 4, initial, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( {}, 4, initial, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( ( x: number ): number => x, 4, initial, 1, 0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a number...
+{
+	const initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] );
+	const out = new Float64Array( 7 );
+
+	decompose( 12, '4', initial, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, true, initial, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, false, initial, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, null, initial, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, void 0, initial, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, [], initial, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, {}, initial, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, ( x: number ): number => x, initial, 1, 0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a Float64Array...
+{
+	const out = new Float64Array( 7 );
+
+	decompose( 12, 4, '4,2,3,5', 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, 5, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, true, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, false, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, null, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, void 0, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, [], 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, {}, 1, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, ( x: number ): number => x, 1, 0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fourth argument which is not a number...
+{
+	const initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] );
+	const out = new Float64Array( 7 );
+
+	decompose( 12, 4, initial, '1', 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, true, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, false, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, null, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, void 0, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, [], 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, {}, 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, ( x: number ): number => x, 0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fifth argument which is not a number...
+{
+	const initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] );
+	const out = new Float64Array( 7 );
+
+	decompose( 12, 4, initial, 1, '0', out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, true, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, false, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, null, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, void 0, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, [], out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, {}, out, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, ( x: number ): number => x, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a sixth argument which is not a Float64Array...
+{
+	const initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] );
+
+	decompose( 12, 4, initial, 1, 0, 123, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, true, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, false, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, null, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, void 0, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, [], 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, {}, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, ( x: number ): number => x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a seventh argument which is not a number...
+{
+	const initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] );
+	const out = new Float64Array( 7 );
+
+	decompose( 12, 4, initial, 1, 0, out, '1', 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out, true, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out, false, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out, null, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out, void 0, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out, [], 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out, {}, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an eighth argument which is not a number...
+{
+	const initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] );
+	const out = new Float64Array( 7 );
+
+	decompose( 12, 4, initial, 1, 0, out, 1, '0' ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out, 1, true ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out, 1, false ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out, 1, null ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out, 1, void 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out, 1, [] ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out, 1, {} ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out, 1, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] );
+	const out = new Float64Array( 7 );
+
+	decompose(); // $ExpectError
+	decompose( 12 ); // $ExpectError
+	decompose( 12, 4 ); // $ExpectError
+	decompose( 12, 4, initial ); // $ExpectError
+	decompose( 12, 4, initial, 1 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out, 1 ); // $ExpectError
+	decompose( 12, 4, initial, 1, 0, out, 1, 0, 123 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/examples/index.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/examples/index.js
@@ -1,0 +1,36 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Float64Array = require( '@stdlib/array/float64' );
+var decompose = require( './../lib' );
+
+var initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] ); // as found in FFTPACK
+var factors = new Float64Array( 4 );
+
+var nf = decompose( 12, 4, initial, 1, 0, factors, 1, 0 );
+
+console.log( 'Sequence length: %d', 12 );
+console.log( 'Number of factors: %d', nf );
+
+console.log( 'Factors:' );
+var j;
+for ( j = 0; j < nf; j++ ) {
+	console.log( '  %d', factors[ j+2 ] );
+}

--- a/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/lib/index.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/lib/index.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Factorize a sequence length into a product of integers and store the results in a double-precision floating-point array.
+*
+* @module @stdlib/fft/base/fftpack/float64/decompose
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var decompose = require( '@stdlib/fft/base/fftpack/float64/decompose' );
+*
+* var N = 630;
+* var initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] ); // as found in FFTPACK
+* var factors = new Float64Array( 7 );
+*
+* var numFactors = decompose( N, 4, initial, 1, 0, factors, 1, 0 );
+* // returns 5
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var decompose = require( '@stdlib/fft/base/fftpack/float64/decompose' );
+*
+* var N = 12;
+* var initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] ); // as found in FFTPACK
+* var factors = new Float64Array( 4 );
+*
+* var numFactors = decompose( N, 4, initial, 1, 0, factors, 1, 0 );
+* // returns 2
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/lib/main.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/lib/main.js
@@ -1,0 +1,200 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*
+* ## Notice
+*
+* The original C code and copyright notice are from the [PFFFT library]{@link https://github.com/marton78/pffft/blob/0b4ee12c4ba45a4a8e567550c16d96d1679f50ce/src/fftpack.c}. The implementation follows the original, but has been modified for JavaScript.
+*
+* ```text
+* Copyright (c) 2004 the University Corporation for Atmospheric
+* Research ("UCAR"). All rights reserved. Developed by NCAR's
+* Computational and Information Systems Laboratory, UCAR,
+* www.cisl.ucar.edu.
+*
+* Redistribution and use of the Software in source and binary forms,
+* with or without modification, is permitted provided that the
+* following conditions are met:
+*
+*     - Neither the names of NCAR's Computational and Information Systems
+*       Laboratory, the University Corporation for Atmospheric Research,
+*       nor the names of its sponsors or contributors may be used to
+*       endorse or promote products derived from this Software without
+*       specific prior written permission.
+*
+*     - Redistributions of source code must retain the above copyright
+*       notices, this list of conditions, and the disclaimer below.
+*
+*     - Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions, and the disclaimer below in the
+*       documentation and/or other materials provided with the
+*       distribution.
+*
+* THIS SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT
+* HOLDERS BE LIABLE FOR ANY CLAIM, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+* ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+* CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+* SOFTWARE.
+* ```
+*/
+
+'use strict';
+
+// MODULES //
+
+var floor = require( '@stdlib/math/base/special/floor' );
+
+
+// MAIN //
+
+/**
+* Factorizes a sequence length into a product of integers and stores the results in a double-precision floating-point array.
+*
+* ## Notes
+*
+* -   Factorization results are stored in the output array as follows:
+*
+*     ```text
+*     [ sequence_length | number_of_factors | integer_factors | unused_storage ]
+*     ```
+*
+* @param {NonNegativeInteger} N - length of the sequence
+* @param {NonNegativeInteger} M - number of trial divisors
+* @param {Float64Array} initial - strided array of initial trial divisors
+* @param {integer} si - stride length for `initial`
+* @param {NonNegativeInteger} oi - starting index for `initial`
+* @param {Float64Array} out - output array for storing factorization results
+* @param {integer} so - stride length for `out`
+* @param {NonNegativeInteger} oo - starting index for `out`
+* @returns {NonNegativeInteger} number of factors into which `N` was decomposed
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var N = 630;
+* var initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] ); // as found in FFTPACK
+* var factors = new Float64Array( 7 );
+*
+* var numFactors = decompose( N, 4, initial, 1, 0, factors, 1, 0 );
+* // returns 5
+*
+* var f = factors.slice();
+* // returns <Float64Array>[ 630, 5, 2, 3, 3, 5, 7 ]
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var N = 8;
+* var initial = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] ); // as found in FFTPACK
+* var factors = new Float64Array( 4 );
+*
+* var numFactors = decompose( N, 4, initial, 1, 0, factors, 1, 0 );
+* // returns 2
+*
+* var f = factors.slice();
+* // returns <Float64Array>[ 8, 2, 2, 4 ]
+*/
+function decompose( N, M, initial, si, oi, out, so, oo ) {
+	var divisor;
+	var ntrials;
+	var nl;
+	var nf;
+	var nq;
+	var nr;
+	var ib;
+	var i;
+	var j;
+
+	if ( N === 0 ) {
+		out[ oo ] = N;
+		out[ oo+so ] = 0;
+		return 0;
+	}
+
+	// Resolve the number of trial divisors:
+	ntrials = M;
+
+	// Initialize a variable for storing a trial divisor:
+	divisor = 0;
+
+	// Initialize a variable for storing a sub-sequence length:
+	nl = N;
+
+	// Initialize a variable for keeping track of the number of factors into which `N` decomposes:
+	nf = 0;
+
+	j = 0;
+	do {
+		if ( j < ntrials ) {
+			divisor = initial[ oi + (j * si) ];
+		} else {
+			divisor += 2;
+		}
+		j += 1;
+		while ( true ) {
+			// Compute the integer quotient:
+			nq = floor( nl / divisor );
+
+			// Compute the remainder:
+			nr = nl - ( divisor * nq );
+
+			// If the divisor did not evenly divide the current sub-sequence length, try a new divisor...
+			if ( nr !== 0 ) {
+				break;
+			}
+			// We found a new factor:
+			nf += 1;
+
+			// Update the sub-sequence length:
+			nl = nq;
+
+			// Store the factor in the output array:
+			out[ oo+((nf+1)*so) ] = divisor;
+
+			// When the divisor is `2` and we've already found other factors, shift the other factors right to make room for the most recent `2` factor...
+			if ( divisor === 2 && nf !== 1 ) {
+				for ( i = 2; i <= nf; i++ ) {
+					ib = nf - i + 2;
+					out[ oo+((ib+1)*so) ] = out[ oo + (ib*so) ];
+				}
+				out[ oo+(2*so) ] = 2;
+			}
+			// If we cannot further divide the sequence length into smaller sub-sequences, we're done...
+			if ( nl === 1 ) {
+				break;
+			}
+		}
+	} while ( nl !== 1 );
+
+	// Store the sequence length:
+	out[ oo ] = N;
+
+	// Store the number of factors:
+	out[ oo+so ] = nf;
+
+	// Return the number of factors:
+	return nf;
+}
+
+
+// EXPORTS //
+
+module.exports = decompose;

--- a/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/package.json
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@stdlib/fft/base/fftpack/float64/decompose",
+  "version": "0.0.0",
+  "description": "Factorize a sequence length into a product of integers and store the results in a double-precision floating-point array.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "fft",
+    "fftpack",
+    "decompose",
+    "factorization",
+    "factorize",
+    "factor",
+    "prime",
+    "sequence",
+    "product",
+    "float64",
+    "double",
+    "float64array"
+  ],
+  "__stdlib__": {}
+}

--- a/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/test/test.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/test/test.js
@@ -1,0 +1,130 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Float64Array = require( '@stdlib/array/float64' );
+var isSameFloat64Array = require( '@stdlib/assert/is-same-float64array' );
+var decompose = require( './../lib' );
+
+
+// VARIABLES //
+
+var INITIAL = new Float64Array( [ 3.0, 4.0, 2.0, 5.0 ] ); // as found in FFTPACK
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof decompose, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 8', function test( t ) {
+	t.strictEqual( decompose.length, 8, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function correctly factorizes a sequence length into a product of integers', function test( t ) {
+	var factors;
+	var nf;
+
+	factors = new Float64Array( 7 );
+	nf = decompose( 630, 4, INITIAL, 1, 0, factors, 1, 0 );
+
+	t.strictEqual( nf, 5, 'returns expected value' );
+	t.strictEqual( factors[ 0 ], 630, 'returns expected value' );
+	t.strictEqual( factors[ 1 ], 5, 'returns expected value' );
+	t.strictEqual( factors[ 2 ], 2, 'returns expected value' );
+	t.strictEqual( factors[ 3 ], 3, 'returns expected value' );
+	t.strictEqual( factors[ 4 ], 3, 'returns expected value' );
+	t.strictEqual( factors[ 5 ], 5, 'returns expected value' );
+	t.strictEqual( factors[ 6 ], 7, 'returns expected value' );
+
+	factors = new Float64Array( 4 );
+	nf = decompose( 8, 4, INITIAL, 1, 0, factors, 1, 0 );
+
+	t.strictEqual( nf, 2, 'returns expected value' );
+	t.strictEqual( factors[ 0 ], 8, 'returns expected value' );
+	t.strictEqual( factors[ 1 ], 2, 'returns expected value' );
+	t.strictEqual( factors[ 2 ], 2, 'returns expected value' );
+	t.strictEqual( factors[ 3 ], 4, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function correctly factorizes prime numbers', function test( t ) {
+	var primesList;
+	var factors;
+	var nf;
+	var i;
+
+	// First 10 prime numbers:
+	primesList = [ 2, 3, 5, 7, 11, 13, 17, 19, 23, 29 ];
+
+	for ( i = 0; i < primesList.length; i++ ) {
+		factors = new Float64Array( 3 );
+		nf = decompose( primesList[ i ], 4, INITIAL, 1, 0, factors, 1, 0 );
+
+		t.strictEqual( nf, 1, 'returns expected value for ' + primesList[ i ] );
+		t.strictEqual( factors[ 0 ], primesList[ i ], 'returns expected value' );
+		t.strictEqual( factors[ 1 ], 1, 'returns expected value' );
+		t.strictEqual( factors[ 2 ], primesList[ i ], 'returns expected value' );
+	}
+
+	t.end();
+});
+
+tape( 'the function returns expected results when provided a sequence length of 0', function test( t ) {
+	var factors;
+	var nf;
+
+	factors = new Float64Array( 2 );
+	nf = decompose( 0, 4, INITIAL, 1, 0, factors, 1, 0 );
+
+	t.strictEqual( nf, 0, 'returns expected value' );
+	t.strictEqual( factors[ 0 ], 0, 'returns expected value' );
+	t.strictEqual( factors[ 1 ], 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function correctly handles stride and offset parameters', function test( t ) {
+	var expected;
+	var factors;
+	var so;
+	var oo;
+	var nf;
+
+	factors = new Float64Array( 11 );
+
+	so = 2;
+	oo = 1;
+	nf = decompose( 12, 4, INITIAL, 1, 0, factors, so, oo );
+
+	expected = new Float64Array([ 0.0, 12.0, 0.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0, 0.0, 0.0 ]);
+
+	t.strictEqual( nf, 2, 'returns expected value' );
+	t.strictEqual( isSameFloat64Array( factors, expected ), true, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/test/test.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/float64/decompose/test/test.js
@@ -121,7 +121,7 @@ tape( 'the function correctly handles stride and offset parameters', function te
 	oo = 1;
 	nf = decompose( 12, 4, INITIAL, 1, 0, factors, so, oo );
 
-	expected = new Float64Array([ 0.0, 12.0, 0.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0, 0.0, 0.0 ]);
+	expected = new Float64Array( [ 0.0, 12.0, 0.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0, 0.0, 0.0 ] ); // eslint-disable-line max-len
 
 	t.strictEqual( nf, 2, 'returns expected value' );
 	t.strictEqual( isSameFloat64Array( factors, expected ), true, 'returns expected value' );


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown_pkg_readmes status: passed
  - task: lint_markdown_docs status: na
  - task: lint_markdown status: na
  - task: lint_package_json status: passed
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed ---

Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1206.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds `fft/base/fftpack/float64/decompose`, which will be the `float64` equivalent for [`fft/base/fftpack/generic/decompose`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/fft/base/fftpack/generic/decompose).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   https://github.com/stdlib-js/metr-issue-tracker/issues/1206

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding
-   [x] Code review

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Used Claude Code to review the implementation and do some R&D related to other similar packages in `blas`, `blas/ext`, and `stats` namespaces.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
