### PR TITLE
feat!: add `fromIndex` support to `blas/ext/base/ndarray/gfind-index`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/README.md
@@ -41,6 +41,7 @@ var gfindIndex = require( '@stdlib/blas/ext/base/ndarray/gfind-index' );
 Returns the index of the first element in a one-dimensional ndarray which passes a test implemented by a predicate function.
 
 ```javascript
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var vector = require( '@stdlib/ndarray/vector/ctor' );
 
 function isEven( v ) {
@@ -49,13 +50,18 @@ function isEven( v ) {
 
 var x = vector( [ 1.0, 3.0, 4.0, 2.0 ], 'generic' );
 
-var idx = gfindIndex( [ x ], isEven );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var idx = gfindIndex( [ x, fromIndex ], isEven );
 // returns 2
 ```
 
 If no element passes a test implemented by a predicate function, the function returns `-1`.
 
 ```javascript
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var vector = require( '@stdlib/ndarray/vector/ctor' );
 
 function isEven( v ) {
@@ -64,13 +70,21 @@ function isEven( v ) {
 
 var x = vector( [ 1.0, 3.0, 5.0, 7.0 ], 'generic' );
 
-var idx = gfindIndex( [ x ], isEven );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var idx = gfindIndex( [ x, fromIndex ], isEven );
 // returns -1
 ```
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing a one-dimensional input ndarray.
+-   **arrays**: array-like object containing the following ndarrays:
+
+    -   a one-dimensional input ndarray.
+    -   a zero-dimensional ndarray containing the index from which to begin searching.
+
 -   **clbk**: callback function.
 -   **thisArg**: callback execution context (_optional_).
 
@@ -83,6 +97,7 @@ The callback function is provided the following arguments:
 To set the callback execution context, provide a `thisArg`.
 
 ```javascript
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var vector = require( '@stdlib/ndarray/vector/ctor' );
 
 function isEven( v ) {
@@ -95,7 +110,11 @@ var ctx = {
     'count': 0
 };
 
-var v = gfindIndex( [ x ], isEven, ctx );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var v = gfindIndex( [ x, fromIndex ], isEven, ctx );
 // returns 2
 
 var count = ctx.count;
@@ -111,6 +130,7 @@ var count = ctx.count;
 ## Notes
 
 -   If provided an empty one-dimensional ndarray, the function returns `-1`.
+-   If a specified starting search index is negative, the function resolves the starting search index by counting backward from the last element (where `-1` refers to the last element).
 
 </section>
 
@@ -124,6 +144,7 @@ var count = ctx.count;
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/discrete-uniform' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var gfindIndex = require( '@stdlib/blas/ext/base/ndarray/gfind-index' );
 
@@ -138,7 +159,11 @@ var opts = {
 var x = discreteUniform( [ 10 ], -100, 100, opts );
 console.log( ndarray2array( x ) );
 
-var idx = gfindIndex( [ x ], isEven );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var idx = gfindIndex( [ x, fromIndex ], isEven );
 console.log( idx );
 ```
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/README.md
@@ -86,6 +86,7 @@ The function has the following parameters:
     -   a zero-dimensional ndarray containing the index from which to begin searching.
 
 -   **clbk**: callback function.
+
 -   **thisArg**: callback execution context (_optional_).
 
 The callback function is provided the following arguments:

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/uniform' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
@@ -57,7 +58,13 @@ function clbk( v ) {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( [ len ], 0.0, 100.0, options );
+	var fromIndex;
+	var x;
+
+	x = uniform( [ len ], 0.0, 100.0, options );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 	return benchmark;
 
 	/**
@@ -72,7 +79,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			v = gfindIndex( [ x ], clbk );
+			v = gfindIndex( [ x, fromIndex ], clbk );
 			if ( isnan( v ) ) {
 				b.fail( 'should not return NaN' );
 			}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/docs/repl.txt
@@ -3,6 +3,10 @@
     Returns the index of the first element in a one-dimensional ndarray which
     passes a test implemented by a predicate function.
 
+    If a specified starting search index is negative, the function resolves the
+    starting search index by counting backward from the last element (where `-1`
+    refers to the last element).
+
     If provided an empty ndarray or no element passes a test implemented by a
     predicate function, the function returns `-1`.
 
@@ -15,7 +19,11 @@
     Parameters
     ----------
     arrays: ArrayLikeObject<ndarray>
-        Array-like object containing a one-dimensional input ndarray.
+        Array-like object containing the following ndarrays:
+
+        - a one-dimensional input ndarray.
+        - a zero-dimensional ndarray containing the index from which to begin
+        searching.
 
     clbk: Function
         Callback function.
@@ -31,8 +39,9 @@
     Examples
     --------
     > var x = {{alias:@stdlib/ndarray/vector/ctor}}( [ 1.0, -2.0, 2.0 ], 'generic' );
+    > var i = {{alias:@stdlib/ndarray/from-scalar}}( 0, { 'dtype': 'generic' } );
     > function f ( v ) { return v % 2.0 === 0.0; };
-    > {{alias}}( [ x ], f )
+    > {{alias}}( [ x, i ], f )
     1
 
     See Also

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/docs/types/index.d.ts
@@ -74,6 +74,7 @@ type Predicate<T, U, ThisArg> = Nullary<ThisArg> | Unary<T, ThisArg> | Binary<T,
 * -   The function expects the following ndarrays:
 *
 *     -   a one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * -   If no element passes a test implemented by a predicate function, the function returns `-1`.
 *
@@ -83,6 +84,7 @@ type Predicate<T, U, ThisArg> = Nullary<ThisArg> | Unary<T, ThisArg> | Binary<T,
 * @returns index
 *
 * @example
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var vector = require( '@stdlib/ndarray/vector/ctor' );
 *
 * function clbk( v ) {
@@ -91,10 +93,14 @@ type Predicate<T, U, ThisArg> = Nullary<ThisArg> | Unary<T, ThisArg> | Binary<T,
 *
 * var x = vector( [ 1.0, 3.0, 4.0, 2.0 ], 'generic' );
 *
-* var v = gfindIndex( [ x ], clbk );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var v = gfindIndex( [ x, fromIndex ], clbk );
 * // returns 2
 */
-declare function gfindIndex<T = unknown, U extends typedndarray<T> = typedndarray<T>, ThisArg = unknown>( arrays: [ U ], clbk: Predicate<T, U, ThisArg>, thisArg?: ThisParameterType<Predicate<T, U, ThisArg>> ): number;
+declare function gfindIndex<T = unknown, U extends typedndarray<T> = typedndarray<T>, ThisArg = unknown>( arrays: [ U, typedndarray<number> ], clbk: Predicate<T, U, ThisArg>, thisArg?: ThisParameterType<Predicate<T, U, ThisArg>> ): number;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/docs/types/test.ts
@@ -19,6 +19,7 @@
 /* eslint-disable space-in-parens */
 
 import zeros = require( '@stdlib/ndarray/zeros' );
+import scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 import gfindIndex = require( './index' );
 
 /**
@@ -39,9 +40,12 @@ function clbk( value: any ): boolean {
 	const x = zeros( [ 10 ], {
 		'dtype': 'generic'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	gfindIndex( [ x ], clbk ); // $ExpectType number
-	gfindIndex( [ x ], clbk, {} ); // $ExpectType number
+	gfindIndex( [ x, fromIndex ], clbk ); // $ExpectType number
+	gfindIndex( [ x, fromIndex ], clbk, {} ); // $ExpectType number
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
@@ -72,24 +76,27 @@ function clbk( value: any ): boolean {
 	const x = zeros( [ 10 ], {
 		'dtype': 'generic'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	gfindIndex( [ x ], '10' ); // $ExpectError
-	gfindIndex( [ x ], 10 ); // $ExpectError
-	gfindIndex( [ x ], true ); // $ExpectError
-	gfindIndex( [ x ], false ); // $ExpectError
-	gfindIndex( [ x ], null ); // $ExpectError
-	gfindIndex( [ x ], undefined ); // $ExpectError
-	gfindIndex( [ x ], [] ); // $ExpectError
-	gfindIndex( [ x ], {} ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], '10' ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], 10 ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], true ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], false ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], null ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], undefined ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], [] ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], {} ); // $ExpectError
 
-	gfindIndex( [ x ], '10', {} ); // $ExpectError
-	gfindIndex( [ x ], 10, {} ); // $ExpectError
-	gfindIndex( [ x ], true, {} ); // $ExpectError
-	gfindIndex( [ x ], false, {} ); // $ExpectError
-	gfindIndex( [ x ], null, {} ); // $ExpectError
-	gfindIndex( [ x ], undefined, {} ); // $ExpectError
-	gfindIndex( [ x ], [], {} ); // $ExpectError
-	gfindIndex( [ x ], {}, {} ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], '10', {} ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], 10, {} ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], true, {} ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], false, {} ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], null, {} ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], undefined, {} ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], [], {} ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], {}, {} ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided an unsupported number of arguments...
@@ -98,6 +105,10 @@ function clbk( value: any ): boolean {
 		'dtype': 'generic'
 	});
 
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+
 	gfindIndex(); // $ExpectError
-	gfindIndex( [ x ], clbk, {}, {} ); // $ExpectError
+	gfindIndex( [ x, fromIndex ], clbk, {}, {} ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/discrete-uniform' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var gfindIndex = require( './../lib' );
 
@@ -33,5 +34,9 @@ var opts = {
 var x = discreteUniform( [ 10 ], -100, 100, opts );
 console.log( ndarray2array( x ) );
 
-var idx = gfindIndex( [ x ], isEven );
+var fromIndex = scalar2ndarray( 0, {
+	'dtype': 'generic'
+});
+
+var idx = gfindIndex( [ x, fromIndex ], isEven );
 console.log( idx );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/lib/index.js
@@ -24,6 +24,7 @@
 * @module @stdlib/blas/ext/base/ndarray/gfind-index
 *
 * @example
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var vector = require( '@stdlib/ndarray/vector/ctor' );
 * var gfindIndex = require( '@stdlib/blas/ext/base/ndarray/gfind-index' );
 *
@@ -33,7 +34,11 @@
 *
 * var x = vector( [ 1.0, 3.0, 4.0, 2.0 ], 'generic' );
 *
-* var v = gfindIndex( [ x ], clbk );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var v = gfindIndex( [ x, fromIndex ], clbk );
 * // returns 2
 */
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/lib/main.js
@@ -20,10 +20,12 @@
 
 // MODULES //
 
+var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
 var getStride = require( '@stdlib/ndarray/base/stride' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
+var clipIndex = require( '@stdlib/ndarray/base/clip-index' );
 var strided = require( '@stdlib/blas/ext/base/gfind-index' ).ndarray;
 
 
@@ -37,6 +39,7 @@ var strided = require( '@stdlib/blas/ext/base/gfind-index' ).ndarray;
 * -   The function expects the following ndarrays:
 *
 *     -   a one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
 * @param {Function} clbk - callback function
@@ -44,6 +47,7 @@ var strided = require( '@stdlib/blas/ext/base/gfind-index' ).ndarray;
 * @returns {integer} index
 *
 * @example
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var vector = require( '@stdlib/ndarray/vector/ctor' );
 *
 * function clbk( v ) {
@@ -52,12 +56,39 @@ var strided = require( '@stdlib/blas/ext/base/gfind-index' ).ndarray;
 *
 * var x = vector( [ 1.0, 3.0, 4.0, 2.0 ], 'generic' );
 *
-* var v = gfindIndex( [ x ], clbk );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var v = gfindIndex( [ x, fromIndex ], clbk );
 * // returns 2
 */
 function gfindIndex( arrays, clbk, thisArg ) {
-	var x = arrays[ 0 ];
-	return strided( numelDimension( x, 0 ), getData( x ), getStride( x, 0 ), getOffset( x ), wrapper, null ); // eslint-disable-line max-len
+	var fromIndex;
+	var stride;
+	var offset;
+	var idx;
+	var N;
+	var x;
+
+	x = arrays[ 0 ];
+	fromIndex = ndarraylike2scalar( arrays[ 1 ] );
+
+	N = numelDimension( x, 0 );
+	fromIndex = clipIndex( fromIndex, N );
+	if ( fromIndex >= N ) {
+		return -1;
+	}
+	N -= fromIndex;
+
+	stride = getStride( x, 0 );
+	offset = getOffset( x ) + ( stride*fromIndex );
+
+	idx = strided( N, getData( x ), stride, offset, wrapper, null );
+	if ( idx >= 0 ) {
+		idx += fromIndex;
+	}
+	return idx;
 
 	/**
 	* Invokes a provided callback.
@@ -70,7 +101,7 @@ function gfindIndex( arrays, clbk, thisArg ) {
 	* @returns {*} result
 	*/
 	function wrapper( value, aidx ) {
-		return clbk.call( thisArg, value, aidx, x );
+		return clbk.call( thisArg, value, aidx + fromIndex, x );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/test/test.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
 var gfindIndex = require( './../lib' );
 
@@ -51,19 +52,24 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function returns the index of the first element which passes a test implemented by a predicate function', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+
 	x = [ 1.0, 3.0, -2.0, 5.0, 0.0, 4.0 ];
-	actual = gfindIndex( [ vector( x, 6, 1, 0 ) ], isEven );
+	actual = gfindIndex( [ vector( x, 6, 1, 0 ), fromIndex ], isEven );
 	t.strictEqual( actual, 2, 'returns expected value' );
 
 	x = [ 4.0, 5.0 ];
-	actual = gfindIndex( [ vector( x, 2, 1, 0 ) ], isEven );
+	actual = gfindIndex( [ vector( x, 2, 1, 0 ), fromIndex ], isEven );
 	t.strictEqual( actual, 0, 'returns expected value' );
 
 	x = [ 1.0, 3.0, 5.0 ];
-	actual = gfindIndex( [ vector( x, 3, 1, 0 ) ], isEven );
+	actual = gfindIndex( [ vector( x, 3, 1, 0 ), fromIndex ], isEven );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
@@ -73,13 +79,119 @@ tape( 'the function returns the index of the first element which passes a test i
 	}
 });
 
+tape( 'the function supports a `fromIndex` parameter (nonnegative)', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+
+	x = vector( [ 1.0, 0.0, 1.0, 0.0, 1.0, 0.0 ], 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	actual = gfindIndex( [ x, fromIndex ], isEven );
+	t.strictEqual( actual, 1, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 1, {
+		'dtype': 'generic'
+	});
+	actual = gfindIndex( [ x, fromIndex ], isEven );
+	t.strictEqual( actual, 1, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
+	actual = gfindIndex( [ x, fromIndex ], isEven );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 5, {
+		'dtype': 'generic'
+	});
+	actual = gfindIndex( [ x, fromIndex ], isEven );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	t.end();
+
+	function isEven( v ) {
+		return v % 2.0 === 0.0;
+	}
+});
+
+tape( 'the function supports a `fromIndex` parameter (negative)', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+
+	x = vector( [ 0.0, 1.0, 0.0, 1.0, 0.0, 1.0 ], 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( -1, {
+		'dtype': 'generic'
+	});
+	actual = gfindIndex( [ x, fromIndex ], isEven );
+	t.strictEqual( actual, -1, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -2, {
+		'dtype': 'generic'
+	});
+	actual = gfindIndex( [ x, fromIndex ], isEven );
+	t.strictEqual( actual, 4, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -3, {
+		'dtype': 'generic'
+	});
+	actual = gfindIndex( [ x, fromIndex ], isEven );
+	t.strictEqual( actual, 4, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -7, {
+		'dtype': 'generic'
+	});
+	actual = gfindIndex( [ x, fromIndex ], isEven );
+	t.strictEqual( actual, 0, 'returns expected value' );
+
+	t.end();
+
+	function isEven( v ) {
+		return v % 2.0 === 0.0;
+	}
+});
+
 tape( 'the function returns `-1` if provided an empty input ndarray', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
 	x = vector( [], 0, 1, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = gfindIndex( [ x ], isEven );
+	actual = gfindIndex( [ x, fromIndex ], isEven );
+	t.strictEqual( actual, -1, 'returns expected value' );
+
+	t.end();
+
+	function isEven( v ) {
+		return v % 2.0 === 0.0;
+	}
+});
+
+tape( 'the function returns `-1` if provided a starting search index which is greater than or equal to number of elements in the input ndarray', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+
+	x = vector( [ 1.0, 0.0, 1.0, 0.0, 1.0, 0.0 ], 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( 6, {
+		'dtype': 'generic'
+	});
+	actual = gfindIndex( [ x, fromIndex ], isEven );
+	t.strictEqual( actual, -1, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 7, {
+		'dtype': 'generic'
+	});
+	actual = gfindIndex( [ x, fromIndex ], isEven );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
@@ -90,6 +202,7 @@ tape( 'the function returns `-1` if provided an empty input ndarray', function t
 });
 
 tape( 'the function supports one-dimensional ndarrays having non-unit strides', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
@@ -103,8 +216,11 @@ tape( 'the function supports one-dimensional ndarrays having non-unit strides', 
 		4.0,  // 3
 		2.0
 	];
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = gfindIndex( [ vector( x, 4, 2, 0 ) ], isEven );
+	actual = gfindIndex( [ vector( x, 4, 2, 0 ), fromIndex ], isEven );
 
 	t.strictEqual( actual, 3, 'returns expected value' );
 	t.end();
@@ -115,6 +231,7 @@ tape( 'the function supports one-dimensional ndarrays having non-unit strides', 
 });
 
 tape( 'the function supports one-dimensional ndarrays having negative strides', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
@@ -128,8 +245,11 @@ tape( 'the function supports one-dimensional ndarrays having negative strides', 
 		3.0,  // 0
 		2.0
 	];
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = gfindIndex( [ vector( x, 4, -2, 6 ) ], isEven );
+	actual = gfindIndex( [ vector( x, 4, -2, 6 ), fromIndex ], isEven );
 
 	t.strictEqual( actual, 2, 'returns expected value' );
 	t.end();
@@ -140,6 +260,7 @@ tape( 'the function supports one-dimensional ndarrays having negative strides', 
 });
 
 tape( 'the function supports one-dimensional ndarrays having non-zero offsets', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
@@ -153,8 +274,11 @@ tape( 'the function supports one-dimensional ndarrays having non-zero offsets', 
 		3.0,
 		4.0   // 3
 	];
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = gfindIndex( [ vector( x, 4, 2, 1 ) ], isEven );
+	actual = gfindIndex( [ vector( x, 4, 2, 1 ), fromIndex ], isEven );
 	t.strictEqual( actual, 1, 'returns expected value' );
 
 	t.end();
@@ -193,13 +317,12 @@ tape( 'the function supports providing an execution context', function test( t )
 	arrays = [];
 
 	arr = vector( x, 4, 2, 0 );
-	actual = gfindIndex( [ arr ], isEven, ctx );
+	actual = gfindIndex( [ arr, scalar2ndarray( 1, { 'dtype': 'generic' } ) ], isEven, ctx ); // eslint-disable-line max-len
 
 	t.strictEqual( actual, 3, 'returns expected value' );
-	t.strictEqual( ctx.count, 4, 'returns expected value' );
+	t.strictEqual( ctx.count, 3, 'returns expected value' );
 
 	expected = [
-		1.0,
 		3.0,
 		-7.0,
 		4.0
@@ -207,7 +330,6 @@ tape( 'the function supports providing an execution context', function test( t )
 	t.deepEqual( values, expected, 'returns expected value' );
 
 	expected = [
-		0,
 		1,
 		2,
 		3
@@ -215,7 +337,6 @@ tape( 'the function supports providing an execution context', function test( t )
 	t.deepEqual( indices, expected, 'returns expected value' );
 
 	expected = [
-		arr,
 		arr,
 		arr,
 		arr

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfind-index/test/test.js
@@ -289,6 +289,7 @@ tape( 'the function supports one-dimensional ndarrays having non-zero offsets', 
 });
 
 tape( 'the function supports providing an execution context', function test( t ) {
+	var fromIndex;
 	var expected;
 	var indices;
 	var values;
@@ -317,7 +318,10 @@ tape( 'the function supports providing an execution context', function test( t )
 	arrays = [];
 
 	arr = vector( x, 4, 2, 0 );
-	actual = gfindIndex( [ arr, scalar2ndarray( 1, { 'dtype': 'generic' } ) ], isEven, ctx ); // eslint-disable-line max-len
+	fromIndex = scalar2ndarray( 1, {
+		'dtype': 'generic'
+	});
+	actual = gfindIndex( [ arr, fromIndex ], isEven, ctx );
 
 	t.strictEqual( actual, 3, 'returns expected value' );
 	t.strictEqual( ctx.count, 3, 'returns expected value' );


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1182.

## Description

> What is the purpose of this pull request?

This pull request:

-   add `fromIndex` support to `blas/ext/base/ndarray/gfind-index`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1182.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Primarily written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
