### PR TITLE
docs: use correct format specifier

### DIFF
--- a/lib/node_modules/@stdlib/fft/base/fftpack/generic/cffti/README.md
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/generic/cffti/README.md
@@ -128,7 +128,7 @@ console.log( 'Sequence length: %d', N );
 
 console.log( 'Twiddle factors:' );
 var idx = zeroTo( 2*N, 'generic' );
-logEach( '  workspace[ %d ] = %d', idx, workspace.slice( 2*N, 4*N ) );
+logEach( '  workspace[ %d ] = %0.4f', idx, workspace.slice( 2*N, 4*N ) );
 
 console.log( 'Factorization:' );
 var nf = workspace[ (4*N)+1 ];

--- a/lib/node_modules/@stdlib/fft/base/fftpack/generic/cffti/examples/index.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/generic/cffti/examples/index.js
@@ -31,7 +31,7 @@ console.log( 'Sequence length: %d', N );
 
 console.log( 'Twiddle factors:' );
 var idx = zeroTo( 2*N, 'generic' );
-logEach( '  workspace[ %d ] = %d', idx, workspace.slice( 2*N, 4*N ) );
+logEach( '  workspace[ %d ] = %0.4f', idx, workspace.slice( 2*N, 4*N ) );
 
 console.log( 'Factorization:' );
 var nf = workspace[ (4*N)+1 ];

--- a/lib/node_modules/@stdlib/fft/base/fftpack/generic/rffti/README.md
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/generic/rffti/README.md
@@ -128,7 +128,7 @@ console.log( 'Sequence length: %d', N );
 
 console.log( 'Twiddle factors:' );
 var idx = zeroTo( N, 'generic' );
-logEach( '  workspace[ %d ] = %d', idx, workspace.slice( N, 2*N ) );
+logEach( '  workspace[ %d ] = %0.4f', idx, workspace.slice( N, 2*N ) );
 
 console.log( 'Factorization:' );
 var nf = workspace[ (2*N)+1 ];

--- a/lib/node_modules/@stdlib/fft/base/fftpack/generic/rffti/examples/index.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/generic/rffti/examples/index.js
@@ -31,7 +31,7 @@ console.log( 'Sequence length: %d', N );
 
 console.log( 'Twiddle factors:' );
 var idx = zeroTo( N, 'generic' );
-logEach( '  workspace[ %d ] = %d', idx, workspace.slice( N, 2*N ) );
+logEach( '  workspace[ %d ] = %0.4f', idx, workspace.slice( N, 2*N ) );
 
 console.log( 'Factorization:' );
 var nf = workspace[ (2*N)+1 ];


### PR DESCRIPTION
Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces the `%d` format specifier by `%0.4f`, to make sure that the twiddle factors (which are not integers) are not printed as zeroes. This is similar to how we have used `%0.4f` in packages such as [`fft/base/fftpack/generic/sinqi`](https://github.com/stdlib-js/stdlib/blob/develop/lib/node_modules/%40stdlib/fft/base/fftpack/generic/sinqi/examples/index.js#L38).
-   fixes this for both [`fft/base/fftpack/generic/rffti`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/fft/base/fftpack/generic/rffti) and [`fft/base/fftpack/generic/cffti`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/fft/base/fftpack/generic/cffti).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

None.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
