### PR TITLE
test: migrate `math/base/special/sici` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sici/test/test.assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/sici/test/test.assign.js
@@ -21,12 +21,11 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var HALF_PI = require( '@stdlib/constants/float64/half-pi' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var Float64Array = require( '@stdlib/array/float64' );
 var sici = require( './../lib/assign.js' );
 
@@ -51,8 +50,6 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function computes the sine and cosine integrals for small positive numbers', function test( t ) {
-	var delta;
-	var tol;
 	var out;
 	var si;
 	var ci;
@@ -68,21 +65,13 @@ tape( 'the function computes the sine and cosine integrals for small positive nu
 		out = [ 0.0, 0.0 ];
 		v = sici( x[ i ], out, 1, 0 );
 		t.strictEqual( v, out, 'returns output array' );
-
-		delta = abs( v[ 0 ] - si[ i ] );
-		tol = 2.0 * EPS * abs( si[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. SI: ' + v[ 0 ] + '. Expected: ' + si[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-
-		delta = abs( v[ 1 ] - ci[ i ] );
-		tol = 2.0 * EPS * abs( ci[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. CI: ' + v[ 1 ] + '. Expected: ' + ci[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v[ 0 ], si[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( v[ 1 ], ci[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine integrals for medium positive numbers', function test( t ) {
-	var delta;
-	var tol;
 	var out;
 	var si;
 	var ci;
@@ -98,21 +87,13 @@ tape( 'the function computes the sine and cosine integrals for medium positive n
 		out = [ 0.0, 0.0 ];
 		v = sici( x[ i ], out, 1, 0 );
 		t.strictEqual( v, out, 'returns output array' );
-
-		delta = abs( v[ 0 ] - si[ i ] );
-		tol = 60.0 * EPS * abs( si[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. SI: ' + v[ 0 ] + '. Expected: ' + si[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-
-		delta = abs( v[ 1 ] - ci[ i ] );
-		tol = 60.0 * EPS * abs( ci[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. CI: ' + v[ 1 ] + '. Expected: ' + ci[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v[ 0 ], si[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( v[ 1 ], ci[ i ], 64 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine integrals for large positive numbers', function test( t ) {
-	var delta;
-	var tol;
 	var out;
 	var si;
 	var ci;
@@ -128,21 +109,13 @@ tape( 'the function computes the sine and cosine integrals for large positive nu
 		out = [ 0.0, 0.0 ];
 		v = sici( x[ i ], out, 1, 0 );
 		t.strictEqual( v, out, 'returns output array' );
-
-		delta = abs( v[ 0 ] - si[ i ] );
-		tol = 2.0 * EPS * abs( si[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. SI: ' + v[ 0 ] + '. Expected: ' + si[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-
-		delta = abs( v[ 1 ] - ci[ i ] );
-		tol = 2.0 * EPS * abs( ci[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. CI: ' + v[ 1 ] + '. Expected: ' + ci[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v[ 0 ], si[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( v[ 1 ], ci[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine integrals for small negative numbers', function test( t ) {
-	var delta;
-	var tol;
 	var out;
 	var si;
 	var ci;
@@ -158,21 +131,13 @@ tape( 'the function computes the sine and cosine integrals for small negative nu
 		out = [ 0.0, 0.0 ];
 		v = sici( x[ i ], out, 1, 0 );
 		t.strictEqual( v, out, 'returns output array' );
-
-		delta = abs( v[ 0 ] - si[ i ] );
-		tol = 2.0 * EPS * abs( si[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. SI: ' + v[ 0 ] + '. Expected: ' + si[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-
-		delta = abs( v[ 1 ] - ci[ i ] );
-		tol = 2.0 * EPS * abs( ci[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. CI: ' + v[ 1 ] + '. Expected: ' + ci[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v[ 0 ], si[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( v[ 1 ], ci[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine integrals for medium negative numbers', function test( t ) {
-	var delta;
-	var tol;
 	var out;
 	var si;
 	var ci;
@@ -188,21 +153,13 @@ tape( 'the function computes the sine and cosine integrals for medium negative n
 		out = [ 0.0, 0.0 ];
 		v = sici( x[ i ], out, 1, 0 );
 		t.strictEqual( v, out, 'returns output array' );
-
-		delta = abs( v[ 0 ] - si[ i ] );
-		tol = 60.0 * EPS * abs( si[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. SI: ' + v[ 0 ] + '. Expected: ' + si[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-
-		delta = abs( v[ 1 ] - ci[ i ] );
-		tol = 60.0 * EPS * abs( ci[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. CI: ' + v[ 1 ] + '. Expected: ' + ci[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v[ 0 ], si[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( v[ 1 ], ci[ i ], 64 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine integrals for large negative numbers', function test( t ) {
-	var delta;
-	var tol;
 	var out;
 	var si;
 	var ci;
@@ -218,21 +175,13 @@ tape( 'the function computes the sine and cosine integrals for large negative nu
 		out = [ 0.0, 0.0 ];
 		v = sici( x[ i ], out, 1, 0 );
 		t.strictEqual( v, out, 'returns output array' );
-
-		delta = abs( v[ 0 ] - si[ i ] );
-		tol = 2.0 * EPS * abs( si[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. SI: ' + v[ 0 ] + '. Expected: ' + si[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-
-		delta = abs( v[ 1 ] - ci[ i ] );
-		tol = 2.0 * EPS * abs( ci[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. CI: ' + v[ 1 ] + '. Expected: ' + ci[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v[ 0 ], si[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( v[ 1 ], ci[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine integrals for very large positive numbers', function test( t ) {
-	var delta;
-	var tol;
 	var out;
 	var si;
 	var ci;
@@ -248,14 +197,8 @@ tape( 'the function computes the sine and cosine integrals for very large positi
 		out = [ 0.0, 0.0 ];
 		v = sici( x[ i ], out, 1, 0 );
 		t.strictEqual( v, out, 'returns output array' );
-
-		delta = abs( v[ 0 ] - si[ i ] );
-		tol = 2.0 * EPS * abs( si[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. SI: ' + v[ 0 ] + '. Expected: ' + si[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-
-		delta = abs( v[ 1 ] - ci[ i ] );
-		tol = 2.0 * EPS * abs( ci[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. CI: ' + v[ 1 ] + '. Expected: ' + ci[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v[ 0 ], si[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( v[ 1 ], ci[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/sici/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/base/special/sici/test/test.main.js
@@ -21,13 +21,12 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isArray = require( '@stdlib/assert/is-array' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var HALF_PI = require( '@stdlib/constants/float64/half-pi' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var sici = require( './../lib/main.js' );
 
 
@@ -51,8 +50,6 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function computes the sine and cosine integrals for small positive numbers', function test( t ) {
-	var delta;
-	var tol;
 	var si;
 	var ci;
 	var x;
@@ -65,21 +62,13 @@ tape( 'the function computes the sine and cosine integrals for small positive nu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = sici( x[ i ] );
-
-		delta = abs( v[ 0 ] - si[ i ] );
-		tol = 2.0 * EPS * abs( si[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. SI: ' + v[ 0 ] + '. Expected: ' + si[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-
-		delta = abs( v[ 1 ] - ci[ i ] );
-		tol = 2.0 * EPS * abs( ci[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. CI: ' + v[ 1 ] + '. Expected: ' + ci[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v[ 0 ], si[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( v[ 1 ], ci[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine integrals for medium positive numbers', function test( t ) {
-	var delta;
-	var tol;
 	var si;
 	var ci;
 	var x;
@@ -92,21 +81,13 @@ tape( 'the function computes the sine and cosine integrals for medium positive n
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = sici( x[ i ] );
-
-		delta = abs( v[ 0 ] - si[ i ] );
-		tol = 60.0 * EPS * abs( si[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. SI: ' + v[ 0 ] + '. Expected: ' + si[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-
-		delta = abs( v[ 1 ] - ci[ i ] );
-		tol = 60.0 * EPS * abs( ci[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. CI: ' + v[ 1 ] + '. Expected: ' + ci[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v[ 0 ], si[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( v[ 1 ], ci[ i ], 64 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine integrals for large positive numbers', function test( t ) {
-	var delta;
-	var tol;
 	var si;
 	var ci;
 	var x;
@@ -119,21 +100,13 @@ tape( 'the function computes the sine and cosine integrals for large positive nu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = sici( x[ i ] );
-
-		delta = abs( v[ 0 ] - si[ i ] );
-		tol = 2.0 * EPS * abs( si[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. SI: ' + v[ 0 ] + '. Expected: ' + si[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-
-		delta = abs( v[ 1 ] - ci[ i ] );
-		tol = 2.0 * EPS * abs( ci[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. CI: ' + v[ 1 ] + '. Expected: ' + ci[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v[ 0 ], si[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( v[ 1 ], ci[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine integrals for small negative numbers', function test( t ) {
-	var delta;
-	var tol;
 	var si;
 	var ci;
 	var x;
@@ -146,21 +119,13 @@ tape( 'the function computes the sine and cosine integrals for small negative nu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = sici( x[ i ] );
-
-		delta = abs( v[ 0 ] - si[ i ] );
-		tol = 2.0 * EPS * abs( si[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. SI: ' + v[ 0 ] + '. Expected: ' + si[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-
-		delta = abs( v[ 1 ] - ci[ i ] );
-		tol = 2.0 * EPS * abs( ci[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. CI: ' + v[ 1 ] + '. Expected: ' + ci[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v[ 0 ], si[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( v[ 1 ], ci[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine integrals for medium negative numbers', function test( t ) {
-	var delta;
-	var tol;
 	var si;
 	var ci;
 	var x;
@@ -173,21 +138,13 @@ tape( 'the function computes the sine and cosine integrals for medium negative n
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = sici( x[ i ] );
-
-		delta = abs( v[ 0 ] - si[ i ] );
-		tol = 60.0 * EPS * abs( si[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. SI: ' + v[ 0 ] + '. Expected: ' + si[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-
-		delta = abs( v[ 1 ] - ci[ i ] );
-		tol = 60.0 * EPS * abs( ci[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. CI: ' + v[ 1 ] + '. Expected: ' + ci[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v[ 0 ], si[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( v[ 1 ], ci[ i ], 64 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine integrals for large negative numbers', function test( t ) {
-	var delta;
-	var tol;
 	var si;
 	var ci;
 	var x;
@@ -200,21 +157,13 @@ tape( 'the function computes the sine and cosine integrals for large negative nu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = sici( x[ i ] );
-
-		delta = abs( v[ 0 ] - si[ i ] );
-		tol = 2.0 * EPS * abs( si[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. SI: ' + v[ 0 ] + '. Expected: ' + si[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-
-		delta = abs( v[ 1 ] - ci[ i ] );
-		tol = 2.0 * EPS * abs( ci[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. CI: ' + v[ 1 ] + '. Expected: ' + ci[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v[ 0 ], si[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( v[ 1 ], ci[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine integrals for very large positive numbers', function test( t ) {
-	var delta;
-	var tol;
 	var si;
 	var ci;
 	var x;
@@ -227,14 +176,8 @@ tape( 'the function computes the sine and cosine integrals for very large positi
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = sici( x[ i ] );
-
-		delta = abs( v[ 0 ] - si[ i ] );
-		tol = 2.0 * EPS * abs( si[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. SI: ' + v[ 0 ] + '. Expected: ' + si[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-
-		delta = abs( v[ 1 ] - ci[ i ] );
-		tol = 2.0 * EPS * abs( ci[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. CI: ' + v[ 1 ] + '. Expected: ' + ci[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v[ 0 ], si[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( v[ 1 ], ci[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/sici` from relative-tolerance assertions (`abs( delta ) <= tol`, with `tol = k * EPS * abs( expected )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the same migration to both `test/test.main.js` and `test/test.assign.js`.
-   preserves all existing test cases, structure, and non-tolerance assertions (e.g., special-case values for `0`, `+Infinity`, `-Infinity`, and `NaN`).

The minimum ULP bounds used per fixture block (identical for `test.main.js` and `test.assign.js`) are:

| Fixture block    | `si` (SI) | `ci` (CI) |
| ---------------- | :-------: | :-------: |
| small positive   | 0         | 2         |
| medium positive  | 0         | 64        |
| large positive   | 1         | 2         |
| small negative   | 0         | 2         |
| medium negative  | 0         | 64        |
| large negative   | 1         | 2         |
| very large       | 0         | 2         |

Each ULP value is the minimum integer `N` such that `isAlmostSameValue( actual, expected, N )` holds for every fixture entry in that block. Tests were run twice at the final `N` to confirm deterministic passing.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code: the assistant mechanically converted the tolerance-based assertions to `isAlmostSameValue`, agentically searched for the minimum ULP bound per fixture block, verified determinism across two full runs, and ran the local lint and test suites before submitting.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVZuDdZhGo2obXqUGgxEKG)_