### PR TITLE
feat!: add `fromIndex` support to `blas/ext/base/ndarray/gindex-of-not-equal`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/README.md
@@ -50,7 +50,11 @@ var searchElement = scalar2ndarray( 1.0, {
     'dtype': 'generic'
 });
 
-var idx = gindexOfNotEqual( [ x, searchElement ] );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var idx = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 // returns 2
 ```
 
@@ -60,6 +64,7 @@ The function has the following parameters:
 
     -   a one-dimensional input ndarray.
     -   a zero-dimensional ndarray containing the search element.
+    -   a zero-dimensional ndarray containing the index from which to begin searching.
 
 If the function is unable to find an element which is not equal to a specified search element, the function returns `-1`.
 
@@ -73,7 +78,11 @@ var searchElement = scalar2ndarray( 1.0, {
     'dtype': 'generic'
 });
 
-var idx = gindexOfNotEqual( [ x, searchElement ] );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var idx = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 // returns -1
 ```
 
@@ -85,6 +94,7 @@ var idx = gindexOfNotEqual( [ x, searchElement ] );
 
 ## Notes
 
+-   If a specified starting search index is negative, the function resolves the starting search index by counting backward from the last element (where `-1` refers to the last element).
 -   When searching for a search element, the function checks for inequality using the strict inequality operator `!==`. As a consequence, `NaN` values are considered distinct from all values (including other `NaN` values), and `-0` and `+0` are considered the same.
 
 </section>
@@ -114,7 +124,12 @@ console.log( ndarray2array( x ) );
 var searchElement = scalar2ndarray( 0, opts );
 console.log( 'Search Element:', ndarraylike2scalar( searchElement ) );
 
-var idx = gindexOfNotEqual( [ x, searchElement ] );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+console.log( 'From Index:', ndarraylike2scalar( fromIndex ) );
+
+var idx = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 console.log( idx );
 ```
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/benchmark/benchmark.js
@@ -48,11 +48,14 @@ var options = {
 */
 function createBenchmark( len ) {
 	var searchElement;
+	var fromIndex;
 	var x;
 
 	x = zeros( [ len ], options );
 	searchElement = scalar2ndarray( 0.0, options );
-
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 	return benchmark;
 
 	/**
@@ -67,7 +70,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			out = gindexOfNotEqual( [ x, searchElement ] );
+			out = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 			if ( out !== out ) {
 				b.fail( 'should return an integer' );
 			}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/docs/repl.txt
@@ -3,6 +3,10 @@
     Returns the first index of an element in a one-dimensional ndarray which is
     not equal to a specified search element.
 
+    If a specified starting search index is negative, the function resolves the
+    starting search index by counting backward from the last element (where `-1`
+    refers to the last element).
+
     When searching for a search element, the function checks for inequality
     using the strict inequality operator `!==`. As a consequence, `NaN` values
     are considered distinct from all values (including other `NaN` values), and
@@ -18,6 +22,8 @@
 
         - a one-dimensional input ndarray.
         - a zero-dimensional ndarray containing the search element.
+        - a zero-dimensional ndarray containing the index from which to begin
+        searching.
 
     Returns
     -------
@@ -28,7 +34,8 @@
     --------
     > var x = {{alias:@stdlib/ndarray/vector/ctor}}( [ 1.0, 1.0, 3.0 ], 'generic' );
     > var v = {{alias:@stdlib/ndarray/from-scalar}}( 1.0, { 'dtype': 'generic' } );
-    > {{alias}}( [ x, v ] )
+    > var i = {{alias:@stdlib/ndarray/from-scalar}}( 0, { 'dtype': 'generic' } );
+    > {{alias}}( [ x, v, i ] )
     2
 
     See Also

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/docs/types/index.d.ts
@@ -31,6 +31,7 @@ import { typedndarray } from '@stdlib/types/ndarray';
 *
 *     -   a one-dimensional input ndarray.
 *     -   a zero-dimensional ndarray containing the search element.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * @param arrays - array-like object containing ndarrays
 * @returns index
@@ -45,10 +46,14 @@ import { typedndarray } from '@stdlib/types/ndarray';
 *     'dtype': 'generic'
 * });
 *
-* var v = gindexOfNotEqual( [ x, searchElement ] );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var v = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 * // returns 2
 */
-declare function gindexOfNotEqual( arrays: [ typedndarray<unknown>, typedndarray<unknown> ] ): number;
+declare function gindexOfNotEqual( arrays: [ typedndarray<unknown>, typedndarray<unknown>, typedndarray<number> ] ): number;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/docs/types/test.ts
@@ -33,8 +33,11 @@ import gindexOfNotEqual = require( './index' );
 	const searchElement = scalar2ndarray( 0.0, {
 		'dtype': 'generic'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	gindexOfNotEqual( [ x, searchElement ] ); // $ExpectType number
+	gindexOfNotEqual( [ x, searchElement, fromIndex ] ); // $ExpectType number
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
@@ -58,7 +61,10 @@ import gindexOfNotEqual = require( './index' );
 	const searchElement = scalar2ndarray( 0.0, {
 		'dtype': 'generic'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	gindexOfNotEqual(); // $ExpectError
-	gindexOfNotEqual( [ x, searchElement ], {} ); // $ExpectError
+	gindexOfNotEqual( [ x, searchElement, fromIndex ], {} ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/examples/index.js
@@ -34,5 +34,10 @@ console.log( ndarray2array( x ) );
 var searchElement = scalar2ndarray( 0, opts );
 console.log( 'Search Element:', ndarraylike2scalar( searchElement ) );
 
-var idx = gindexOfNotEqual( [ x, searchElement ] );
+var fromIndex = scalar2ndarray( 0, {
+	'dtype': 'generic'
+});
+console.log( 'From Index:', ndarraylike2scalar( fromIndex ) );
+
+var idx = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 console.log( idx );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/lib/index.js
@@ -34,7 +34,11 @@
 *     'dtype': 'generic'
 * });
 *
-* var v = gindexOfNotEqual( [ x, searchElement ] );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var v = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 * // returns 2
 */
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/lib/main.js
@@ -24,8 +24,9 @@ var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
 var getStride = require( '@stdlib/ndarray/base/stride' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
-var strided = require( '@stdlib/blas/ext/base/gindex-of-not-equal' ).ndarray;
 var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
+var clipIndex = require( '@stdlib/ndarray/base/clip-index' );
+var strided = require( '@stdlib/blas/ext/base/gindex-of-not-equal' ).ndarray;
 
 
 // MAIN //
@@ -39,6 +40,7 @@ var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 *
 *     -   a one-dimensional input ndarray.
 *     -   a zero-dimensional ndarray containing the search element.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
 * @returns {integer} index
@@ -53,12 +55,41 @@ var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 *     'dtype': 'generic'
 * });
 *
-* var v = gindexOfNotEqual( [ x, searchElement ] );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var v = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 * // returns 2
 */
 function gindexOfNotEqual( arrays ) {
-	var x = arrays[ 0 ];
-	return strided( numelDimension( x, 0 ), ndarraylike2scalar( arrays[ 1 ] ), getData( x ), getStride( x, 0 ), getOffset( x ) ); // eslint-disable-line max-len
+	var searchElement;
+	var fromIndex;
+	var stride;
+	var offset;
+	var idx;
+	var N;
+	var x;
+
+	x = arrays[ 0 ];
+	searchElement = ndarraylike2scalar( arrays[ 1 ] );
+	fromIndex = ndarraylike2scalar( arrays[ 2 ] );
+
+	N = numelDimension( x, 0 );
+	fromIndex = clipIndex( fromIndex, N );
+	if ( fromIndex >= N ) {
+		return -1;
+	}
+	N -= fromIndex;
+
+	stride = getStride( x, 0 );
+	offset = getOffset( x ) + ( stride*fromIndex );
+
+	idx = strided( N, searchElement, getData( x ), stride, offset );
+	if ( idx >= 0 ) {
+		idx += fromIndex;
+	}
+	return idx;
 }
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-not-equal/test/test.js
@@ -53,33 +53,38 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function returns the index of the first element in a one-dimensional ndarray which is not equal to a provided search element', function test( t ) {
 	var searchElement;
+	var fromIndex;
 	var actual;
 	var x;
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	x = vector( [ 1.0, 1.0, 2.0, 2.0, 3.0, 3.0 ], 6, 1, 0 );
 
 	searchElement = scalar2ndarray( 1.0, {
 		'dtype': 'generic'
 	});
-	actual = gindexOfNotEqual( [ x, searchElement ] );
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 	t.strictEqual( actual, 2, 'returns expected value' );
 
 	searchElement = scalar2ndarray( 2.0, {
 		'dtype': 'generic'
 	});
-	actual = gindexOfNotEqual( [ x, searchElement ] );
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 	t.strictEqual( actual, 0, 'returns expected value' );
 
 	searchElement = scalar2ndarray( 3.0, {
 		'dtype': 'generic'
 	});
-	actual = gindexOfNotEqual( [ x, searchElement ] );
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 	t.strictEqual( actual, 0, 'returns expected value' );
 
 	searchElement = scalar2ndarray( 4.0, {
 		'dtype': 'generic'
 	});
-	actual = gindexOfNotEqual( [ x, searchElement ] );
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 	t.strictEqual( actual, 0, 'returns expected value' );
 
 	t.end();
@@ -87,15 +92,20 @@ tape( 'the function returns the index of the first element in a one-dimensional 
 
 tape( 'the function returns `-1` if every element in a one-dimensional ndarray is equal to a provided search element', function test( t ) {
 	var searchElement;
+	var fromIndex;
 	var actual;
 	var x;
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	x = vector( [ 2.0, 2.0, 2.0 ], 3, 1, 0 );
 	searchElement = scalar2ndarray( 2.0, {
 		'dtype': 'generic'
 	});
 
-	actual = gindexOfNotEqual( [ x, searchElement ] );
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
@@ -103,15 +113,20 @@ tape( 'the function returns `-1` if every element in a one-dimensional ndarray i
 
 tape( 'the function considers `NaN` elements to be not equal to a provided search element', function test( t ) {
 	var searchElement;
+	var fromIndex;
 	var actual;
 	var x;
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	x = vector( [ 1.0, NaN, 1.0 ], 3, 1, 0 );
 	searchElement = scalar2ndarray( 1.0, {
 		'dtype': 'generic'
 	});
 
-	actual = gindexOfNotEqual( [ x, searchElement ] );
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 	t.strictEqual( actual, 1, 'returns expected value' );
 
 	t.end();
@@ -119,15 +134,20 @@ tape( 'the function considers `NaN` elements to be not equal to a provided searc
 
 tape( 'the function returns the index of the first element if a provided search element is `NaN`', function test( t ) {
 	var searchElement;
+	var fromIndex;
 	var actual;
 	var x;
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	x = vector( [ NaN, 1.0 ], 2, 1, 0 );
 	searchElement = scalar2ndarray( NaN, {
 		'dtype': 'generic'
 	});
 
-	actual = gindexOfNotEqual( [ x, searchElement ] );
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 	t.strictEqual( actual, 0, 'returns expected value' );
 
 	t.end();
@@ -135,15 +155,20 @@ tape( 'the function returns the index of the first element if a provided search 
 
 tape( 'the function considers `-0` and `+0` to be equal', function test( t ) {
 	var searchElement;
+	var fromIndex;
 	var actual;
 	var x;
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	x = vector( [ -0.0, 0.0 ], 2, 1, 0 );
 	searchElement = scalar2ndarray( 0.0, {
 		'dtype': 'generic'
 	});
 
-	actual = gindexOfNotEqual( [ x, searchElement ] );
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
@@ -151,21 +176,26 @@ tape( 'the function considers `-0` and `+0` to be equal', function test( t ) {
 
 tape( 'the function supports one-dimensional ndarrays having non-unit strides', function test( t ) {
 	var searchElement;
+	var fromIndex;
 	var actual;
 	var x;
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	x = vector( [ 2.0, 9.0, 2.0, 9.0, 3.0, 9.0 ], 3, 2, 0 );
 
 	searchElement = scalar2ndarray( 2.0, {
 		'dtype': 'generic'
 	});
-	actual = gindexOfNotEqual( [ x, searchElement ] );
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 	t.strictEqual( actual, 2, 'returns expected value' );
 
 	searchElement = scalar2ndarray( 9.0, {
 		'dtype': 'generic'
 	});
-	actual = gindexOfNotEqual( [ x, searchElement ] );
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 	t.strictEqual( actual, 0, 'returns expected value' );
 
 	t.end();
@@ -173,21 +203,26 @@ tape( 'the function supports one-dimensional ndarrays having non-unit strides', 
 
 tape( 'the function supports one-dimensional ndarrays having negative strides', function test( t ) {
 	var searchElement;
+	var fromIndex;
 	var actual;
 	var x;
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	x = vector( [ 2.0, 1.0, 2.0, 2.0, 3.0, 3.0 ], 6, -1, 5 );
 
 	searchElement = scalar2ndarray( 3.0, {
 		'dtype': 'generic'
 	});
-	actual = gindexOfNotEqual( [ x, searchElement ] );
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 	t.strictEqual( actual, 2, 'returns expected value' );
 
 	searchElement = scalar2ndarray( 1.0, {
 		'dtype': 'generic'
 	});
-	actual = gindexOfNotEqual( [ x, searchElement ] );
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 	t.strictEqual( actual, 0, 'returns expected value' );
 
 	t.end();
@@ -195,15 +230,20 @@ tape( 'the function supports one-dimensional ndarrays having negative strides', 
 
 tape( 'the function supports one-dimensional ndarrays having non-zero offsets', function test( t ) {
 	var searchElement;
+	var fromIndex;
 	var actual;
 	var x;
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	x = vector( [ 1.0, 1.0, 2.0, 2.0, 3.0, 3.0 ], 3, 1, 3 );
 	searchElement = scalar2ndarray( 2.0, {
 		'dtype': 'generic'
 	});
 
-	actual = gindexOfNotEqual( [ x, searchElement ] );
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 	t.strictEqual( actual, 1, 'returns expected value' );
 
 	t.end();
@@ -211,15 +251,124 @@ tape( 'the function supports one-dimensional ndarrays having non-zero offsets', 
 
 tape( 'the function returns `-1` if provided an empty one-dimensional ndarray', function test( t ) {
 	var searchElement;
+	var fromIndex;
 	var actual;
 	var x;
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	x = vector( [], 0, 1, 0 );
 	searchElement = scalar2ndarray( 2.0, {
 		'dtype': 'generic'
 	});
 
-	actual = gindexOfNotEqual( [ x, searchElement ] );
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
+	t.strictEqual( actual, -1, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a nonnegative starting search index', function test( t ) {
+	var searchElement;
+	var fromIndex;
+	var actual;
+	var x;
+
+	x = vector( [ 2.0, 1.0, 1.0, 3.0, 1.0, 4.0 ], 6, 1, 0 );
+	searchElement = scalar2ndarray( 1.0, {
+		'dtype': 'generic'
+	});
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
+	t.strictEqual( actual, 0, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 1, {
+		'dtype': 'generic'
+	});
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative starting search index', function test( t ) {
+	var searchElement;
+	var fromIndex;
+	var actual;
+	var x;
+
+	x = vector( [ 2.0, 1.0, 1.0, 3.0, 1.0, 4.0 ], 6, 1, 0 );
+	searchElement = scalar2ndarray( 1.0, {
+		'dtype': 'generic'
+	});
+
+	fromIndex = scalar2ndarray( -1, {
+		'dtype': 'generic'
+	});
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -2, {
+		'dtype': 'generic'
+	});
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -3, {
+		'dtype': 'generic'
+	});
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -7, {
+		'dtype': 'generic'
+	});
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
+	t.strictEqual( actual, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `-1` if provided a starting search index which is greater than or equal to number of elements in the input ndarray', function test( t ) {
+	var searchElement;
+	var fromIndex;
+	var actual;
+	var x;
+
+	x = vector( [ 2.0, 1.0, 1.0, 3.0, 1.0, 4.0 ], 6, 1, 0 );
+	searchElement = scalar2ndarray( 1.0, {
+		'dtype': 'generic'
+	});
+
+	fromIndex = scalar2ndarray( 6, {
+		'dtype': 'generic'
+	});
+
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
+	t.strictEqual( actual, -1, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 7, {
+		'dtype': 'generic'
+	});
+
+	actual = gindexOfNotEqual( [ x, searchElement, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1188.

## Description

> What is the purpose of this pull request?

This pull request:

-   add `fromIndex` support to `blas/ext/base/ndarray/gindex-of-not-equal`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1188.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Primarily written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
