### PR TITLE
feat!: add `fromIndex` support to `blas/ext/base/ndarray/ginddex-of-truthy`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/README.md
@@ -42,25 +42,38 @@ Returns the index of the first truthy element in a one-dimensional ndarray.
 
 ```javascript
 var vector = require( '@stdlib/ndarray/vector/ctor' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 
 var x = vector( [ 0.0, 0.0, 3.0, 0.0, 4.0 ], 'generic' );
 
-var idx = gindexOfTruthy( [ x ] );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var idx = gindexOfTruthy( [ x, fromIndex ] );
 // returns 2
 ```
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing a one-dimensional input ndarray.
+-   **arrays**: array-like object containing the following ndarrays:
+
+    -   a one-dimensional input ndarray.
+    -   a zero-dimensional ndarray containing the index from which to begin searching.
 
 If the function is unable to find a truthy element, the function returns `-1`.
 
 ```javascript
 var vector = require( '@stdlib/ndarray/vector/ctor' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 
 var x = vector( [ 0.0, 0.0, 0.0, 0.0 ], 'generic' );
 
-var idx = gindexOfTruthy( [ x ] );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var idx = gindexOfTruthy( [ x, fromIndex ] );
 // returns -1
 ```
 
@@ -73,6 +86,7 @@ var idx = gindexOfTruthy( [ x ] );
 ## Notes
 
 -   The function treats `NaN` values as falsy.
+-   If a specified starting search index is negative, the function resolves the starting search index by counting backward from the last element (where `-1` refers to the last element).
 
 </section>
 
@@ -86,6 +100,7 @@ var idx = gindexOfTruthy( [ x ] );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/discrete-uniform' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var gindexOfTruthy = require( '@stdlib/blas/ext/base/ndarray/gindex-of-truthy' );
 
@@ -96,7 +111,11 @@ var opts = {
 var x = discreteUniform( [ 10 ], 0, 5, opts );
 console.log( ndarray2array( x ) );
 
-var idx = gindexOfTruthy( [ x ] );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var idx = gindexOfTruthy( [ x, fromIndex ] );
 console.log( idx );
 ```
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/benchmark/benchmark.js
@@ -21,9 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var pow = require( '@stdlib/math/base/special/pow' );
-var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var zeros = require( '@stdlib/ndarray/zeros' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gindexOfTruthy = require( './../lib' );
@@ -46,7 +47,13 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = zeros( [ len ], options );
+	var fromIndex;
+	var x;
+
+	x = zeros( [ len ], options );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 	return benchmark;
 
 	/**
@@ -61,7 +68,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			out = gindexOfTruthy( [ x ] );
+			out = gindexOfTruthy( [ x, fromIndex ] );
 			if ( out !== out ) {
 				b.fail( 'should return an integer' );
 			}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/docs/repl.txt
@@ -2,12 +2,20 @@
 {{alias}}( arrays )
     Returns the index of the first truthy element in a one-dimensional ndarray.
 
+    If a specified starting search index is negative, the function resolves the
+    starting search index by counting backward from the last element (where `-1`
+    refers to the last element).
+
     If unable to find a truthy element, the function returns `-1`.
 
     Parameters
     ----------
     arrays: ArrayLikeObject<ndarray>
-        Array-like object containing a one-dimensional input ndarray.
+        Array-like object containing the following ndarrays:
+
+        - a one-dimensional input ndarray.
+        - a zero-dimensional ndarray containing the index from which to begin
+        searching.
 
     Returns
     -------
@@ -17,7 +25,8 @@
     Examples
     --------
     > var x = {{alias:@stdlib/ndarray/vector/ctor}}( [ 0.0, 0.0, 3.0 ], 'generic' );
-    > {{alias}}( [ x ] )
+    > var i = {{alias:@stdlib/ndarray/from-scalar}}( 0, { 'dtype': 'generic' } );
+    > {{alias}}( [ x, i ] )
     2
 
     See Also

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/docs/types/index.d.ts
@@ -25,18 +25,30 @@ import { typedndarray } from '@stdlib/types/ndarray';
 /**
 * Returns the index of the first truthy element in a one-dimensional ndarray.
 *
+* ## Notes
+*
+* -   The function expects the following ndarrays:
+*
+*     -   a one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
+*
 * @param arrays - array-like object containing ndarrays
 * @returns index
 *
 * @example
 * var vector = require( '@stdlib/ndarray/vector/ctor' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 *
 * var x = vector( [ 0.0, 0.0, 3.0, 0.0, 4.0 ], 'generic' );
 *
-* var idx = gindexOfTruthy( [ x ] );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var idx = gindexOfTruthy( [ x, fromIndex ] );
 * // returns 2
 */
-declare function gindexOfTruthy( arrays: [ typedndarray<unknown> ] ): number;
+declare function gindexOfTruthy( arrays: [ typedndarray<unknown>, typedndarray<number> ] ): number;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/docs/types/test.ts
@@ -19,6 +19,7 @@
 /* eslint-disable space-in-parens */
 
 import zeros = require( '@stdlib/ndarray/zeros' );
+import scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 import gindexOfTruthy = require( './index' );
 
 
@@ -29,8 +30,11 @@ import gindexOfTruthy = require( './index' );
 	const x = zeros( [ 10 ], {
 		'dtype': 'generic'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	gindexOfTruthy( [ x ] ); // $ExpectType number
+	gindexOfTruthy( [ x, fromIndex ] ); // $ExpectType number
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
@@ -51,7 +55,10 @@ import gindexOfTruthy = require( './index' );
 	const x = zeros( [ 10 ], {
 		'dtype': 'generic'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	gindexOfTruthy(); // $ExpectError
-	gindexOfTruthy( [ x ], {} ); // $ExpectError
+	gindexOfTruthy( [ x, fromIndex ], {} ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/discrete-uniform' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var gindexOfTruthy = require( './../lib' );
 
@@ -29,5 +30,9 @@ var opts = {
 var x = discreteUniform( [ 10 ], 0, 5, opts );
 console.log( ndarray2array( x ) );
 
-var idx = gindexOfTruthy( [ x ] );
+var fromIndex = scalar2ndarray( 0, {
+	'dtype': 'generic'
+});
+
+var idx = gindexOfTruthy( [ x, fromIndex ] );
 console.log( idx );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/lib/index.js
@@ -25,11 +25,16 @@
 *
 * @example
 * var vector = require( '@stdlib/ndarray/vector/ctor' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var gindexOfTruthy = require( '@stdlib/blas/ext/base/ndarray/gindex-of-truthy' );
 *
 * var x = vector( [ 0.0, 0.0, 3.0, 0.0, 4.0 ], 'generic' );
 *
-* var idx = gindexOfTruthy( [ x ] );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var idx = gindexOfTruthy( [ x, fromIndex ] );
 * // returns 2
 */
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/lib/main.js
@@ -20,10 +20,12 @@
 
 // MODULES //
 
+var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
 var getStride = require( '@stdlib/ndarray/base/stride' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
+var clipIndex = require( '@stdlib/ndarray/base/clip-index' );
 var strided = require( '@stdlib/blas/ext/base/gindex-of-truthy' ).ndarray;
 
 
@@ -37,21 +39,50 @@ var strided = require( '@stdlib/blas/ext/base/gindex-of-truthy' ).ndarray;
 * -   The function expects the following ndarrays:
 *
 *     -   a one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
 * @returns {integer} index
 *
 * @example
 * var vector = require( '@stdlib/ndarray/vector/ctor' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 *
 * var x = vector( [ 0.0, 0.0, 3.0, 0.0, 4.0 ], 'generic' );
 *
-* var idx = gindexOfTruthy( [ x ] );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var idx = gindexOfTruthy( [ x, fromIndex ] );
 * // returns 2
 */
 function gindexOfTruthy( arrays ) {
-	var x = arrays[ 0 ];
-	return strided( numelDimension( x, 0 ), getData( x ), getStride( x, 0 ), getOffset( x ) ); // eslint-disable-line max-len
+	var fromIndex;
+	var stride;
+	var offset;
+	var idx;
+	var N;
+	var x;
+
+	x = arrays[ 0 ];
+	fromIndex = ndarraylike2scalar( arrays[ 1 ] );
+
+	N = numelDimension( x, 0 );
+	fromIndex = clipIndex( fromIndex, N );
+	if ( fromIndex >= N ) {
+		return -1;
+	}
+	N -= fromIndex;
+
+	stride = getStride( x, 0 );
+	offset = getOffset( x ) + ( stride*fromIndex );
+
+	idx = strided( N, getData( x ), stride, offset );
+	if ( idx >= 0 ) {
+		idx += fromIndex;
+	}
+	return idx;
 }
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/test/test.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
 var gindexOfTruthy = require( './../lib' );
 
@@ -50,95 +51,212 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
+tape( 'the function has an arity of 1', function test( t ) {
+	t.strictEqual( gindexOfTruthy.length, 1, 'returns expected value' );
+	t.end();
+});
+
 tape( 'the function returns the index of the first truthy element', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
 	x = vector( [ 0.0, 0.0, 3.0, 0.0, 4.0, 0.0 ], 6, 1, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = gindexOfTruthy( [ x ] );
+	actual = gindexOfTruthy( [ x, fromIndex ] );
 	t.strictEqual( actual, 2, 'returns expected value' );
 
 	x = vector( [ 1.0, 2.0, 3.0 ], 3, 1, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = gindexOfTruthy( [ x ] );
+	actual = gindexOfTruthy( [ x, fromIndex ] );
 	t.strictEqual( actual, 0, 'returns expected value' );
 
 	t.end();
 });
 
+tape( 'the function supports a `fromIndex` parameter (nonnegative)', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+
+	x = vector( [ 1.0, 0.0, 1.0, 0.0, 1.0, 0.0 ], 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	actual = gindexOfTruthy( [ x, fromIndex ] );
+	t.strictEqual( actual, 0, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 1, {
+		'dtype': 'generic'
+	});
+	actual = gindexOfTruthy( [ x, fromIndex ] );
+	t.strictEqual( actual, 2, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
+	actual = gindexOfTruthy( [ x, fromIndex ] );
+	t.strictEqual( actual, 4, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a `fromIndex` parameter (negative)', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+
+	x = vector( [ 0.0, 1.0, 0.0, 1.0, 0.0, 1.0 ], 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( -1, {
+		'dtype': 'generic'
+	});
+	actual = gindexOfTruthy( [ x, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -2, {
+		'dtype': 'generic'
+	});
+	actual = gindexOfTruthy( [ x, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -3, {
+		'dtype': 'generic'
+	});
+	actual = gindexOfTruthy( [ x, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -7, {
+		'dtype': 'generic'
+	});
+	actual = gindexOfTruthy( [ x, fromIndex ] );
+	t.strictEqual( actual, 1, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function returns `-1` if unable to find a truthy element', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
 	x = vector( [ 0.0, 0.0, 0.0, 0.0 ], 4, 1, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = gindexOfTruthy( [ x ] );
+	actual = gindexOfTruthy( [ x, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function ignores falsy elements (e.g., `0`, `NaN`)', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
 	x = vector( [ 0.0, NaN, 5.0, 0.0 ], 4, 1, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = gindexOfTruthy( [ x ] );
+	actual = gindexOfTruthy( [ x, fromIndex ] );
 	t.strictEqual( actual, 2, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having non-unit strides', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
 	x = vector( [ 0.0, 3.0, 0.0, 4.0, 0.0, 5.0 ], 3, 2, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = gindexOfTruthy( [ x ] );
+	actual = gindexOfTruthy( [ x, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	x = vector( [ 3.0, 0.0, 0.0, 4.0, 0.0, 5.0 ], 3, 2, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = gindexOfTruthy( [ x ] );
+	actual = gindexOfTruthy( [ x, fromIndex ] );
 	t.strictEqual( actual, 0, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having negative strides', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
 	x = vector( [ 0.0, 0.0, 3.0, 0.0, 4.0, 0.0 ], 6, -1, 5 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = gindexOfTruthy( [ x ] );
+	actual = gindexOfTruthy( [ x, fromIndex ] );
 	t.strictEqual( actual, 1, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having non-zero offsets', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
 	x = vector( [ 3.0, 0.0, 0.0, 4.0, 0.0, 5.0 ], 3, 1, 1 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = gindexOfTruthy( [ x ] );
+	actual = gindexOfTruthy( [ x, fromIndex ] );
 	t.strictEqual( actual, 2, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `-1` if provided an empty one-dimensional ndarray', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
 	x = vector( [], 0, 1, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = gindexOfTruthy( [ x ] );
+	actual = gindexOfTruthy( [ x, fromIndex ] );
+	t.strictEqual( actual, -1, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `-1` if provided a starting search index which is greater than or equal to number of elements in the input ndarray', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+
+	x = vector( [ 1.0, 0.0, 1.0, 0.0, 1.0, 0.0 ], 6, 1, 0 );
+	fromIndex = scalar2ndarray( 7, {
+		'dtype': 'generic'
+	});
+
+	actual = gindexOfTruthy( [ x, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1189.

## Description

> What is the purpose of this pull request?

This pull request:

-   add `fromIndex` support to `blas/ext/base/ndarray/ginddex-of-truthy`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1189.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Primarily written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
