### PR TITLE
test: migrate `math/base/special/fast/atanh` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fast/atanh/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/atanh/test/test.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -48,8 +48,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the hyperbolic arctangent (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -59,21 +57,13 @@ tape( 'the function computes the hyperbolic arctangent (negative values)', funct
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 500.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+' Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 468 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arctangent (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -83,13 +73,7 @@ tape( 'the function computes the hyperbolic arctangent (positive values)', funct
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 650.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+' Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 655 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/fast/atanh/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/atanh/test/test.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -57,8 +57,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the hyperbolic arctangent (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -68,21 +66,13 @@ tape( 'the function computes the hyperbolic arctangent (negative values)', opts,
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 500.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+' Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 468 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arctangent (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -92,13 +82,7 @@ tape( 'the function computes the hyperbolic arctangent (positive values)', opts,
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 650.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+' Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 655 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/fast/atanh` from relative tolerance testing (`delta <= EPS * abs( expected )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].

Changes are confined to `test/test.js` and `test/test.native.js`. No source, documentation, benchmark, or fixture files were touched, and no test cases were added, removed, or reordered.

The measured minimum ULP bounds (the maximum observed ULP difference across the full fixture set, i.e. the smallest integer for which every case passes) are:

| Test case | Previous tolerance | ULP bound | Fixture size |
| --------- | ------------------ | --------- | ------------ |
| negative values (`fixtures/julia/negative.json`) | `500.0 * EPS * abs( expected )` | `468` | 2003 |
| positive values (`fixtures/julia/positive.json`) | `650.0 * EPS * abs( expected )` | `655` | 2003 |

Each bound was tightened to the minimum: `468` and `655` pass for every fixture value, while `467` and `654` do not.

The same bounds apply to both `test.js` and `test.native.js`. The native add-on was built locally, and the C implementation was verified to produce bit-identical results to the JavaScript implementation across both fixture files (max ULP difference of `468` and `655`, respectively), so no JS/C divergence adjustment was required.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed:

-   `make test TESTS_FILTER=".*/math/base/special/fast/atanh/.*"` — 6015 passing / 0 failing in `test.js` and 6015 passing / 0 failing in `test.native.js`. The suite was run twice at the final ULP values with identical results (no FMA/architecture-dependent variation observed).
-   ESLint with `etc/eslint/.eslintrc.tests.js` — clean for both changed files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. It studied the migration guidance in #11352 and the already-migrated sibling packages (`math/base/special/fast/asinh`, `math/base/special/fast/acosh`) to mirror the established idiom, measured the ULP bounds empirically against the fixtures, and ran the test suite and linter locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value


---
_Generated by [Claude Code](https://claude.ai/code/session_01CtsVG1PwNF7Rdg1zo4amRT)_