### PR TITLE
fix: avoid overflow and duplicate computation

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/logpdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/logpdf/lib/factory.js
@@ -49,7 +49,6 @@ var C = 0.5 * ( LN2 - LNPI );
 */
 function factory( sigma ) {
 	var lsigma;
-	var sigma2;
 	if (
 		isnan( sigma ) ||
 		sigma <= 0.0
@@ -57,7 +56,6 @@ function factory( sigma ) {
 		return constantFunction( NaN );
 	}
 	lsigma = ln( sigma );
-	sigma2 = sigma * sigma;
 	return logpdf;
 
 	/**
@@ -72,13 +70,15 @@ function factory( sigma ) {
 	* // returns <number>
 	*/
 	function logpdf( x ) {
+		var v;
 		if ( isnan( x ) ) {
 			return NaN;
 		}
 		if ( x < 0.0 ) {
 			return NINF;
 		}
-		return C - lsigma - ( (x*x) / ( 2.0 * sigma2 ) );
+		v = x / sigma;
+		return C - lsigma - ( (v*v) / 2.0 );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/logpdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/logpdf/lib/main.js
@@ -76,6 +76,7 @@ var C = 0.5 * ( LN2 - LNPI );
 * // returns NaN
 */
 function logpdf( x, sigma ) {
+	var v;
 	if (
 		isnan( x ) ||
 		isnan( sigma ) ||
@@ -86,7 +87,8 @@ function logpdf( x, sigma ) {
 	if ( x < 0.0 ) {
 		return NINF;
 	}
-	return C - ln( sigma ) - ( (x*x) / ( 2.0 * (sigma*sigma) ) );
+	v = x / sigma;
+	return C - ln( sigma ) - ( (v*v) / 2.0 );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/logpdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/logpdf/src/main.c
@@ -38,6 +38,7 @@ static const double C = 0.5 * ( STDLIB_CONSTANT_FLOAT64_LN2 - STDLIB_CONSTANT_FL
 * // returns ~-0.546
 */
 double stdlib_base_dists_halfnormal_logpdf( const double x, const double sigma ) {
+	double v;
 	if (
 		stdlib_base_is_nan( x ) ||
 		stdlib_base_is_nan( sigma ) ||
@@ -48,5 +49,6 @@ double stdlib_base_dists_halfnormal_logpdf( const double x, const double sigma )
 	if ( x < 0.0 ) {
 		return STDLIB_CONSTANT_FLOAT64_NINF;
 	}
-	return C - stdlib_base_ln( sigma ) - ( (x*x) / ( 2.0 * (sigma*sigma) ) );
+	v = x / sigma;
+	return C - stdlib_base_ln( sigma ) - ( (v*v) / 2.0 );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/lib/factory.js
@@ -22,7 +22,7 @@
 
 var constantFunction = require( '@stdlib/utils/constant-function' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var pow = require( '@stdlib/math/base/special/pow' );
+var abs2 = require( '@stdlib/math/base/special/abs2' );
 var ln = require( '@stdlib/math/base/special/ln' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var PI = require( '@stdlib/constants/float64/pi' );
@@ -75,7 +75,7 @@ function factory( mu, sigma ) {
 		if ( x <= 0.0 ) {
 			return NINF;
 		}
-		return A - ln( x ) - ( 0.5 * pow( ( ln(x) - mu ) / sigma, 2.0 ) );
+		return A - ln( x ) - ( 0.5 * abs2( ( ln(x) - mu ) / sigma ) );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/lib/factory.js
@@ -69,13 +69,15 @@ function factory( mu, sigma ) {
 	* // returns <number>
 	*/
 	function logpdf( x ) {
+		var lnx;
 		if ( isnan( x ) ) {
 			return NaN;
 		}
 		if ( x <= 0.0 ) {
 			return NINF;
 		}
-		return A - ln( x ) - ( 0.5 * abs2( ( ln(x) - mu ) / sigma ) );
+		lnx = ln( x );
+		return A - lnx - ( 0.5 * abs2( ( lnx - mu ) / sigma ) );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/lib/factory.js
@@ -25,7 +25,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var abs2 = require( '@stdlib/math/base/special/abs2' );
 var ln = require( '@stdlib/math/base/special/ln' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var PI = require( '@stdlib/constants/float64/pi' );
+var LN_TWO_PI = require( '@stdlib/constants/float64/ln-two-pi' );
 
 
 // MAIN //
@@ -54,7 +54,7 @@ function factory( mu, sigma ) {
 	) {
 		return constantFunction( NaN );
 	}
-	A = ( -0.5 * ln( 2.0 * PI ) ) - ln( sigma );
+	A = ( -0.5 * LN_TWO_PI ) - ln( sigma );
 	return logpdf;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/lib/factory.js
@@ -46,9 +46,7 @@ var PI = require( '@stdlib/constants/float64/pi' );
 * // returns ~-3.672
 */
 function factory( mu, sigma ) {
-	var s2;
 	var A;
-	var B;
 	if (
 		isnan( mu ) ||
 		isnan( sigma ) ||
@@ -56,9 +54,7 @@ function factory( mu, sigma ) {
 	) {
 		return constantFunction( NaN );
 	}
-	s2 = pow( sigma, 2.0 );
-	A = -0.5 * ln( 2.0 * s2 * PI );
-	B = -1.0 / ( 2.0 * s2 );
+	A = ( -0.5 * ln( 2.0 * PI ) ) - ln( sigma );
 	return logpdf;
 
 	/**
@@ -79,7 +75,7 @@ function factory( mu, sigma ) {
 		if ( x <= 0.0 ) {
 			return NINF;
 		}
-		return A - ln( x ) + ( B * pow( ln(x) - mu, 2.0 ) );
+		return A - ln( x ) - ( 0.5 * pow( ( ln(x) - mu ) / sigma, 2.0 ) );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/lib/main.js
@@ -71,9 +71,7 @@ var PI = require( '@stdlib/constants/float64/pi' );
 * // returns NaN
 */
 function logpdf( x, mu, sigma ) {
-	var s2;
 	var A;
-	var B;
 	if (
 		isnan( x ) ||
 		isnan( mu ) ||
@@ -85,10 +83,8 @@ function logpdf( x, mu, sigma ) {
 	if ( x <= 0.0 ) {
 		return NINF;
 	}
-	s2 = pow( sigma, 2.0 );
-	A = -0.5 * ln( 2.0 * s2 * PI );
-	B = -1.0 / ( 2.0 * s2 );
-	return A - ln( x ) + ( B * pow( ln(x) - mu, 2.0 ) );
+	A = ( -0.5 * ln( 2.0 * PI ) ) - ln( sigma );
+	return A - ln( x ) - ( 0.5 * pow( ( ln(x) - mu ) / sigma, 2.0 ) );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/lib/main.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var pow = require( '@stdlib/math/base/special/pow' );
+var abs2 = require( '@stdlib/math/base/special/abs2' );
 var ln = require( '@stdlib/math/base/special/ln' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var PI = require( '@stdlib/constants/float64/pi' );
@@ -84,7 +84,7 @@ function logpdf( x, mu, sigma ) {
 		return NINF;
 	}
 	A = ( -0.5 * ln( 2.0 * PI ) ) - ln( sigma );
-	return A - ln( x ) - ( 0.5 * pow( ( ln(x) - mu ) / sigma, 2.0 ) );
+	return A - ln( x ) - ( 0.5 * abs2( ( ln(x) - mu ) / sigma ) );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/lib/main.js
@@ -71,6 +71,7 @@ var LN_TWO_PI = require( '@stdlib/constants/float64/ln-two-pi' );
 * // returns NaN
 */
 function logpdf( x, mu, sigma ) {
+	var lnx;
 	var A;
 	if (
 		isnan( x ) ||
@@ -83,8 +84,9 @@ function logpdf( x, mu, sigma ) {
 	if ( x <= 0.0 ) {
 		return NINF;
 	}
+	lnx = ln( x );
 	A = ( -0.5 * LN_TWO_PI ) - ln( sigma );
-	return A - ln( x ) - ( 0.5 * abs2( ( ln(x) - mu ) / sigma ) );
+	return A - lnx - ( 0.5 * abs2( ( lnx - mu ) / sigma ) );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/lib/main.js
@@ -24,7 +24,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var abs2 = require( '@stdlib/math/base/special/abs2' );
 var ln = require( '@stdlib/math/base/special/ln' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var PI = require( '@stdlib/constants/float64/pi' );
+var LN_TWO_PI = require( '@stdlib/constants/float64/ln-two-pi' );
 
 
 // MAIN //
@@ -83,7 +83,7 @@ function logpdf( x, mu, sigma ) {
 	if ( x <= 0.0 ) {
 		return NINF;
 	}
-	A = ( -0.5 * ln( 2.0 * PI ) ) - ln( sigma );
+	A = ( -0.5 * LN_TWO_PI ) - ln( sigma );
 	return A - ln( x ) - ( 0.5 * abs2( ( ln(x) - mu ) / sigma ) );
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/manifest.json
@@ -40,10 +40,10 @@
       "dependencies": [
         "@stdlib/math/base/napi/ternary",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/abs2",
         "@stdlib/math/base/special/ln",
         "@stdlib/constants/float64/ninf",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/ln-two-pi"
       ]
     },
     {
@@ -59,11 +59,11 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/abs2",
         "@stdlib/math/base/special/ln",
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/eps",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/ln-two-pi"
       ]
     },
     {
@@ -79,10 +79,10 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/abs2",
         "@stdlib/math/base/special/ln",
         "@stdlib/constants/float64/ninf",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/ln-two-pi"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/src/main.c
@@ -18,10 +18,10 @@
 
 #include "stdlib/stats/base/dists/lognormal/logpdf.h"
 #include "stdlib/math/base/assert/is_nan.h"
-#include "stdlib/math/base/special/pow.h"
+#include "stdlib/math/base/special/abs2.h"
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/constants/float64/ninf.h"
-#include "stdlib/constants/float64/pi.h"
+#include "stdlib/constants/float64/ln_two_pi.h"
 
 /**
 * Evaluates the natural logarithm of the probability density function (PDF) for a lognormal distribution with location parameter `mu` and scale parameter `sigma` at a value `x`.
@@ -51,6 +51,6 @@ double stdlib_base_dists_lognormal_logpdf( const double x, const double mu, cons
 		return STDLIB_CONSTANT_FLOAT64_NINF;
 	}
 	lnx = stdlib_base_ln( x );
-	A = ( -0.5 * stdlib_base_ln( 2.0 * STDLIB_CONSTANT_FLOAT64_PI ) ) - stdlib_base_ln( sigma );
-	return A - lnx - ( 0.5 * stdlib_base_pow( ( lnx - mu ) / sigma, 2.0 ) );
+	A = ( -0.5 * STDLIB_CONSTANT_FLOAT64_LN_TWO_PI ) - stdlib_base_ln( sigma );
+	return A - lnx - ( 0.5 * stdlib_base_abs2( ( lnx - mu ) / sigma ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/src/main.c
@@ -37,9 +37,7 @@
 */
 double stdlib_base_dists_lognormal_logpdf( const double x, const double mu, const double sigma ) {
 	double lnx;
-	double s2;
 	double A;
-	double B;
 
 	if (
 		stdlib_base_is_nan( x ) ||
@@ -52,9 +50,7 @@ double stdlib_base_dists_lognormal_logpdf( const double x, const double mu, cons
 	if ( x <= 0.0 ) {
 		return STDLIB_CONSTANT_FLOAT64_NINF;
 	}
-	s2 = stdlib_base_pow( sigma, 2.0 );
 	lnx = stdlib_base_ln( x );
-	A = -0.5 * stdlib_base_ln( 2.0 * s2 * STDLIB_CONSTANT_FLOAT64_PI );
-	B = -1.0 / ( 2.0 * s2 );
-	return A - lnx + ( B * stdlib_base_pow( lnx - mu, 2.0 ) );
+	A = ( -0.5 * stdlib_base_ln( 2.0 * STDLIB_CONSTANT_FLOAT64_PI ) ) - stdlib_base_ln( sigma );
+	return A - lnx - ( 0.5 * stdlib_base_pow( ( lnx - mu ) / sigma, 2.0 ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/lib/factory.js
@@ -47,9 +47,7 @@ var PI = require( '@stdlib/constants/float64/pi' );
 * // returns ~0.025
 */
 function factory( mu, sigma ) {
-	var s2;
 	var A;
-	var B;
 	if (
 		isnan( mu ) ||
 		isnan( sigma ) ||
@@ -57,9 +55,7 @@ function factory( mu, sigma ) {
 	) {
 		return constantFunction( NaN );
 	}
-	s2 = pow( sigma, 2.0 );
-	A = 1.0 / ( sqrt( 2.0 * s2 * PI ) );
-	B = -1.0 / ( 2.0 * s2 );
+	A = 1.0 / ( sigma * sqrt( 2.0 * PI ) );
 	return pdf;
 
 	/**
@@ -80,7 +76,7 @@ function factory( mu, sigma ) {
 		if ( x <= 0.0 ) {
 			return 0.0;
 		}
-		return (1.0/x) * A * exp( B * pow( ln(x) - mu, 2.0 ) );
+		return (1.0/x) * A * exp( -0.5 * pow( ( ln(x) - mu ) / sigma, 2.0 ) );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/lib/factory.js
@@ -24,7 +24,7 @@ var constantFunction = require( '@stdlib/utils/constant-function' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var exp = require( '@stdlib/math/base/special/exp' );
-var pow = require( '@stdlib/math/base/special/pow' );
+var abs2 = require( '@stdlib/math/base/special/abs2' );
 var ln = require( '@stdlib/math/base/special/ln' );
 var PI = require( '@stdlib/constants/float64/pi' );
 
@@ -76,7 +76,7 @@ function factory( mu, sigma ) {
 		if ( x <= 0.0 ) {
 			return 0.0;
 		}
-		return (1.0/x) * A * exp( -0.5 * pow( ( ln(x) - mu ) / sigma, 2.0 ) );
+		return (1.0/x) * A * exp( -0.5 * abs2( ( ln(x) - mu ) / sigma ) );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/lib/factory.js
@@ -22,11 +22,10 @@
 
 var constantFunction = require( '@stdlib/utils/constant-function' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var abs2 = require( '@stdlib/math/base/special/abs2' );
 var ln = require( '@stdlib/math/base/special/ln' );
-var PI = require( '@stdlib/constants/float64/pi' );
+var SQRT_TWO_PI = require( '@stdlib/constants/float64/sqrt-two-pi' );
 
 
 // MAIN //
@@ -55,7 +54,7 @@ function factory( mu, sigma ) {
 	) {
 		return constantFunction( NaN );
 	}
-	A = 1.0 / ( sigma * sqrt( 2.0 * PI ) );
+	A = 1.0 / ( sigma * SQRT_TWO_PI );
 	return pdf;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/lib/main.js
@@ -72,9 +72,7 @@ var PI = require( '@stdlib/constants/float64/pi' );
 * // returns NaN
 */
 function pdf( x, mu, sigma ) {
-	var s2;
 	var A;
-	var B;
 	if (
 		isnan( x ) ||
 		isnan( mu ) ||
@@ -86,10 +84,8 @@ function pdf( x, mu, sigma ) {
 	if ( x <= 0.0 ) {
 		return 0.0;
 	}
-	s2 = pow( sigma, 2.0 );
-	A = 1.0 / ( sqrt( 2.0 * s2 * PI ) );
-	B = -1.0 / ( 2.0 * s2 );
-	return (1.0/x) * A * exp( B * pow( ln(x) - mu, 2.0 ) );
+	A = 1.0 / ( sigma * sqrt( 2.0 * PI ) );
+	return (1.0/x) * A * exp( -0.5 * pow( ( ln(x) - mu ) / sigma, 2.0 ) );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/lib/main.js
@@ -23,7 +23,7 @@
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var exp = require( '@stdlib/math/base/special/exp' );
-var pow = require( '@stdlib/math/base/special/pow' );
+var abs2 = require( '@stdlib/math/base/special/abs2' );
 var ln = require( '@stdlib/math/base/special/ln' );
 var PI = require( '@stdlib/constants/float64/pi' );
 
@@ -85,7 +85,7 @@ function pdf( x, mu, sigma ) {
 		return 0.0;
 	}
 	A = 1.0 / ( sigma * sqrt( 2.0 * PI ) );
-	return (1.0/x) * A * exp( -0.5 * pow( ( ln(x) - mu ) / sigma, 2.0 ) );
+	return (1.0/x) * A * exp( -0.5 * abs2( ( ln(x) - mu ) / sigma ) );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/lib/main.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var abs2 = require( '@stdlib/math/base/special/abs2' );
 var ln = require( '@stdlib/math/base/special/ln' );
-var PI = require( '@stdlib/constants/float64/pi' );
+var SQRT_TWO_PI = require( '@stdlib/constants/float64/sqrt-two-pi' );
 
 
 // MAIN //
@@ -84,7 +83,7 @@ function pdf( x, mu, sigma ) {
 	if ( x <= 0.0 ) {
 		return 0.0;
 	}
-	A = 1.0 / ( sigma * sqrt( 2.0 * PI ) );
+	A = 1.0 / ( sigma * SQRT_TWO_PI );
 	return (1.0/x) * A * exp( -0.5 * abs2( ( ln(x) - mu ) / sigma ) );
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/manifest.json
@@ -41,10 +41,9 @@
         "@stdlib/math/base/napi/ternary",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/exp",
-        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/abs2",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/special/sqrt",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/sqrt-two-pi"
       ]
     },
     {
@@ -62,10 +61,9 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/constants/float64/eps",
         "@stdlib/math/base/special/exp",
-        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/abs2",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/special/sqrt",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/sqrt-two-pi"
       ]
     },
     {
@@ -83,10 +81,9 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/constants/float64/eps",
         "@stdlib/math/base/special/exp",
-        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/abs2",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/special/sqrt",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/sqrt-two-pi"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/src/main.c
@@ -20,9 +20,8 @@
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/exp.h"
-#include "stdlib/math/base/special/pow.h"
-#include "stdlib/math/base/special/sqrt.h"
-#include "stdlib/constants/float64/pi.h"
+#include "stdlib/math/base/special/abs2.h"
+#include "stdlib/constants/float64/sqrt_two_pi.h"
 
 /**
 * Evaluates the PDF for a lognormal distribution with location `mu` and scale `sigma`.
@@ -52,10 +51,10 @@ double stdlib_base_dists_lognormal_pdf( const double x, const double mu, const d
 	if ( x <= 0.0 ) {
 		return 0.0;
 	}
-	lnx_u = stdlib_base_pow( ( stdlib_base_ln( x ) - mu ) / sigma, 2.0 );
+	lnx_u = stdlib_base_abs2( ( stdlib_base_ln( x ) - mu ) / sigma );
 	z = -0.5 * lnx_u;
 	exp_value = stdlib_base_exp( z );
-	y = 1.0 / ( x * sigma * stdlib_base_sqrt( 2.0 * STDLIB_CONSTANT_FLOAT64_PI ) );
+	y = 1.0 / ( x * sigma * STDLIB_CONSTANT_FLOAT64_SQRT_TWO_PI );
 
 	return y * exp_value;
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/src/main.c
@@ -39,7 +39,6 @@
 double stdlib_base_dists_lognormal_pdf( const double x, const double mu, const double sigma ) {
 	double exp_value;
 	double lnx_u;
-	double s2;
 	double z;
 	double y;
 	if (
@@ -53,9 +52,8 @@ double stdlib_base_dists_lognormal_pdf( const double x, const double mu, const d
 	if ( x <= 0.0 ) {
 		return 0.0;
 	}
-	s2 = stdlib_base_pow( sigma, 2.0 );
-	lnx_u = stdlib_base_pow( ( stdlib_base_ln( x ) - mu ), 2.0 );
-	z = -lnx_u / ( 2.0 * s2 );
+	lnx_u = stdlib_base_pow( ( stdlib_base_ln( x ) - mu ) / sigma, 2.0 );
+	z = -0.5 * lnx_u;
 	exp_value = stdlib_base_exp( z );
 	y = 1.0 / ( x * sigma * stdlib_base_sqrt( 2.0 * STDLIB_CONSTANT_FLOAT64_PI ) );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/lib/factory.js
@@ -46,9 +46,7 @@ var ln = require( '@stdlib/math/base/special/ln' );
 * // returns ~-4.737
 */
 function factory( mu, sigma ) {
-	var s2;
 	var A;
-	var B;
 	if (
 		isnan( mu ) ||
 		isnan( sigma ) ||
@@ -59,9 +57,7 @@ function factory( mu, sigma ) {
 	if ( sigma === 0.0 ) {
 		return degenerate( mu );
 	}
-	s2 = pow( sigma, 2.0 );
 	A = (-0.5) * ( ( 2.0*ln( sigma ) ) + LN_TWO_PI );
-	B = -1.0 / ( 2.0*s2 );
 	return logpdf;
 
 	/**
@@ -76,7 +72,7 @@ function factory( mu, sigma ) {
 	* // returns <number>
 	*/
 	function logpdf( x ) {
-		return A + ( B * pow( x-mu, 2.0 ) );
+		return A - ( 0.5 * pow( ( x-mu ) / sigma, 2.0 ) );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/lib/factory.js
@@ -24,7 +24,7 @@ var constantFunction = require( '@stdlib/utils/constant-function' );
 var degenerate = require( '@stdlib/stats/base/dists/degenerate/logpdf' ).factory;
 var LN_TWO_PI = require( '@stdlib/constants/float64/ln-two-pi' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var pow = require( '@stdlib/math/base/special/pow' );
+var abs2 = require( '@stdlib/math/base/special/abs2' );
 var ln = require( '@stdlib/math/base/special/ln' );
 
 
@@ -72,7 +72,7 @@ function factory( mu, sigma ) {
 	* // returns <number>
 	*/
 	function logpdf( x ) {
-		return A - ( 0.5 * pow( ( x-mu ) / sigma, 2.0 ) );
+		return A - ( 0.5 * abs2( ( x-mu ) / sigma ) );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/lib/main.js
@@ -72,9 +72,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 * // returns Infinity
 */
 function logpdf( x, mu, sigma ) {
-	var s2;
 	var A;
-	var B;
 	if (
 		isnan( x ) ||
 		isnan( mu ) ||
@@ -86,10 +84,8 @@ function logpdf( x, mu, sigma ) {
 	if ( sigma === 0.0 ) {
 		return ( x === mu ) ? PINF : NINF;
 	}
-	s2 = pow( sigma, 2.0 );
 	A = (-0.5) * ( ( 2.0*ln( sigma ) ) + LN_TWO_PI );
-	B = -1.0 / ( 2.0*s2 );
-	return A + ( B * pow( x-mu, 2.0 ) );
+	return A - ( 0.5 * pow( ( x-mu ) / sigma, 2.0 ) );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/lib/main.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var ln = require( '@stdlib/math/base/special/ln' );
-var pow = require( '@stdlib/math/base/special/pow' );
+var abs2 = require( '@stdlib/math/base/special/abs2' );
 var LN_TWO_PI = require( '@stdlib/constants/float64/ln-two-pi' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
@@ -85,7 +85,7 @@ function logpdf( x, mu, sigma ) {
 		return ( x === mu ) ? PINF : NINF;
 	}
 	A = (-0.5) * ( ( 2.0*ln( sigma ) ) + LN_TWO_PI );
-	return A - ( 0.5 * pow( ( x-mu ) / sigma, 2.0 ) );
+	return A - ( 0.5 * abs2( ( x-mu ) / sigma ) );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/manifest.json
@@ -41,7 +41,7 @@
         "@stdlib/math/base/napi/ternary",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/abs2",
         "@stdlib/constants/float64/ln-two-pi",
         "@stdlib/constants/float64/pinf",
         "@stdlib/constants/float64/ninf"
@@ -61,7 +61,7 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/abs2",
         "@stdlib/constants/float64/ln-two-pi",
         "@stdlib/constants/float64/pinf",
         "@stdlib/constants/float64/ninf"
@@ -81,7 +81,7 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/abs2",
         "@stdlib/constants/float64/ln-two-pi",
         "@stdlib/constants/float64/pinf",
         "@stdlib/constants/float64/ninf"

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/src/main.c
@@ -37,9 +37,7 @@
 * // returns ~-2.919
 */
 double stdlib_base_dists_normal_logpdf( const double x, const double mu, const double sigma ) {
-	double s2;
 	double A;
-	double B;
 
 	if (
 		stdlib_base_is_nan( x ) ||
@@ -52,8 +50,6 @@ double stdlib_base_dists_normal_logpdf( const double x, const double mu, const d
 	if ( sigma == 0.0 ) {
 		return (x == mu) ? STDLIB_CONSTANT_FLOAT64_PINF : STDLIB_CONSTANT_FLOAT64_NINF;
 	}
-	s2 = stdlib_base_pow( sigma, 2.0 );
 	A = (-0.5) * ( ( 2.0 * stdlib_base_ln(sigma) ) + STDLIB_CONSTANT_FLOAT64_LN_TWO_PI );
-	B = -1.0 / ( 2.0 * s2 );
-	return A + ( B * stdlib_base_pow( x - mu, 2.0 ) );
+	return A - ( 0.5 * stdlib_base_pow( ( x - mu ) / sigma, 2.0 ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/src/main.c
@@ -19,7 +19,7 @@
 #include "stdlib/stats/base/dists/normal/logpdf.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/ln.h"
-#include "stdlib/math/base/special/pow.h"
+#include "stdlib/math/base/special/abs2.h"
 #include "stdlib/constants/float64/ln_two_pi.h"
 #include "stdlib/constants/float64/ninf.h"
 #include "stdlib/constants/float64/pinf.h"
@@ -51,5 +51,5 @@ double stdlib_base_dists_normal_logpdf( const double x, const double mu, const d
 		return (x == mu) ? STDLIB_CONSTANT_FLOAT64_PINF : STDLIB_CONSTANT_FLOAT64_NINF;
 	}
 	A = (-0.5) * ( ( 2.0 * stdlib_base_ln(sigma) ) + STDLIB_CONSTANT_FLOAT64_LN_TWO_PI );
-	return A - ( 0.5 * stdlib_base_pow( ( x - mu ) / sigma, 2.0 ) );
+	return A - ( 0.5 * stdlib_base_abs2( ( x - mu ) / sigma ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/lib/factory.js
@@ -23,10 +23,9 @@
 var constantFunction = require( '@stdlib/utils/constant-function' );
 var degenerate = require( '@stdlib/stats/base/dists/degenerate/pdf' ).factory;
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var abs2 = require( '@stdlib/math/base/special/abs2' );
-var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
+var SQRT_TWO_PI = require( '@stdlib/constants/float64/sqrt-two-pi' );
 
 
 // MAIN //
@@ -58,7 +57,7 @@ function factory( mu, sigma ) {
 	if ( sigma === 0.0 ) {
 		return degenerate( mu );
 	}
-	A = 1.0 / ( sigma * sqrt( TWO_PI ) );
+	A = 1.0 / ( sigma * SQRT_TWO_PI );
 	return pdf;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/lib/factory.js
@@ -47,9 +47,7 @@ var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 * // returns ~0.009
 */
 function factory( mu, sigma ) {
-	var s2;
 	var A;
-	var B;
 	if (
 		isnan( mu ) ||
 		isnan( sigma ) ||
@@ -60,9 +58,7 @@ function factory( mu, sigma ) {
 	if ( sigma === 0.0 ) {
 		return degenerate( mu );
 	}
-	s2 = pow( sigma, 2.0 );
-	A = 1.0 / sqrt( s2*TWO_PI );
-	B = -1.0 / ( 2.0*s2 );
+	A = 1.0 / ( sigma * sqrt( TWO_PI ) );
 	return pdf;
 
 	/**
@@ -80,7 +76,7 @@ function factory( mu, sigma ) {
 		if ( isnan( x ) ) {
 			return NaN;
 		}
-		return A * exp( B * pow(x-mu, 2.0) );
+		return A * exp( -0.5 * pow( ( x-mu ) / sigma, 2.0 ) );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/lib/factory.js
@@ -25,7 +25,7 @@ var degenerate = require( '@stdlib/stats/base/dists/degenerate/pdf' ).factory;
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var exp = require( '@stdlib/math/base/special/exp' );
-var pow = require( '@stdlib/math/base/special/pow' );
+var abs2 = require( '@stdlib/math/base/special/abs2' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 
 
@@ -76,7 +76,7 @@ function factory( mu, sigma ) {
 		if ( isnan( x ) ) {
 			return NaN;
 		}
-		return A * exp( -0.5 * pow( ( x-mu ) / sigma, 2.0 ) );
+		return A * exp( -0.5 * abs2( ( x-mu ) / sigma ) );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/lib/main.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var exp = require( '@stdlib/math/base/special/exp' );
-var pow = require( '@stdlib/math/base/special/pow' );
+var abs2 = require( '@stdlib/math/base/special/abs2' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
@@ -85,7 +85,7 @@ function pdf( x, mu, sigma ) {
 		return ( x === mu ) ? PINF : 0.0;
 	}
 	A = 1.0 / ( sigma * sqrt( TWO_PI ) );
-	return A * exp( -0.5 * pow( ( x-mu ) / sigma, 2.0 ) );
+	return A * exp( -0.5 * abs2( ( x-mu ) / sigma ) );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/lib/main.js
@@ -72,9 +72,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 * // returns Infinity
 */
 function pdf( x, mu, sigma ) {
-	var s2;
 	var A;
-	var B;
 	if (
 		isnan( x ) ||
 		isnan( mu ) ||
@@ -86,10 +84,8 @@ function pdf( x, mu, sigma ) {
 	if ( sigma === 0.0 ) {
 		return ( x === mu ) ? PINF : 0.0;
 	}
-	s2 = pow( sigma, 2.0 );
-	A = 1.0 / sqrt( s2*TWO_PI );
-	B = -1.0 / ( 2.0*s2 );
-	return A * exp( B * pow(x-mu, 2.0) );
+	A = 1.0 / ( sigma * sqrt( TWO_PI ) );
+	return A * exp( -0.5 * pow( ( x-mu ) / sigma, 2.0 ) );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/lib/main.js
@@ -22,8 +22,7 @@
 
 var exp = require( '@stdlib/math/base/special/exp' );
 var abs2 = require( '@stdlib/math/base/special/abs2' );
-var sqrt = require( '@stdlib/math/base/special/sqrt' );
-var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
+var SQRT_TWO_PI = require( '@stdlib/constants/float64/sqrt-two-pi' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 
@@ -84,7 +83,7 @@ function pdf( x, mu, sigma ) {
 	if ( sigma === 0.0 ) {
 		return ( x === mu ) ? PINF : 0.0;
 	}
-	A = 1.0 / ( sigma * sqrt( TWO_PI ) );
+	A = 1.0 / ( sigma * SQRT_TWO_PI );
 	return A * exp( -0.5 * abs2( ( x-mu ) / sigma ) );
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/manifest.json
@@ -39,10 +39,9 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/napi/ternary",
-        "@stdlib/constants/float64/two-pi",
+        "@stdlib/constants/float64/sqrt-two-pi",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/sqrt",
-        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/abs2",
         "@stdlib/math/base/special/exp",
         "@stdlib/constants/float64/pinf"
       ]
@@ -59,10 +58,9 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/constants/float64/two-pi",
+        "@stdlib/constants/float64/sqrt-two-pi",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/sqrt",
-        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/abs2",
         "@stdlib/math/base/special/exp",
         "@stdlib/constants/float64/pinf",
         "@stdlib/constants/float64/eps"
@@ -80,10 +78,9 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/constants/float64/two-pi",
+        "@stdlib/constants/float64/sqrt-two-pi",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/sqrt",
-        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/abs2",
         "@stdlib/math/base/special/exp",
         "@stdlib/constants/float64/pinf",
         "@stdlib/constants/float64/eps"

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/src/main.c
@@ -18,10 +18,9 @@
 
 #include "stdlib/stats/base/dists/normal/pdf.h"
 #include "stdlib/math/base/assert/is_nan.h"
-#include "stdlib/math/base/special/sqrt.h"
-#include "stdlib/math/base/special/pow.h"
+#include "stdlib/math/base/special/abs2.h"
 #include "stdlib/math/base/special/exp.h"
-#include "stdlib/constants/float64/two_pi.h"
+#include "stdlib/constants/float64/sqrt_two_pi.h"
 #include "stdlib/constants/float64/pinf.h"
 
 /**
@@ -49,6 +48,6 @@ double stdlib_base_dists_normal_pdf( const double x, const double mu, const doub
 	if ( sigma == 0.0 ) {
 		return ( x == mu ) ? STDLIB_CONSTANT_FLOAT64_PINF : 0.0;
 	}
-	A = 1.0 / ( sigma * stdlib_base_sqrt( STDLIB_CONSTANT_FLOAT64_TWO_PI ) );
-	return A * stdlib_base_exp( -0.5 * stdlib_base_pow( ( x - mu ) / sigma, 2.0 ) );
+	A = 1.0 / ( sigma * STDLIB_CONSTANT_FLOAT64_SQRT_TWO_PI );
+	return A * stdlib_base_exp( -0.5 * stdlib_base_abs2( ( x - mu ) / sigma ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/src/main.c
@@ -37,9 +37,7 @@
 * // returns ~0.054
 */
 double stdlib_base_dists_normal_pdf( const double x, const double mu, const double sigma ) {
-	double s2;
 	double A;
-	double B;
 	if (
 		stdlib_base_is_nan( x ) ||
 		stdlib_base_is_nan( mu ) ||
@@ -51,8 +49,6 @@ double stdlib_base_dists_normal_pdf( const double x, const double mu, const doub
 	if ( sigma == 0.0 ) {
 		return ( x == mu ) ? STDLIB_CONSTANT_FLOAT64_PINF : 0.0;
 	}
-	s2 = stdlib_base_pow( sigma, 2.0 );
-	A = 1.0 / stdlib_base_sqrt( s2 * STDLIB_CONSTANT_FLOAT64_TWO_PI );
-	B = -1.0 / ( 2.0 * s2 );
-	return A * stdlib_base_exp( B * stdlib_base_pow( x - mu, 2.0 ) );
+	A = 1.0 / ( sigma * stdlib_base_sqrt( STDLIB_CONSTANT_FLOAT64_TWO_PI ) );
+	return A * stdlib_base_exp( -0.5 * stdlib_base_pow( ( x - mu ) / sigma, 2.0 ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/lib/factory.js
@@ -66,9 +66,7 @@ var normalCDF = normal( 0.0, 1.0 );
 * // returns 0.0
 */
 function factory( a, b, mu, sigma ) {
-	var s2x2;
 	var A;
-	var B;
 	var C;
 
 	if (
@@ -81,9 +79,7 @@ function factory( a, b, mu, sigma ) {
 	) {
 		return constantFunction( NaN );
 	}
-	s2x2 = 2.0 * pow( sigma, 2.0 );
-	A = 1.0 / ( sqrt( s2x2 * PI ) );
-	B = -1.0 / ( s2x2 );
+	A = 1.0 / ( sigma * sqrt( 2.0 * PI ) );
 	C = normalCDF( (b-mu)/sigma ) - normalCDF( (a-mu)/sigma );
 	return pdf;
 
@@ -101,7 +97,7 @@ function factory( a, b, mu, sigma ) {
 		if ( x < a || x > b ) {
 			return 0.0;
 		}
-		return A * exp( B * pow( x - mu, 2.0 ) ) / C;
+		return A * exp( -0.5 * pow( ( x - mu ) / sigma, 2.0 ) ) / C;
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/lib/factory.js
@@ -24,9 +24,8 @@ var constantFunction = require( '@stdlib/utils/constant-function' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var abs2 = require( '@stdlib/math/base/special/abs2' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var normal = require( '@stdlib/stats/base/dists/normal/cdf' ).factory;
-var PI = require( '@stdlib/constants/float64/pi' );
+var SQRT_TWO_PI = require( '@stdlib/constants/float64/sqrt-two-pi' );
 
 
 // VARIABLES //
@@ -79,7 +78,7 @@ function factory( a, b, mu, sigma ) {
 	) {
 		return constantFunction( NaN );
 	}
-	A = 1.0 / ( sigma * sqrt( 2.0 * PI ) );
+	A = 1.0 / ( sigma * SQRT_TWO_PI );
 	C = normalCDF( (b-mu)/sigma ) - normalCDF( (a-mu)/sigma );
 	return pdf;
 

--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/lib/factory.js
@@ -22,7 +22,7 @@
 
 var constantFunction = require( '@stdlib/utils/constant-function' );
 var exp = require( '@stdlib/math/base/special/exp' );
-var pow = require( '@stdlib/math/base/special/pow' );
+var abs2 = require( '@stdlib/math/base/special/abs2' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var normal = require( '@stdlib/stats/base/dists/normal/cdf' ).factory;
@@ -97,7 +97,7 @@ function factory( a, b, mu, sigma ) {
 		if ( x < a || x > b ) {
 			return 0.0;
 		}
-		return A * exp( -0.5 * pow( ( x - mu ) / sigma, 2.0 ) ) / C;
+		return A * exp( -0.5 * abs2( ( x - mu ) / sigma ) ) / C;
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/lib/main.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var exp = require( '@stdlib/math/base/special/exp' );
-var pow = require( '@stdlib/math/base/special/pow' );
+var abs2 = require( '@stdlib/math/base/special/abs2' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var normal = require( '@stdlib/stats/base/dists/normal/cdf' ).factory;
@@ -83,7 +83,7 @@ function pdf( x, a, b, mu, sigma ) {
 	}
 	A = 1.0 / ( sigma * sqrt( 2.0 * PI ) );
 	C = normalCDF( (b-mu)/sigma ) - normalCDF( (a-mu)/sigma );
-	return A * exp( -0.5 * pow( ( x - mu ) / sigma, 2.0 ) ) / C;
+	return A * exp( -0.5 * abs2( ( x - mu ) / sigma ) ) / C;
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/lib/main.js
@@ -66,9 +66,7 @@ var normalCDF = normal( 0.0, 1.0 );
 * // returns 0.0
 */
 function pdf( x, a, b, mu, sigma ) {
-	var s2x2;
 	var A;
-	var B;
 	var C;
 
 	if (
@@ -83,11 +81,9 @@ function pdf( x, a, b, mu, sigma ) {
 	if ( x < a || x > b ) {
 		return 0.0;
 	}
-	s2x2 = 2.0 * pow( sigma, 2.0 );
-	A = 1.0 / ( sqrt( s2x2 * PI ) );
-	B = -1.0 / ( s2x2 );
+	A = 1.0 / ( sigma * sqrt( 2.0 * PI ) );
 	C = normalCDF( (b-mu)/sigma ) - normalCDF( (a-mu)/sigma );
-	return A * exp( B * pow( x - mu, 2.0 ) ) / C;
+	return A * exp( -0.5 * pow( ( x - mu ) / sigma, 2.0 ) ) / C;
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/lib/main.js
@@ -22,10 +22,9 @@
 
 var exp = require( '@stdlib/math/base/special/exp' );
 var abs2 = require( '@stdlib/math/base/special/abs2' );
-var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var normal = require( '@stdlib/stats/base/dists/normal/cdf' ).factory;
-var PI = require( '@stdlib/constants/float64/pi' );
+var SQRT_TWO_PI = require( '@stdlib/constants/float64/sqrt-two-pi' );
 
 
 // VARIABLES //
@@ -81,7 +80,7 @@ function pdf( x, a, b, mu, sigma ) {
 	if ( x < a || x > b ) {
 		return 0.0;
 	}
-	A = 1.0 / ( sigma * sqrt( 2.0 * PI ) );
+	A = 1.0 / ( sigma * SQRT_TWO_PI );
 	C = normalCDF( (b-mu)/sigma ) - normalCDF( (a-mu)/sigma );
 	return A * exp( -0.5 * abs2( ( x - mu ) / sigma ) ) / C;
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/lib/factory.js
@@ -60,7 +60,7 @@ function factory( mu, lambda ) {
 		return degenerate( mu );
 	}
 	A = sqrt( lambda / TWO_PI );
-	B = -lambda / ( 2.0 * mu * mu );
+	B = -0.5 * lambda;
 	return pdf;
 
 	/**
@@ -82,8 +82,8 @@ function factory( mu, lambda ) {
 		if ( x <= 0.0 || !isFinite( x ) ) {
 			return 0.0;
 		}
-		v = x - mu;
-		return A / ( x * sqrt( x ) ) * exp( B * v * v / x );
+		v = ( x - mu ) / mu;
+		return A / ( x * sqrt( x ) ) * exp( ( ( B / x ) * v ) * v );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/lib/main.js
@@ -109,9 +109,9 @@ function pdf( x, mu, lambda ) {
 		return 0.0;
 	}
 	A = sqrt( lambda / TWO_PI );
-	B = -lambda / ( 2.0 * mu * mu );
-	v = x - mu;
-	return A / ( x * sqrt( x ) ) * exp( B * v * v / x );
+	B = -0.5 * lambda;
+	v = ( x - mu ) / mu;
+	return A / ( x * sqrt( x ) ) * exp( ( ( B / x ) * v ) * v );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/src/main.c
@@ -56,7 +56,7 @@ double stdlib_base_dists_wald_pdf( const double x, const double mu, const double
 		return 0.0;
 	}
 	A = stdlib_base_sqrt( lambda / STDLIB_CONSTANT_FLOAT64_TWO_PI );
-	B = -lambda / ( 2.0 * mu * mu );
-	v = x - mu;
-	return A / ( x * stdlib_base_sqrt( x ) ) * stdlib_base_exp( B * v * v / x );
+	B = -0.5 * lambda;
+	v = ( x - mu ) / mu;
+	return A / ( x * stdlib_base_sqrt( x ) ) * stdlib_base_exp( ( ( B / x ) * v ) * v );
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request propagates a fix merged to `develop` between 2026-08-19 and 2026-08-20 to sibling packages exhibiting the same defect.

-   **Intermediate overflow in distribution functions** — `76d80cc4`

    Fixes the same defect Athan patched in 76d80cc4 for `stats/base/dists/wald/logpdf`: squaring an unnormalized deviate, or squaring the scale parameter in isolation, before combining quotients, so intermediate products overflow or underflow and the function returns `NaN` for inputs whose true double-precision result is representable. Applied the same normalize-before-square regrouping to `stats/base/dists/wald/pdf`, `stats/base/dists/normal/pdf`, `stats/base/dists/normal/logpdf`, `stats/base/dists/lognormal/pdf`, `stats/base/dists/lognormal/logpdf`, `stats/base/dists/truncated-normal/pdf`, and `stats/base/dists/halfnormal/logpdf`, across their `lib/main.js`, `lib/factory.js`, and (where present) `src/main.c` implementations. Confirmed failures included `wald/pdf( 1e-200, 1e-200, 1.0 )`, `normal/pdf( 1e200, 0.0, 1e200 )`, `lognormal/logpdf( 1.0, -1e200, 1e200 )`, and `halfnormal/logpdf( 1e200, 1e195 )`, all previously `NaN`; existing R and Julia fixture assertions pass unchanged, with ordinary-input results differing by no more than a few ULP.

    Target packages:

    -   `stats/base/dists/wald/pdf`
    -   `stats/base/dists/normal/pdf`
    -   `stats/base/dists/normal/logpdf`
    -   `stats/base/dists/lognormal/pdf`
    -   `stats/base/dists/lognormal/logpdf`
    -   `stats/base/dists/truncated-normal/pdf`
    -   `stats/base/dists/halfnormal/logpdf`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Candidate sites were located by searching `stats/base/dists/**/{lib/main.js,lib/factory.js,src/main.c}` for premature-squaring shapes. Each surviving site was reviewed by two independent validation passes (defect reproduced from concrete inputs against an independently derived reference value), an adaptation pass producing the per-site patch, and a style-consistency pass. Patched implementations were checked against the pre-patch implementations over a grid of ordinary inputs (maximum relative deviation 1.1e-13, occurring in a deep tail well inside the package's fixture tolerance), and the C implementations were compiled and compared against their JavaScript counterparts. All 20,275 assertions in the affected packages' test suites pass.

**Deliberately excluded.**

-   `stats/base/dists/wald/mgf` — same overflow class, but no regrouping analogous to the source fix repairs every failing input; the correct repair requires a branched or conjugate reformulation, which is a maintainer decision rather than a propagation.
-   `stats/base/dists/f/pdf` — regrouping the rational term removes the `NaN`, but the returned value remains wrong because the inaccuracy originates in `ibeta_derivative.js`, outside the target files.
-   `stats/base/dists/rayleigh/pdf` and `stats/base/dists/rayleigh/logpdf` — the defect is present, but every overflow-safe reordering shifts results beyond the 2-ULP (respectively 15-EPS) agreement those packages assert against their Julia fixtures, so landing the fix would require changing fixtures or tolerances.
-   `strided/base/map-by2` — the source commit `4e9f4337` corrected the public entry points, but four private implementation files (`lib/accessors.js`, `lib/map.js`, `lib/accessors.ndarray.js`, `lib/map.ndarray.js`) still carry the stale singular-input description. These are in the originating package rather than a sibling, so they are left for a follow-up.
-   `string/format` — a second pattern from `10dda530` (hyphenating "floating point" used as a compound adjective) applied cleanly to three lines of that README, but including it pulls the README into `Run changed examples`, which then fails on four pre-existing, unrelated example expectations. Rather than widen this PR, that change is dropped; the pre-existing errors are reported below.
-   Sites whose fix would cascade into test, fixture, or cross-package changes, and adaptive fixes that could not be confined to a single file.

**Unrelated pre-existing defects observed in `lib/node_modules/@stdlib/string/format/README.md`** (not addressed here; reported for a separate PR). Actual values verified against `string/format`:

| Line | Documented | Actual |
| ---- | ---------- | ------ |
| 124 | `'3.14159'` | `'3.14159 (shortest representation)'` |
| 177 | `'   2'` | `'    2'` |
| ~220 | `'a       b       '` | `'a          b         '` |
| ~223 | `'       a       b'` | `'         a          b'` |

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was produced by an automated Claude Code routine that reviews fixes merged to `develop` in the preceding 24 hours, searches for sibling packages exhibiting the same defect, and proposes the equivalent fix. Defect presence was confirmed at each site from concrete failing inputs, and every patch was verified against the package's existing fixtures before inclusion; sites requiring human judgment were dropped rather than patched. Opened as a draft for maintainer review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
