### PR TITLE
test: migrate `stats/base/dists/weibull/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/stdev/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -97,8 +96,6 @@ tape( 'if provided `lambda <= 0`, the function returns `NaN`', function test( t 
 tape( 'the function returns the standard deviation of a Weibull distribution', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -108,13 +105,7 @@ tape( 'the function returns the standard deviation of a Weibull distribution', f
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 170.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 277 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/stdev/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -106,8 +105,6 @@ tape( 'if provided `lambda <= 0`, the function returns `NaN`', opts, function te
 tape( 'the function returns the standard deviation of a Weibull distribution', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -117,13 +114,7 @@ tape( 'the function returns the standard deviation of a Weibull distribution', o
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 180.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 277 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `@stdlib/stats/base/dists/weibull/stdev` from relative-tolerance assertions to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per the guidance in #11352.
-   updates both `test/test.js` and `test/test.native.js` to mirror the idiom used in previously converted packages (e.g. `stats/base/dists/chi/stdev`, `stats/base/dists/erlang/stdev`, `stats/base/dists/frechet/variance`).
-   replaces the previous `170.0 * EPS * abs( expected[ i ] )` (`test/test.js`) and `180.0 * EPS * abs( expected[ i ] )` (`test/test.native.js`) tolerance loops with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 277 ), true, 'returns expected value' )`.
-   drops the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

The tightest ULP bound was determined empirically by measuring the maximum ULP difference over the full 500-value Julia fixture set:

-   `test/test.js`: **N = 277 ULP**. The measured maximum ULP difference over the fixtures is exactly 277; the worst case is `k = 10.905349225171449, lambda = 1.9805794474478602`, where `stdev( k, lambda )` returns `0.2095944993595373` against an expected value of `0.20959449935952962`. Lowering the bound to `276` fails that fixture, so `277` is the minimum passing integer.
-   `test/test.native.js`: **N = 277 ULP**. The native add-on was built locally for this package, and the maximum ULP difference for the C implementation over the same fixtures is likewise exactly 277, so the bound matches the JavaScript implementation.

Both `test/test.js` and `test/test.native.js` were run twice at the final `N = 277` (514 assertions each, all passing, with the native add-on built so the native tests were not skipped) to confirm the bound is deterministic.

Only the two test files are changed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code (Anthropic) running as an unattended scheduled task. The conversion mirrors the exact idiom used in previously merged ULP migrations authored by the PR author (e.g. #14447, #14457), and the ULP bound was measured empirically against the existing Julia fixtures and confirmed tight (276 fails, 277 passes) for both the JavaScript and the locally built C implementation.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdZNmofYMomVkRxLrMz15U)_