### PR TITLE
fix: avoid overflow in `stats/base/dists/rayleigh/quantile`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/lib/factory.js
@@ -44,14 +44,12 @@ var sqrt = require( '@stdlib/math/base/special/sqrt' );
 * // returns ~17.941
 */
 function factory( sigma ) {
-	var s2;
 	if ( isnan( sigma ) || sigma < 0.0 ) {
 		return constantFunction( NaN );
 	}
 	if ( sigma === 0.0 ) {
 		return degenerate( 0.0 );
 	}
-	s2 = sigma * sigma;
 	return quantile;
 
 	/**
@@ -69,7 +67,7 @@ function factory( sigma ) {
 		if ( isnan( p ) || p < 0.0 || p > 1.0 ) {
 			return NaN;
 		}
-		return sqrt( -2.0 * s2 * log1p( -p ) );
+		return sigma * sqrt( -2.0 * log1p( -p ) );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/lib/main.js
@@ -64,7 +64,6 @@ var sqrt = require( '@stdlib/math/base/special/sqrt' );
 * // returns NaN
 */
 function quantile( p, sigma ) {
-	var s2;
 	if ( isnan( sigma ) || sigma < 0.0 ) {
 		return NaN;
 	}
@@ -74,8 +73,7 @@ function quantile( p, sigma ) {
 	if ( sigma === 0.0 ) {
 		return 0.0;
 	}
-	s2 = sigma * sigma;
-	return sqrt( -2.0 * s2 * log1p( -p ) );
+	return sigma * sqrt( -2.0 * log1p( -p ) );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/src/main.c
@@ -33,7 +33,6 @@
 * // returns ~1.794
 */
 double stdlib_base_dists_rayleigh_quantile( const double p, const double sigma ) {
-	double s2;
 	if (
 		stdlib_base_is_nan( p ) ||
 		stdlib_base_is_nan( sigma ) ||
@@ -46,6 +45,5 @@ double stdlib_base_dists_rayleigh_quantile( const double p, const double sigma )
 	if ( sigma == 0.0 ) {
 		return 0.0;
 	}
-	s2 = sigma * sigma;
-	return stdlib_base_sqrt( -2.0 * s2 * stdlib_base_log1p( -p ) );
+	return sigma * stdlib_base_sqrt( -2.0 * stdlib_base_log1p( -p ) );
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   propagates fixes merged to `develop` between 2026-08-20 and 2026-08-21 to sibling packages.

Propagates the overflow fix from f51d7fed (#14446) to `@stdlib/stats/base/dists/rayleigh/quantile`. Computing `sigma*sigma` overflows for `sigma > ~1.34e154`, returning `Infinity` for every `p`, and underflows to `0` for `sigma < ~1.5e-154`; replacing `sqrt( -2.0 * s2 * log1p( -p ) )` with `sigma * sqrt( -2.0 * log1p( -p ) )` avoids the intermediate square and returns correct finite values across the full `sigma` range. Applied identically to the JS `main.js`, `factory.js`, and C `main.c` implementations; all 3000 Julia fixture values pass at the existing `1.0 * EPS` tolerance.

-   `lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/lib/main.js`
-   `lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/lib/factory.js`
-   `lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/src/main.c`

## Related Issues

> Does this pull request have any related issues?

No related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed: signature search over `stats/base/dists/*` for `pow( sigma, 2.0 )` / `sigma * sigma` kernels; two independent validation passes confirming the defect and guard preservation at each site (edge cases `sigma === 0`, `sigma === Infinity`, `p === 0`, `p === 1`, `NaN` verified bit-identical); an adaptation pass producing per-file patches; and a style-consistency pass against the conventions of f51d7fed. Existing Julia fixtures were re-run against the patched code: `0/3000` failures for both `quantile` and `factory` paths.

Deliberately excluded: `rayleigh/{pdf,logpdf,cdf,logcdf}` carry the same `sigma^2` overflow defect, but their test fixtures were generated by Julia code using the same squared-form algebra at `0`–`2` ULP tolerances, so the ratio-form fix shifts results by up to ~1180 ULP through `exp()` amplification and fails 1–1146 of 3000 fixture assertions per package. Landing those requires loosening tolerances (as already done for `normal/*`, `lognormal/*`, and `halfnormal/logpdf`) or regenerating fixtures — a reviewer decision, so they are left out of this propagation. `wald/logpdf` was checked and is already fixed (#14412).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated fix-propagation routine: candidate sites were located by pattern search, validated by independent review passes, and verified against the existing Julia test fixtures before committing.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXQVJeeR1SEeUHiN9Q58eY)_