### PR TITLE
docs: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/logcdf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/logcdf/docs/types/index.d.ts
@@ -22,7 +22,7 @@
 * Evaluates the natural logarithm of the cumulative distribution function (CDF) for a logistic distribution.
 *
 * @param x - input value
-* @returns evaluated logarithm of CDF
+* @returns evaluated logCDF
 */
 type Unary = ( x: number ) => number;
 

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/logcdf/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/logcdf/lib/index.js
@@ -31,7 +31,7 @@
 *
 * var mylogcdf = logcdf.factory( 3.0, 1.5 );
 *
-* var y = mylogcdf( 1.0 );
+* y = mylogcdf( 1.0 );
 * // returns ~-1.567
 */
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request corrects two JSDoc-only inconsistencies in `stats/base/dists/logistic/logcdf` surfaced by a majority-vote drift sweep against the 14 sibling packages in the `stats/base/dists/logistic` namespace.

### `stats/base/dists/logistic/logcdf`

- `lib/index.js`: drop the redundant second `var y` in the `@module` `@example`. `y` is already declared four lines above; all five sibling factory-bearing packages (`cdf`, `pdf`, `logpdf`, `mgf`, `quantile`) reuse the identifier on the second call (5/5 conformance among factory-bearing siblings).
- `docs/types/index.d.ts`: change the `Unary` type's `@returns evaluated logarithm of CDF` to `@returns evaluated logCDF`, matching the wording already used at lines 43 and 92 of the same file and the `evaluated <ABBREV>` convention shared by every sibling type-def (5/5 sibling type-defs). Conformance in the namespace as a whole: 14/15.

No runtime, signature, test-expected, or public-API behavior changes; both edits sit inside JSDoc comment blocks.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Opened as a draft for maintainer review.

Deliberately excluded from this run:

- `logcdf/LICENSE` — flagged as a stray file (unique across the 15 siblings), but rejected on second review: the file documents third-party attribution for `logcdf/lib/log1pexp.js`, which is adapted from [StatsFuns.jl](https://github.com/JuliaStats/StatsFuns.jl) (Copyright © 2015 Dahua Lin, MIT). Per-package `LICENSE` files ship across ~184 stdlib packages under this convention; the other 14 `logistic` siblings simply have no third-party derivation to attribute.
- `ctor` — legitimately lacks C/native/manifest/factory (it is the distribution class, structurally distinct from the moment and function packages).
- Moment-package prologues using `s <= 0.0` vs function-package prologues using `s < 0.0` — mathematically driven (whether the function is defined at `s = 0`), not drift.
- `stdev`/`variance` `@returns {PositiveNumber}` — correct; both are strictly positive.
- `stdev` shipping Python test fixtures instead of Julia — converting would cascade into rewriting test data and `test.js`, which the drift routine excludes as out of scope.
- Various per-package unique filenames (`entropy.h`, `mean.h`, `test.pdf.js`, per-package equation SVGs) — normal per-package variation.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself."

This PR was produced by an automated Claude Code routine that picks a random stdlib namespace, extracts structural and semantic features from every package in it, identifies the majority pattern per feature, and drafts corrections for packages that deviate without semantic justification. Every candidate correction was passed through three independent validation agents (semantic review, cross-reference, structural review); items marked `intentional-deviation` or `needs-human` by any agent were dropped and are listed in the "Other" section above. Opened as a draft for maintainer review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_015LtTEuYk8BFyudmQBggT8K)_