### PR TITLE
test: migrate `stats/base/dists/chi/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chi/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/stdev/test/test.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -61,8 +60,6 @@ tape( 'if provided a degrees of freedom parameter `k` that is not a nonnegative 
 
 tape( 'the function returns the standard deviation of a chi distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -71,13 +68,7 @@ tape( 'the function returns the standard deviation of a chi distribution', funct
 	k = data.k;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 50.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 64 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/stdev/test/test.native.js
@@ -22,10 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 
 
@@ -70,8 +69,6 @@ tape( 'if provided a degrees of freedom parameter `k` that is not a nonnegative 
 
 tape( 'the function returns the standard deviation of a chi distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -80,13 +77,7 @@ tape( 'the function returns the standard deviation of a chi distribution', opts,
 	k = data.k;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 50.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 64 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

This pull request:

-   migrates the tests for `@stdlib/stats/base/dists/chi/stdev` from relative-tolerance assertions to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per the guidance in #11352.
-   updates both `test/test.js` and `test/test.native.js` to mirror the idiom used in previously converted packages (e.g. `stats/base/dists/erlang/stdev`, `stats/base/dists/frechet/variance`).
-   replaces the previous `50.0 * EPS * abs( expected[ i ] )` tolerance loop with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 64 ), true, 'returns expected value' )`.
-   drops the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

The tightest ULP bound was determined empirically by measuring the maximum ULP difference over the full 1000-value Python fixture set:

-   `test/test.js`: **N = 64 ULP** (max observed ULP difference over the fixtures is exactly 64; the worst case is `k = 7.448033732206665`, where `stdev(k)` differs from the expected value by 64 ULP).
-   `test/test.native.js`: **N = 64 ULP** (same fixtures; native tests are skipped in this environment because the native add-on is not built, so the same bound is used for consistency with the JavaScript implementation).

The tests were run twice at the final `N = 64` (1005 assertions, all passing) to confirm the bound is deterministic.

## Related Issues

This pull request has the following related issues:

-   #11352

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored by Claude Code (Anthropic) running as an unattended scheduled task. The conversion mirrors the exact idiom used in previously merged ULP migrations authored by the PR author (e.g. #14439, #14434), and the ULP bound was measured empirically against the existing Python fixtures.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8VBSvpYMJorBDHUSXYPhT)_