### PR TITLE
test: migrate `stats/base/dists/normal/mean` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mean/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mean = require( './../lib' );
 
 
@@ -76,9 +75,7 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', function 
 
 tape( 'the function returns the expected value of a normal distribution', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -89,13 +86,7 @@ tape( 'the function returns the expected value of a normal distribution', functi
 	for ( i = 0; i < mu.length; i++ ) {
 		y = mean( mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mean/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -85,9 +84,7 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', opts, fun
 
 tape( 'the function returns the expected value of a normal distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -98,13 +95,7 @@ tape( 'the function returns the expected value of a normal distribution', opts, 
 	for ( i = 0; i < mu.length; i++ ) {
 		y = mean( mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `@stdlib/stats/base/dists/normal/mean` from relative-tolerance assertions to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per the guidance in #11352.
-   updates both `test/test.js` and `test/test.native.js` to mirror the idiom used in previously converted packages (e.g. `stats/base/dists/frechet/variance`, `stats/base/dists/chi/stdev`, `stats/base/dists/weibull/stdev`), retaining the existing `expected[i] !== null` fixture guard.
-   replaces the previous `1.0 * EPS * abs( expected[ i ] )` tolerance loops in both files with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' )`.
-   drops the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

The tightest ULP bound was determined empirically by measuring the maximum ULP difference over the full 100-value Julia fixture set:

-   `test/test.js`: **N = 0 ULP**. Every fixture value matches the Julia reference bit-for-bit, so the measured maximum ULP difference is 0, and 0 is the tightest bound expressible.
-   `test/test.native.js`: **N = 0 ULP**. The native add-on was built locally for this package so that the native tests were exercised rather than skipped, and the maximum ULP difference for the C implementation over the same fixtures is likewise 0.

This is expected: both implementations return `mu` verbatim once the `NaN`/nonpositive-`sigma` guards are cleared, so no rounding is introduced and the previous tolerance branch was never taken.

Both `test/test.js` and `test/test.native.js` were run twice at the final `N = 0` (110 assertions each, all passing, with the native add-on built) to confirm the bound is deterministic. Linting via `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/normal/mean/.*"` is clean, and only the two test files are changed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code (Anthropic) running as an unattended scheduled task. The conversion mirrors the exact idiom used in previously merged ULP migrations authored by the PR author (e.g. #14434, #14447, #14469), and the ULP bound was measured empirically against the existing Julia fixtures for both the JavaScript and the locally built C implementation.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdAJag3FcyWDxmtEbqudvF)_