### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/fft/base/fftpack/README.md
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/README.md
@@ -43,7 +43,8 @@ var o = ns;
 
 <div class="namespace-toc">
 
--   <span class="signature">[`base`][@stdlib/fft/base/fftpack/generic]</span><span class="delimiter">: </span><span class="description">FFTPACK routines for fast Fourier transforms on "generic" collections.</span>
+-   <span class="signature">[`generic`][@stdlib/fft/base/fftpack/generic]</span><span class="delimiter">: </span><span class="description">FFTPACK routines for fast Fourier transforms on "generic" collections.</span>
+-   <span class="signature">[`ndarray`][@stdlib/fft/base/fftpack/ndarray]</span><span class="delimiter">: </span><span class="description">lower-level ndarray wrappers for FFTPACK fast Fourier transform routines.</span>
 
 </div>
 
@@ -87,6 +88,8 @@ console.log( objectKeys( ns ) );
 <!-- <toc-links> -->
 
 [@stdlib/fft/base/fftpack/generic]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/fft/base/fftpack/generic
+
+[@stdlib/fft/base/fftpack/ndarray]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/fft/base/fftpack/ndarray
 
 <!-- </toc-links> -->
 

--- a/lib/node_modules/@stdlib/fft/base/fftpack/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/docs/types/index.d.ts
@@ -21,15 +21,21 @@
 /* eslint-disable max-lines */
 
 import generic = require( '@stdlib/fft/base/fftpack/generic' );
+import ndarray = require( '@stdlib/fft/base/fftpack/ndarray' );
 
 /**
 * Interface describing the `fftpack` namespace.
 */
 interface Namespace {
 	/**
-	* FFTPACK routines for fast Fourier transforms for "generic" collections.
+	* FFTPACK routines for fast Fourier transforms on generic collections.
 	*/
 	generic: typeof generic;
+
+	/**
+	* Lower-level ndarray wrappers for FFTPACK fast Fourier transform routines.
+	*/
+	ndarray: typeof ndarray;
 }
 
 /**

--- a/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/docs/types/index.d.ts
@@ -23,11 +23,11 @@
 import generic = require( '@stdlib/fft/base/fftpack/ndarray/generic' );
 
 /**
-* Interface describing the `fftpack` namespace.
+* Interface describing the `ndarray` namespace.
 */
 interface Namespace {
 	/**
-	* TODO.
+	* Lower-level ndarray wrappers for generic FFTPACK fast Fourier transform routines.
 	*/
 	generic: typeof generic;
 }

--- a/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/generic/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/generic/docs/types/index.d.ts
@@ -20,14 +20,49 @@
 
 /* eslint-disable max-lines */
 
-import rffti = require( '@stdlib/fft/base/fftpack/generic/rffti' );
+import rffti = require( '@stdlib/fft/base/fftpack/ndarray/generic/rffti' );
 
 /**
 * Interface describing the `generic` namespace.
 */
 interface Namespace {
 	/**
-	* TODO.
+	* Initializes a workspace array for performing a real-valued Fourier transform on a one-dimensional ndarray.
+	*
+	* ## Notes
+	*
+	* -   The function expects the following ndarrays:
+	*
+	*     -   a one-dimensional input ndarray.
+	*     -   a zero-dimensional ndarray containing the length of the sequence to transform.
+	*
+	* @param arrays - array-like object containing ndarrays
+	* @returns input ndarray
+	*
+	* @example
+	* var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
+	* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+	* var Slice = require( '@stdlib/slice/ctor' );
+	* var slice = require( '@stdlib/ndarray/slice' );
+	*
+	* var N = 8;
+	* var len = scalar2ndarray( N, {
+	*     'dtype': 'int32'
+	* });
+	*
+	* var w = new Float64Vector( ( 2*N ) + 34 );
+	*
+	* var out = ns.rffti( [ w, len ] );
+	* // returns <ndarray>
+	*
+	* var bool = ( out === w );
+	* // returns true
+	*
+	* var twiddleFactors = slice( w, new Slice( N, 2*N ) );
+	* // returns <ndarray>[ ~0.707, ~0.707, 0, 0, 0, 0, 0, 0 ]
+	*
+	* var factors = slice( w, new Slice( 2*N, ( 2*N ) + 4 ) );
+	* // returns <ndarray>[ 8, 2, 2, 4 ]
 	*/
 	rffti: typeof rffti;
 }

--- a/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/lib/index.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/lib/index.js
@@ -37,7 +37,7 @@ var setReadOnly = require( '@stdlib/utils/define-read-only-property' );
 var ns = {};
 
 /**
-* @name base
+* @name generic
 * @memberof ns
 * @readonly
 * @type {Namespace}

--- a/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/package.json
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stdlib/fft/base/fftpack",
+  "name": "@stdlib/fft/base/fftpack/ndarray",
   "version": "0.0.0",
   "description": "Lower-level ndarray wrappers for FFTPACK fast Fourier transform routines.",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-08-19 11:15 PDT (`542efe8`) and 2026-08-20 03:56 PDT (`fd3c50f`). An automated review of the window's 56 commits surfaced ten high-signal issues, all in the new `fft/base/fftpack` namespace packages.

This pull request:

**`fft/base/fftpack/ndarray`**

-   Fixed the duplicate `name` field in `lib/node_modules/@stdlib/fft/base/fftpack/ndarray/package.json` from 1fadbac — it was copy-pasted from the parent package, colliding with `@stdlib/fft/base/fftpack`; now set to `@stdlib/fft/base/fftpack/ndarray`.
-   Fixes a leftover copy-paste error from 1fadbac in `lib/node_modules/@stdlib/fft/base/fftpack/ndarray/lib/index.js`: `@name base` now reads `@name generic` to match the `setReadOnly` property, mirroring the fix already applied to the parent namespace in fd3c50f.
-   Fixes a copy-paste doc-comment bug from 1fadbac: `fft/base/fftpack/ndarray/docs/types/index.d.ts` described the interface as the `fftpack` namespace instead of `ndarray`. Corrected to match the file it actually documents.
-   Fix the "TODO." placeholder JSDoc on the `generic` member in `fft/base/fftpack/ndarray`'s `docs/types/index.d.ts`, shipped in 1fadbac — now reads "Lower-level ndarray wrappers for generic FFTPACK fast Fourier transform routines." to match the package description.

**`fft/base/fftpack/ndarray/generic`**

-   Fixed the `ns.rffti` type signature: c6ce075 imported the strided kernel `@stdlib/fft/base/fftpack/generic/rffti` in `lib/node_modules/@stdlib/fft/base/fftpack/ndarray/generic/docs/types/index.d.ts` instead of the ndarray wrapper, so the declared signature didn't match what the namespace actually exports. Swapped the import to `@stdlib/fft/base/fftpack/ndarray/generic/rffti`.
-   Fix `rffti`'s placeholder "TODO." JSDoc in `lib/node_modules/@stdlib/fft/base/fftpack/ndarray/generic/docs/types/index.d.ts` (c6ce075), pulling full docs from the member's own declaration file and aligning the example with `ns.rffti` per the `fftpack/generic` namespace convention.

**`fft/base/fftpack`**

-   Fix the `fftpack` namespace ToC label: `generic`, not `base` — `lib/node_modules/@stdlib/fft/base/fftpack/README.md` links to `.../fftpack/generic` but was headed `base`, a leftover from the earlier `@name base` annotation (README regenerated in f66e808; the annotation was fixed in fd3c50f without regenerating the README).
-   Fixed the fftpack namespace README to include `ndarray`, missed in fd3c50f (`lib/index.js` added the entry, but `lib/node_modules/@stdlib/fft/base/fftpack/README.md` never got the ToC row or the `[@stdlib/fft/base/fftpack/ndarray]` link definition). Added both.
-   Fixes `ns.ndarray` type error introduced in fd3c50f: `lib/node_modules/@stdlib/fft/base/fftpack/docs/types/index.d.ts` was never updated to declare the `ndarray` member, so TS consumers couldn't access it despite it existing at runtime. Adds the `ndarray` import and `Namespace` member.
-   Fixed `generic` description in `fft/base/fftpack/docs/types/index.d.ts` (92b8505) to read "on generic collections", matching the wording already applied to the sibling `fft/base/fftpack/generic` declaration in 3c3b738 — same phrase, just missed in this file.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** The window's 56 commits were reviewed for (1) stdlib style-guide compliance (checked against `docs/style-guides` and established reference packages) and (2) objective bugs within the changed code (independent parallel scans, findings cross-verified against the files on disk). Only issues corroborated by multiple independent reviews or directly re-verifiable from the diff were kept. Deliberately excluded: subjective suggestions, anything requiring interpretation, and anything whose fix would require touching code outside the window's diff (e.g. the ULP test migrations, the Wald `logpdf` rewrite, and the fftpack package relocations were all confirmed as intentional and left untouched).

**Note.** This PR is intentionally a draft; a maintainer will audit and promote it.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code as part of an automated daily review of commits merged to `develop`; all fixes were cross-verified by multiple independent review passes before being applied.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxJcoaUHMinds5gCP7dY94)_