### PR TITLE
test: migrate `math/base/special/logitf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/logitf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/logitf/test/test.js
@@ -24,8 +24,8 @@ var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var logitf = require( './../lib' );
 
 
@@ -72,69 +72,51 @@ tape( 'the function returns `+Infinity` when provided `1`', function test( t ) {
 
 tape( 'the function evaluates the logit of `x` for the interval `(0,0.25]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = small.expected;
 	x = small.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logitf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		e = float64ToFloat32( expected[i] );
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logit of `x` for the interval `[0.25,0.75]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = medium.expected;
 	x = medium.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logitf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		e = float64ToFloat32( expected[i] );
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logit of `x` for the interval `[0.75,1)`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = large.expected;
 	x = large.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logitf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		e = float64ToFloat32( expected[i] );
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/logitf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/logitf/test/test.native.js
@@ -25,8 +25,8 @@ var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -81,69 +81,51 @@ tape( 'the function returns `+Infinity` when provided `1`', opts, function test(
 
 tape( 'the function evaluates the logit of `x` for the interval `(0,0.25]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = small.expected;
 	x = small.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logitf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		e = float64ToFloat32( expected[i] );
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logit of `x` for the interval `[0.25,0.75]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = medium.expected;
 	x = medium.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logitf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		e = float64ToFloat32( expected[i] );
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logit of `x` for the interval `[0.75,1)`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = large.expected;
 	x = large.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logitf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		e = float64ToFloat32( expected[i] );
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/logitf` from relative-tolerance assertions (`delta = absf( y - expected[i] )`, `tol = EPS * absf( expected[i] )`, `t.ok( delta <= tol, ... )`) to ULP-difference assertions using `@stdlib/number/float32/base/assert/is-almost-same-value`.
-   applies the same migration to both `test/test.js` and `test/test.native.js`.
-   preserves all existing test cases, structure, and non-tolerance assertions (e.g., special-case values for `NaN`, values outside `[0,1]`, `0`, and `1`).

Expected values are converted to single-precision via `@stdlib/number/float64/base/to-float32` before comparison, consistent with other migrated single-precision packages (e.g., `math/base/special/xlogyf`, `math/base/special/log10f`, `math/base/special/rad2degf`).

The minimum ULP bounds used per fixture block (identical for `test.js` and `test.native.js`) are:

| Fixture block            | ULP |
| ------------------------ | :-: |
| `small` (`(0,0.25]`)     | 1   |
| `medium` (`[0.25,0.75]`) | 1   |
| `large` (`[0.75,1)`)     | 1   |

Each ULP value is the minimum integer `N` such that `isAlmostSameValuef( actual, expected, N )` holds for every fixture entry in that block; the measured maximum ULP difference is `1` for all three blocks (500 fixture values each), and `N = 0` fails (113 cases). The JavaScript and C implementations produce identical results across the full fixture set, so both test files use the same bounds. Tests were run twice at the final `N` (1507 assertions passing per file, native addon built locally so `test.native.js` was exercised rather than skipped) to confirm deterministic passing.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code: the assistant mechanically converted the tolerance-based assertions to `isAlmostSameValuef`, agentically searched for the minimum ULP bound per fixture block, verified determinism across two full runs, and ran the local lint and test suites before submitting.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfR1znfsAw4Hag2bE6tDjm)_