### PR TITLE
feat!: add `fromIndex` support to `blas/ext/base/ndarray/dlast-index-of-falsy`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/README.md
@@ -42,25 +42,38 @@ Returns the index of the last falsy element in a one-dimensional double-precisio
 
 ```javascript
 var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 
 var x = new Float64Vector( [ 1.0, 0.0, 3.0, 0.0 ] );
 
-var idx = dlastIndexOfFalsy( [ x ] );
+var fromIndex = scalar2ndarray( 3, {
+    'dtype': 'generic'
+});
+
+var idx = dlastIndexOfFalsy( [ x, fromIndex ] );
 // returns 3
 ```
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing a one-dimensional input ndarray.
+-   **arrays**: array-like object containing the following ndarrays:
+
+    -   a one-dimensional input ndarray.
+    -   a zero-dimensional ndarray containing the index from which to begin searching.
 
 If the function is unable to find a falsy element, the function returns `-1`.
 
 ```javascript
 var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 
 var x = new Float64Vector( [ 1.0, 2.0, 3.0, 4.0 ] );
 
-var idx = dlastIndexOfFalsy( [ x ] );
+var fromIndex = scalar2ndarray( 3, {
+    'dtype': 'generic'
+});
+
+var idx = dlastIndexOfFalsy( [ x, fromIndex ] );
 // returns -1
 ```
 
@@ -73,6 +86,7 @@ var idx = dlastIndexOfFalsy( [ x ] );
 ## Notes
 
 -   The function treats `NaN` values as falsy.
+-   If a specified starting search index is negative, the function resolves the starting search index by counting backward from the last element (where `-1` refers to the last element).
 
 </section>
 
@@ -86,6 +100,7 @@ var idx = dlastIndexOfFalsy( [ x ] );
 
 ```javascript
 var bernoulli = require( '@stdlib/random/bernoulli' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var dlastIndexOfFalsy = require( '@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy' );
 
@@ -96,7 +111,11 @@ var opts = {
 var x = bernoulli( [ 10 ], 0.7, opts );
 console.log( ndarray2array( x ) );
 
-var idx = dlastIndexOfFalsy( [ x ] );
+var fromIndex = scalar2ndarray( 9, {
+    'dtype': 'generic'
+});
+
+var idx = dlastIndexOfFalsy( [ x, fromIndex ] );
 console.log( idx );
 ```
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var ones = require( '@stdlib/ndarray/ones' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
@@ -46,7 +47,13 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = ones( [ len ], options );
+	var fromIndex;
+	var x;
+
+	x = ones( [ len ], options );
+	fromIndex = scalar2ndarray( len - 1, {
+		'dtype': 'generic'
+	});
 	return benchmark;
 
 	/**
@@ -61,7 +68,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			out = dlastIndexOfFalsy( [ x ] );
+			out = dlastIndexOfFalsy( [ x, fromIndex ] );
 			if ( out !== out ) {
 				b.fail( 'should return an integer' );
 			}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/docs/repl.txt
@@ -3,6 +3,10 @@
     Returns the index of the last falsy element in a one-dimensional double-
     precision floating-point ndarray.
 
+    If a specified starting search index is negative, the function resolves the
+    starting search index by counting backward from the last element (where `-1`
+    refers to the last element).
+
     If unable to find a falsy element, the function returns `-1`.
 
     Parameters
@@ -11,6 +15,8 @@
         Array-like object containing the following ndarrays:
 
         - a one-dimensional input ndarray.
+        - a zero-dimensional ndarray containing the index from which to begin
+        searching.
 
     Returns
     -------
@@ -20,7 +26,8 @@
     Examples
     --------
     > var x = new {{alias:@stdlib/ndarray/vector/float64}}( [ 1.0, 0.0, 0.0 ] );
-    > {{alias}}( [ x ] )
+    > var i = {{alias:@stdlib/ndarray/from-scalar}}( 2, { 'dtype': 'generic' } );
+    > {{alias}}( [ x, i ] )
     2
 
     See Also

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { float64ndarray } from '@stdlib/types/ndarray';
+import { float64ndarray, typedndarray } from '@stdlib/types/ndarray';
 
 /**
 * Returns the index of the last falsy element in a one-dimensional double-precision floating-point ndarray.
@@ -30,19 +30,25 @@ import { float64ndarray } from '@stdlib/types/ndarray';
 * -   The function expects the following ndarrays:
 *
 *     -   a one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * @param arrays - array-like object containing ndarrays
 * @returns index
 *
 * @example
 * var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 *
 * var x = new Float64Vector( [ 1.0, 0.0, 3.0, 0.0 ] );
 *
-* var v = dlastIndexOfFalsy( [ x ] );
+* var fromIndex = scalar2ndarray( 3, {
+*     'dtype': 'generic'
+* });
+*
+* var v = dlastIndexOfFalsy( [ x, fromIndex ] );
 * // returns 3
 */
-declare function dlastIndexOfFalsy( arrays: [ float64ndarray ] ): number;
+declare function dlastIndexOfFalsy( arrays: [ float64ndarray, typedndarray<number> ] ): number;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/docs/types/test.ts
@@ -19,6 +19,7 @@
 /* eslint-disable space-in-parens */
 
 import zeros = require( '@stdlib/ndarray/zeros' );
+import scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 import dlastIndexOfFalsy = require( './index' );
 
 
@@ -29,8 +30,11 @@ import dlastIndexOfFalsy = require( './index' );
 	const x = zeros( [ 10 ], {
 		'dtype': 'float64'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	dlastIndexOfFalsy( [ x ] ); // $ExpectType number
+	dlastIndexOfFalsy( [ x, fromIndex ] ); // $ExpectType number
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
@@ -51,7 +55,10 @@ import dlastIndexOfFalsy = require( './index' );
 	const x = zeros( [ 10 ], {
 		'dtype': 'float64'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	dlastIndexOfFalsy(); // $ExpectError
-	dlastIndexOfFalsy( [ x ], {} ); // $ExpectError
+	dlastIndexOfFalsy( [ x, fromIndex ], {} ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var bernoulli = require( '@stdlib/random/bernoulli' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var dlastIndexOfFalsy = require( './../lib' );
 
@@ -29,5 +30,9 @@ var opts = {
 var x = bernoulli( [ 10 ], 0.7, opts );
 console.log( ndarray2array( x ) );
 
-var idx = dlastIndexOfFalsy( [ x ] );
+var fromIndex = scalar2ndarray( 9, {
+	'dtype': 'generic'
+});
+
+var idx = dlastIndexOfFalsy( [ x, fromIndex ] );
 console.log( idx );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/lib/index.js
@@ -25,11 +25,16 @@
 *
 * @example
 * var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var dlastIndexOfFalsy = require( '@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy' );
 *
 * var x = new Float64Vector( [ 1.0, 0.0, 3.0, 0.0 ] );
 *
-* var v = dlastIndexOfFalsy( [ x ] );
+* var fromIndex = scalar2ndarray( 3, {
+*     'dtype': 'generic'
+* });
+*
+* var v = dlastIndexOfFalsy( [ x, fromIndex ] );
 * // returns 3
 */
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/lib/main.js
@@ -20,10 +20,12 @@
 
 // MODULES //
 
+var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
 var getStride = require( '@stdlib/ndarray/base/stride' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
+var clipIndex = require( '@stdlib/ndarray/base/clip-index' );
 var strided = require( '@stdlib/blas/ext/base/dlast-index-of-falsy' ).ndarray;
 
 
@@ -37,21 +39,38 @@ var strided = require( '@stdlib/blas/ext/base/dlast-index-of-falsy' ).ndarray;
 * -   The function expects the following ndarrays:
 *
 *     -   a one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
 * @returns {integer} index
 *
 * @example
 * var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 *
 * var x = new Float64Vector( [ 1.0, 0.0, 3.0, 0.0 ] );
 *
-* var v = dlastIndexOfFalsy( [ x ] );
+* var fromIndex = scalar2ndarray( 3, {
+*     'dtype': 'generic'
+* });
+*
+* var v = dlastIndexOfFalsy( [ x, fromIndex ] );
 * // returns 3
 */
 function dlastIndexOfFalsy( arrays ) {
-	var x = arrays[ 0 ];
-	return strided( numelDimension( x, 0 ), getData( x ), getStride( x, 0 ), getOffset( x ) );
+	var fromIndex;
+	var N;
+	var x;
+
+	x = arrays[ 0 ];
+	fromIndex = ndarraylike2scalar( arrays[ 1 ] );
+
+	N = numelDimension( x, 0 );
+	fromIndex = clipIndex( fromIndex, N );
+	if ( fromIndex >= N ) {
+		fromIndex = N - 1;
+	}
+	return strided( fromIndex+1, getData( x ), getStride( x, 0 ), getOffset( x ) );
 }
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlast-index-of-falsy/test/test.js
@@ -22,6 +22,7 @@
 
 var tape = require( 'tape' );
 var Float64Array = require( '@stdlib/array/float64' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
 var dlastIndexOfFalsy = require( './../lib' );
 
@@ -52,53 +53,194 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function returns the index of the last falsy element', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
 	x = vector( new Float64Array( [ 1.0, 1.0, 0.0, 2.0, 0.0, 1.0 ] ), 6, 1, 0 );
+	fromIndex = scalar2ndarray( 5, {
+		'dtype': 'generic'
+	});
 
-	actual = dlastIndexOfFalsy( [ x ] );
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, 4, 'returns expected value' );
 
 	x = vector( new Float64Array( [ 1.0, 1.0, 0.0, 2.0, 0.0, 1.0 ] ), 4, 1, 2 );
+	fromIndex = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
-	actual = dlastIndexOfFalsy( [ x ] );
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, 2, 'returns expected value' );
 
 	x = vector( new Float64Array( [ 1.0, 1.0, 0.0, 2.0, 0.0, 1.0 ] ), 3, 2, 0 );
+	fromIndex = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
 
-	actual = dlastIndexOfFalsy( [ x ] );
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, 2, 'returns expected value' );
 
 	// Negative stride...
 	x = vector( new Float64Array( [ 1.0, 1.0, 0.0, 2.0, 0.0, 1.0 ] ), 6, -1, 5 );
+	fromIndex = scalar2ndarray( 5, {
+		'dtype': 'generic'
+	});
 
-	actual = dlastIndexOfFalsy( [ x ] );
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, 3, 'returns expected value' );
 
 	t.end();
 });
 
+tape( 'the function supports a `fromIndex` parameter (nonnegative)', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+
+	x = vector( new Float64Array( [ 0.0, 1.0, 0.0, 1.0, 0.0, 1.0 ] ), 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( 5, {
+		'dtype': 'generic'
+	});
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 4, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 4, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 2, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a `fromIndex` parameter (negative)', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+
+	x = vector( new Float64Array( [ 1.0, 0.0, 1.0, 0.0, 1.0, 0.0 ] ), 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( -1, {
+		'dtype': 'generic'
+	});
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -2, {
+		'dtype': 'generic'
+	});
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -3, {
+		'dtype': 'generic'
+	});
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -7, {
+		'dtype': 'generic'
+	});
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, -1, 'returns expected value' );
+
+	x = vector( new Float64Array( [ 0.0, 1.0, 0.0, 1.0, 0.0, 1.0 ] ), 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( -6, {
+		'dtype': 'generic'
+	});
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 0, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -7, {
+		'dtype': 'generic'
+	});
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 0, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function treats `NaN` values as falsy', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
 	x = vector( new Float64Array( [ 3.0, 0.0, NaN, 5.0 ] ), 4, 1, 0 );
+	fromIndex = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
-	actual = dlastIndexOfFalsy( [ x ] );
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, 2, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `-1` if unable to find a falsy element', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
 	x = vector( new Float64Array( [ 1.0, 2.0, 3.0, 4.0 ] ), 4, 1, 0 );
+	fromIndex = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
-	actual = dlastIndexOfFalsy( [ x ] );
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `-1` if provided an empty one-dimensional ndarray', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+
+	x = vector( new Float64Array( [] ), 0, 1, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, -1, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function clamps a starting search index which is greater than or equal to number of elements in the input ndarray', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+
+	x = vector( new Float64Array( [ 0.0, 1.0, 0.0, 1.0, 0.0, 1.0 ] ), 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( 6, {
+		'dtype': 'generic'
+	});
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 4, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 7, {
+		'dtype': 'generic'
+	});
+	actual = dlastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 4, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1180.

## Description

> What is the purpose of this pull request?

This pull request:

-   add `fromIndex` support to `blas/ext/base/ndarray/dlast-index-of-falsy`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1180.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Primarily written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
