### PR TITLE
test: migrate `stats/base/dists/logistic/variance` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/variance/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var variance = require( './../lib' );
 
 
@@ -76,8 +75,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', function test
 
 tape( 'the function returns the variance of a logistic distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var s;
 	var y;
@@ -89,13 +86,7 @@ tape( 'the function returns the variance of a logistic distribution', function t
 	for ( i = 0; i < mu.length; i++ ) {
 		y = variance( mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/variance/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/variance/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -88,8 +87,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', opts, functio
 
 tape( 'the function returns the variance of a logistic distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var s;
 	var y;
@@ -101,13 +98,7 @@ tape( 'the function returns the variance of a logistic distribution', opts, func
 	for ( i = 0; i < mu.length; i++ ) {
 		y = variance( mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Ref #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/logistic/variance` from computed floating-point tolerances to ULP-based assertions, per #11352.
-   replaces the `delta`/`tol` (`2.0 * EPS * abs( expected[i] )`) comparison in `test/test.js` with `isAlmostSameValue( y, expected[ i ], 3 )`.
-   replaces the equivalent `delta`/`tol` comparison in `test/test.native.js` with `isAlmostSameValue( y, expected[ i ], 3 )`.
-   adds the `@stdlib/assert/is-almost-same-value` require and drops the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**Final ULP bound: `3` in both `test/test.js` and `test/test.native.js`.**

Measured minimum: starting from a high bound and tightening, `3` is the minimum integer bound which passes over the full fixture set. Sweeping the bound over the 100 Julia fixture values gives, for both test files:

| Bound | `test/test.js` | `test/test.native.js` |
| ----- | -------------- | --------------------- |
| `0`   | 49 failing     | 49 failing            |
| `1`   | 7 failing      | 7 failing             |
| `2`   | 1 failing      | 1 failing             |
| `3`   | **all pass**   | **all pass**          |

The maximum observed ULP difference is `3` for both the JavaScript and the native implementation (worst case at `mu = -3.790154994337721`, `s = 3.0019267654139057`). The native add-on was built locally so that `test/test.native.js` actually executed rather than being skipped. The full suite (110 assertions in `test/test.js`, 111 in `test/test.native.js`) was run twice at the final bound with identical results, so no FMA/arch-related nondeterminism was observed on this platform (Linux x86-64, gcc).

That the two implementations agree exactly is expected: both evaluate `( s*s ) * PI_SQUARED / 3.0`, which offers no multiply-add for a compiler to contract.

Only the two test files are modified; no source, documentation, benchmark, or fixture files are touched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

-   The bound of `3` reflects the accuracy of the Julia reference values relative to the double-precision result of `s^2 * pi^2 / 3`, not an implementation deficiency. If reviewers would prefer a round number for readability over the measured minimum, `4` would leave a single ULP of headroom.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Verification performed: package tests green (110/110 and 111/111 assertions, each run twice), lint clean via `eslint --config etc/eslint/.eslintrc.tests.js` over both files, and `git status` confirms only the two test files changed.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was written primarily by Claude Code, which selected the package, mirrored the conversion idiom used in previously converted packages, measured the ULP bound against the fixture set, and verified tests and linting.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6vFzKDfHmLxXqHG2jScRi)_