### PR TITLE
test: migrate `stats/base/dists/arcsine/entropy` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/entropy/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/entropy/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var entropy = require( './../lib' );
 
 
@@ -72,8 +71,6 @@ tape( 'if provided `a >= b`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function returns the differential entropy of an arcsine distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -84,13 +81,7 @@ tape( 'the function returns the differential entropy of an arcsine distribution'
 	b = data.b;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 12.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 16 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/entropy/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/entropy/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -81,8 +80,6 @@ tape( 'if provided `a >= b`, the function returns `NaN`', opts, function test( t
 
 tape( 'the function returns the differential entropy of an arcsine distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -93,13 +90,7 @@ tape( 'the function returns the differential entropy of an arcsine distribution'
 	b = data.b;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 12.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 16 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `stats/base/dists/arcsine/entropy` test cases from relative-tolerance (`EPS`-based) assertions to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`, per the migration described in #11352.
-   updates both `test/test.js` and `test/test.native.js`, which shared the identical tolerance-based idiom.
-   the tightest ULP bound was determined empirically by running the full fixture set (100 cases) against both the JS and native (C) implementations and measuring the maximum observed ULP difference, which was `16` for both. This value was confirmed to be the minimum passing bound (`15` fails one fixture case) and confirmed deterministic across repeated runs.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, including discovery of the candidate package, the test migration itself, and empirical determination of the tightest ULP bound.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_015CZSWtjhj8L12FVp8EMR8d)_