### PR TITLE
feat!: add `fromIndex` support to `blas/ext/base/ndarray/gfirst-index-equal`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/README.md
@@ -42,11 +42,16 @@ Returns the index of the first element in a one-dimensional ndarray equal to a c
 
 ```javascript
 var vector = require( '@stdlib/ndarray/vector/ctor' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 
 var x = vector( [ 1.0, 2.0, 3.0, 4.0 ], 'generic' );
 var y = vector( [ 0.0, 0.0, 3.0, 0.0 ], 'generic' );
 
-var idx = gfirstIndexEqual( [ x, y ] );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var idx = gfirstIndexEqual( [ x, y, fromIndex ] );
 // returns 2
 ```
 
@@ -56,16 +61,22 @@ The function has the following parameters:
 
     -   first one-dimensional input ndarray.
     -   second one-dimensional input ndarray.
+    -   a zero-dimensional ndarray containing the index from which to begin searching.
 
 If the function is unable to find an element in the first one-dimensional input ndarray equal to a corresponding element in the second one-dimensional input ndarray, the function returns `-1`.
 
 ```javascript
 var vector = require( '@stdlib/ndarray/vector/ctor' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 
 var x = vector( [ 1.0, 2.0, 3.0, 4.0 ], 'generic' );
 var y = vector( [ 5.0, 6.0, 7.0, 8.0 ], 'generic' );
 
-var idx = gfirstIndexEqual( [ x, y ] );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var idx = gfirstIndexEqual( [ x, y, fromIndex ] );
 // returns -1
 ```
 
@@ -77,6 +88,7 @@ var idx = gfirstIndexEqual( [ x, y ] );
 
 ## Notes
 
+-   If a specified starting search index is negative, the function resolves the starting search index by counting backward from the last element (where `-1` refers to the last element).
 -   When comparing elements, the function checks for equality using the strict equality operator `===`. As a consequence, `NaN` values are considered distinct, and `-0` and `+0` are considered the same.
 
 </section>
@@ -91,7 +103,9 @@ var idx = gfirstIndexEqual( [ x, y ] );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/discrete-uniform' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var ndarraylike2scalar = require( '@stdlib/ndarray/ndarraylike2scalar' );
 var gfirstIndexEqual = require( '@stdlib/blas/ext/base/ndarray/gfirst-index-equal' );
 
 var opts = {
@@ -103,7 +117,12 @@ console.log( ndarray2array( x ) );
 var y = discreteUniform( [ 10 ], 0, 10, opts );
 console.log( ndarray2array( y ) );
 
-var idx = gfirstIndexEqual( [ x, y ] );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+console.log( 'From Index:', ndarraylike2scalar( fromIndex ) );
+
+var idx = gfirstIndexEqual( [ x, y, fromIndex ] );
 console.log( idx );
 ```
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var pow = require( '@stdlib/math/base/special/pow' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var oneTo = require( '@stdlib/blas/ext/one-to' );
 var zeros = require( '@stdlib/ndarray/zeros' );
 var format = require( '@stdlib/string/format' );
@@ -47,8 +48,13 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = oneTo( [ len ], options );
-	var y = zeros( [ len ], options );
+	var fromIndex;
+	var x;
+	var y;
+
+	x = oneTo( [ len ], options );
+	y = zeros( [ len ], options );
+	fromIndex = scalar2ndarray( 0, options );
 	return benchmark;
 
 	/**
@@ -63,7 +69,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			out = gfirstIndexEqual( [ x, y ] );
+			out = gfirstIndexEqual( [ x, y, fromIndex ] );
 			if ( out !== out ) {
 				b.fail( 'should return an integer' );
 			}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/docs/repl.txt
@@ -3,6 +3,10 @@
     Returns the index of the first element in a one-dimensional ndarray equal
     to a corresponding element in another one-dimensional ndarray.
 
+    If a specified starting search index is negative, the function resolves the
+    starting search index by counting backward from the last element (where `-1`
+    refers to the last element).
+
     When comparing elements, the function checks for equality using the strict
     equality operator `===`. As a consequence, `NaN` values are considered
     distinct, and `-0` and `+0` are considered the same.
@@ -14,6 +18,8 @@
 
         - first one-dimensional input ndarray.
         - second one-dimensional input ndarray.
+        - a zero-dimensional ndarray containing the index from which to begin
+        searching.
 
     Returns
     -------
@@ -24,7 +30,8 @@
     --------
     > var x = {{alias:@stdlib/ndarray/vector/ctor}}( [ 1.0, 2.0, 3.0, 4.0 ], 'generic' );
     > var y = {{alias:@stdlib/ndarray/vector/ctor}}( [ 0.0, 0.0, 3.0, 0.0 ], 'generic' );
-    > {{alias}}( [ x, y ] )
+    > var i = {{alias:@stdlib/ndarray/from-scalar}}( 0, { 'dtype': 'generic' } );
+    > {{alias}}( [ x, y, i ] )
     2
 
     See Also

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/docs/types/index.d.ts
@@ -31,6 +31,7 @@ import { typedndarray } from '@stdlib/types/ndarray';
 *
 *     -   first one-dimensional input ndarray.
 *     -   second one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * -   When comparing elements, the function checks for equality using the strict equality operator `===`. As a consequence, `NaN` values are considered distinct, and `-0` and `+0` are considered the same.
 *
@@ -39,14 +40,19 @@ import { typedndarray } from '@stdlib/types/ndarray';
 *
 * @example
 * var vector = require( '@stdlib/ndarray/vector/ctor' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 *
 * var x = vector( [ 1.0, 2.0, 3.0, 4.0 ], 'generic' );
 * var y = vector( [ 0.0, 0.0, 3.0, 0.0 ], 'generic' );
 *
-* var idx = gfirstIndexEqual( [ x, y ] );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var idx = gfirstIndexEqual( [ x, y, fromIndex ] );
 * // returns 2
 */
-declare function gfirstIndexEqual( arrays: [ typedndarray<unknown>, typedndarray<unknown> ] ): number;
+declare function gfirstIndexEqual( arrays: [ typedndarray<unknown>, typedndarray<unknown>, typedndarray<number> ] ): number;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/docs/types/test.ts
@@ -19,6 +19,7 @@
 /* eslint-disable space-in-parens */
 
 import zeros = require( '@stdlib/ndarray/zeros' );
+import scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 import gfirstIndexEqual = require( './index' );
 
 
@@ -32,8 +33,11 @@ import gfirstIndexEqual = require( './index' );
 	const y = zeros( [ 10 ], {
 		'dtype': 'generic'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	gfirstIndexEqual( [ x, y ] ); // $ExpectType number
+	gfirstIndexEqual( [ x, y, fromIndex ] ); // $ExpectType number
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
@@ -57,7 +61,10 @@ import gfirstIndexEqual = require( './index' );
 	const y = zeros( [ 10 ], {
 		'dtype': 'generic'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	gfirstIndexEqual(); // $ExpectError
-	gfirstIndexEqual( [ x, y ], {} ); // $ExpectError
+	gfirstIndexEqual( [ x, y, fromIndex ], {} ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/examples/index.js
@@ -19,7 +19,9 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/discrete-uniform' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var ndarraylike2scalar = require( '@stdlib/ndarray/ndarraylike2scalar' );
 var gfirstIndexEqual = require( './../lib' );
 
 var opts = {
@@ -31,5 +33,10 @@ console.log( ndarray2array( x ) );
 var y = discreteUniform( [ 10 ], 0, 10, opts );
 console.log( ndarray2array( y ) );
 
-var idx = gfirstIndexEqual( [ x, y ] );
+var fromIndex = scalar2ndarray( 0, {
+	'dtype': 'generic'
+});
+console.log( 'From Index:', ndarraylike2scalar( fromIndex ) );
+
+var idx = gfirstIndexEqual( [ x, y, fromIndex ] );
 console.log( idx );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/lib/index.js
@@ -25,12 +25,17 @@
 *
 * @example
 * var vector = require( '@stdlib/ndarray/vector/ctor' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var gfirstIndexEqual = require( '@stdlib/blas/ext/base/ndarray/gfirst-index-equal' );
 *
 * var x = vector( [ 1.0, 2.0, 3.0, 4.0 ], 'generic' );
 * var y = vector( [ 0.0, 0.0, 3.0, 0.0 ], 'generic' );
 *
-* var idx = gfirstIndexEqual( [ x, y ] );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var idx = gfirstIndexEqual( [ x, y, fromIndex ] );
 * // returns 2
 */
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/lib/main.js
@@ -20,10 +20,12 @@
 
 // MODULES //
 
+var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
 var getStride = require( '@stdlib/ndarray/base/stride' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
+var clipIndex = require( '@stdlib/ndarray/base/clip-index' );
 var strided = require( '@stdlib/blas/ext/base/gfirst-index-equal' ).ndarray;
 
 
@@ -38,6 +40,7 @@ var strided = require( '@stdlib/blas/ext/base/gfirst-index-equal' ).ndarray;
 *
 *     -   first one-dimensional input ndarray.
 *     -   second one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * -   When comparing elements, the function checks for equality using the strict equality operator `===`. As a consequence, `NaN` values are considered distinct, and `-0` and `+0` are considered the same.
 *
@@ -46,17 +49,50 @@ var strided = require( '@stdlib/blas/ext/base/gfirst-index-equal' ).ndarray;
 *
 * @example
 * var vector = require( '@stdlib/ndarray/vector/ctor' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 *
 * var x = vector( [ 1.0, 2.0, 3.0, 4.0 ], 'generic' );
 * var y = vector( [ 0.0, 0.0, 3.0, 0.0 ], 'generic' );
 *
-* var idx = gfirstIndexEqual( [ x, y ] );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var idx = gfirstIndexEqual( [ x, y, fromIndex ] );
 * // returns 2
 */
 function gfirstIndexEqual( arrays ) {
-	var x = arrays[ 0 ];
-	var y = arrays[ 1 ];
-	return strided( numelDimension( x, 0 ), getData( x ), getStride( x, 0 ), getOffset( x ), getData( y ), getStride( y, 0 ), getOffset( y ) ); // eslint-disable-line max-len
+	var fromIndex;
+	var idx;
+	var sx;
+	var sy;
+	var ox;
+	var oy;
+	var N;
+	var x;
+	var y;
+
+	x = arrays[ 0 ];
+	y = arrays[ 1 ];
+	fromIndex = ndarraylike2scalar( arrays[ 2 ] );
+
+	N = numelDimension( x, 0 );
+	fromIndex = clipIndex( fromIndex, N );
+	if ( fromIndex >= N ) {
+		return -1;
+	}
+	N -= fromIndex;
+
+	sx = getStride( x, 0 );
+	ox = getOffset( x ) + ( sx*fromIndex );
+	sy = getStride( y, 0 );
+	oy = getOffset( y ) + ( sy*fromIndex );
+
+	idx = strided( N, getData( x ), sx, ox, getData( y ), sy, oy );
+	if ( idx >= 0 ) {
+		idx += fromIndex;
+	}
+	return idx;
 }
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfirst-index-equal/test/test.js
@@ -22,6 +22,7 @@
 
 var tape = require( 'tape' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var gfirstIndexEqual = require( './../lib' );
 
 
@@ -51,55 +52,70 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function returns the index of the first element in a one-dimensional ndarray equal to a corresponding element in another one-dimensional ndarray', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
 
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+
 	x = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], 6, 1, 0 );
 	y = vector( [ 1.0, 0.0, 3.0, 0.0, 5.0, 0.0 ], 6, 1, 0 );
 
-	actual = gfirstIndexEqual( [ x, y ] );
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, 0, 'returns expected value' );
 
 	x = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], 6, 1, 0 );
 	y = vector( [ 0.0, 2.0, 3.0, 0.0, 0.0, 0.0 ], 6, 1, 0 );
 
-	actual = gfirstIndexEqual( [ x, y ] );
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, 1, 'returns expected value' );
 
 	x = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], 6, 1, 0 );
 	y = vector( [ 0.0, 0.0, 0.0, 0.0, 0.0, 6.0 ], 6, 1, 0 );
 
-	actual = gfirstIndexEqual( [ x, y ] );
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, 5, 'returns expected value' );
 
 	x = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], 6, 1, 0 );
 	y = vector( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ], 6, 1, 0 );
 
-	actual = gfirstIndexEqual( [ x, y ] );
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `-1` if unable to find an element in the first one-dimensional input ndarray equal to a corresponding element in the second one-dimensional input ndarray', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
 
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+
 	x = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], 6, 1, 0 );
 	y = vector( [ 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ], 6, 1, 0 );
 
-	actual = gfirstIndexEqual( [ x, y ] );
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having non-unit strides', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	x = [
 		1.0,  // 0
@@ -122,16 +138,21 @@ tape( 'the function supports one-dimensional ndarrays having non-unit strides', 
 		8.0
 	];
 
-	actual = gfirstIndexEqual( [ vector( x, 4, 2, 0 ), vector( y, 4, 2, 0 ) ] );
+	actual = gfirstIndexEqual( [ vector( x, 4, 2, 0 ), vector( y, 4, 2, 0 ), fromIndex ] );
 
 	t.strictEqual( actual, 2, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having negative strides', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	x = [
 		1.0,  // 3
@@ -154,16 +175,21 @@ tape( 'the function supports one-dimensional ndarrays having negative strides', 
 		8.0
 	];
 
-	actual = gfirstIndexEqual( [ vector( x, 4, -2, 6 ), vector( y, 4, -2, 6 ) ] );
+	actual = gfirstIndexEqual( [ vector( x, 4, -2, 6 ), vector( y, 4, -2, 6 ), fromIndex ] );
 
 	t.strictEqual( actual, 2, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having non-zero offsets', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	x = [
 		0.0,
@@ -186,36 +212,144 @@ tape( 'the function supports one-dimensional ndarrays having non-zero offsets', 
 		4.0   // 3
 	];
 
-	actual = gfirstIndexEqual( [ vector( x, 4, 2, 1 ), vector( y, 4, 2, 1 ) ] );
+	actual = gfirstIndexEqual( [ vector( x, 4, 2, 1 ), vector( y, 4, 2, 1 ), fromIndex ] );
 	t.strictEqual( actual, 1, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function considers NaN values as distinct', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
 
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+
 	x = vector( [ NaN, NaN, NaN ], 3, 1, 0 );
 	y = vector( [ NaN, NaN, NaN ], 3, 1, 0 );
 
-	actual = gfirstIndexEqual( [ x, y ] );
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function considers -0 and +0 as the same', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
 
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+
 	x = vector( [ 1.0, -0.0, 3.0 ], 3, 1, 0 );
 	y = vector( [ 0.0, 0.0, 0.0 ], 3, 1, 0 );
 
-	actual = gfirstIndexEqual( [ x, y ] );
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, 1, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a nonnegative starting search index', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+	var y;
+
+	x = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], 6, 1, 0 );
+	y = vector( [ 1.0, 2.0, 0.0, 4.0, 0.0, 6.0 ], 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 0, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 1, {
+		'dtype': 'generic'
+	});
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 1, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative starting search index', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+	var y;
+
+	x = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], 6, 1, 0 );
+	y = vector( [ 1.0, 2.0, 0.0, 4.0, 0.0, 6.0 ], 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( -1, {
+		'dtype': 'generic'
+	});
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -2, {
+		'dtype': 'generic'
+	});
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -3, {
+		'dtype': 'generic'
+	});
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -7, {
+		'dtype': 'generic'
+	});
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `-1` if provided a starting search index which is greater than or equal to number of elements in the input ndarray', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+	var y;
+
+	x = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], 6, 1, 0 );
+	y = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( 6, {
+		'dtype': 'generic'
+	});
+
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, -1, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 7, {
+		'dtype': 'generic'
+	});
+
+	actual = gfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1184.

## Description

> What is the purpose of this pull request?

This pull request:

-   add `fromIndex` support to `blas/ext/base/ndarray/gfirst-index-equal`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1184.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Primarily written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
