### PR TITLE
test: migrate `stats/base/dists/poisson/mgf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/poisson/mgf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/poisson/mgf/test/test.factory.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -89,9 +88,7 @@ tape( 'if provided a nonpositive `lambda`, the created function always returns `
 tape( 'the created function evaluates the mgf for `x` given small `lambda` values', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var mgf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -102,13 +99,7 @@ tape( 'the created function evaluates the mgf for `x` given small `lambda` value
 	for ( i = 0; i < x.length; i++ ) {
 		mgf = factory( lambda[i] );
 		y = mgf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. λ: '+lambda[i]+'. y: '+y+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. λ: '+lambda[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -116,9 +107,7 @@ tape( 'the created function evaluates the mgf for `x` given small `lambda` value
 tape( 'the created function evaluates the mgf for `x` given medium `lambda` values', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var mgf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -129,13 +118,7 @@ tape( 'the created function evaluates the mgf for `x` given medium `lambda` valu
 	for ( i = 0; i < x.length; i++ ) {
 		mgf = factory( lambda[i] );
 		y = mgf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. λ: '+lambda[i]+'. y: '+y+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. λ: '+lambda[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -143,9 +126,7 @@ tape( 'the created function evaluates the mgf for `x` given medium `lambda` valu
 tape( 'the created function evaluates the mgf for `x` given large `lambda` values', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var mgf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -156,13 +137,7 @@ tape( 'the created function evaluates the mgf for `x` given large `lambda` value
 	for ( i = 0; i < x.length; i++ ) {
 		mgf = factory( lambda[i] );
 		y = mgf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. λ: '+lambda[i]+'. y: '+y+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. λ: '+lambda[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/poisson/mgf/test/test.mgf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/poisson/mgf/test/test.mgf.js
@@ -21,12 +21,11 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mgf = require( './../lib' );
 
 
@@ -81,8 +80,6 @@ tape( 'the function evaluates the mgf for `t` given a small `lambda`', function 
 	var expected;
 	var lambda;
 	var values;
-	var delta;
-	var tol;
 	var y;
 	var i;
 
@@ -91,13 +88,7 @@ tape( 'the function evaluates the mgf for `t` given a small `lambda`', function 
 	lambda = small.lambda;
 	for ( i = 0; i < values.length; i++ ) {
 		y = mgf( values[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 't: ' + values[ i ] + ', lambda: ' + lambda[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. t: ' + values[ i ] + '. lambda: ' + lambda[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -106,8 +97,6 @@ tape( 'the function evaluates the mgf for `t` given a medium `lambda`', function
 	var expected;
 	var lambda;
 	var values;
-	var delta;
-	var tol;
 	var y;
 	var i;
 
@@ -116,13 +105,7 @@ tape( 'the function evaluates the mgf for `t` given a medium `lambda`', function
 	lambda = medium.lambda;
 	for ( i = 0; i < values.length; i++ ) {
 		y = mgf( values[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 't: ' + values[ i ] + ', lambda: ' + lambda[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. t: ' + values[ i ] + '. lambda: ' + lambda[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -131,8 +114,6 @@ tape( 'the function evaluates the mgf for `t` given a large range `lambda`', fun
 	var expected;
 	var values;
 	var lambda;
-	var delta;
-	var tol;
 	var y;
 	var i;
 
@@ -141,13 +122,7 @@ tape( 'the function evaluates the mgf for `t` given a large range `lambda`', fun
 	lambda = large.lambda;
 	for ( i = 0; i < values.length; i++ ) {
 		y = mgf( values[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 't: ' + values[ i ] + ', lambda: ' + lambda[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. t: ' + values[ i ] + '. lambda: ' + lambda[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/poisson/mgf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/poisson/mgf/test/test.native.js
@@ -22,13 +22,12 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -90,8 +89,6 @@ tape( 'the function evaluates the mgf for `t` given a small `lambda`', opts, fun
 	var expected;
 	var lambda;
 	var values;
-	var delta;
-	var tol;
 	var y;
 	var i;
 
@@ -100,13 +97,7 @@ tape( 'the function evaluates the mgf for `t` given a small `lambda`', opts, fun
 	lambda = small.lambda;
 	for ( i = 0; i < values.length; i++ ) {
 		y = mgf( values[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 't: ' + values[ i ] + ', lambda: ' + lambda[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. t: ' + values[ i ] + '. lambda: ' + lambda[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -115,8 +106,6 @@ tape( 'the function evaluates the mgf for `t` given a medium `lambda`', opts, fu
 	var expected;
 	var lambda;
 	var values;
-	var delta;
-	var tol;
 	var y;
 	var i;
 
@@ -125,13 +114,7 @@ tape( 'the function evaluates the mgf for `t` given a medium `lambda`', opts, fu
 	lambda = medium.lambda;
 	for ( i = 0; i < values.length; i++ ) {
 		y = mgf( values[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 't: ' + values[ i ] + ', lambda: ' + lambda[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. t: ' + values[ i ] + '. lambda: ' + lambda[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -140,8 +123,6 @@ tape( 'the function evaluates the mgf for `t` given a large range `lambda`', opt
 	var expected;
 	var values;
 	var lambda;
-	var delta;
-	var tol;
 	var y;
 	var i;
 
@@ -150,13 +131,7 @@ tape( 'the function evaluates the mgf for `t` given a large range `lambda`', opt
 	lambda = large.lambda;
 	for ( i = 0; i < values.length; i++ ) {
 		y = mgf( values[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 't: ' + values[ i ] + ', lambda: ' + lambda[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. t: ' + values[ i ] + '. lambda: ' + lambda[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `@stdlib/stats/base/dists/poisson/mgf` from relative-tolerance assertions to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per the guidance in #11352.
-   updates `test/test.mgf.js`, `test/test.factory.js`, and `test/test.native.js` to mirror the idiom used in previously converted packages (e.g. `stats/base/dists/normal/mgf`, `stats/base/dists/normal/mean`, `stats/base/dists/weibull/cdf`).
-   replaces the previous `EPS * abs( expected[ i ] )` tolerance loops in all three files with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' )`.
-   drops the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

`test/test.js` only asserts on the main export and the attached `factory` method and thus required no changes.

The tightest ULP bound was determined empirically by measuring, for every fixture value, the minimum `N` for which `isAlmostSameValue( actual, expected, N )` returns `true`, and taking the maximum over the full Julia fixture set (3000 values across the `small`, `medium`, and `large` fixtures):

-   `test/test.mgf.js`: **N = 0 ULP** (measured maximum ULP difference: 0 across all three fixture groups).
-   `test/test.factory.js`: **N = 0 ULP** (measured maximum ULP difference: 0 across all three fixture groups).
-   `test/test.native.js`: **N = 0 ULP**, mirroring the JavaScript bound, consistent with previously merged conversions.

All 3000 fixture values match the Julia reference bit-for-bit, so 0 is both the measured maximum and the tightest bound expressible, and the previous tolerance branch was never taken.

`test/test.js`, `test/test.mgf.js`, and `test/test.factory.js` were each run twice at the final `N = 0` (3, 3008, and 3009 assertions, respectively; all passing) to confirm the bound is deterministic. Linting with the repository's `etc/eslint/.eslintrc.tests.js` configuration is clean for all four test files, and only the three test files are changed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

The native add-on could not be built in the environment used to author this PR, so `test/test.native.js` was exercised in skipped form only and its `N = 0` bound is mirrored from the JavaScript measurement rather than measured against the C implementation. Reviewers may wish to confirm the native tests pass at `N = 0` in an environment with add-ons built. This is the main reason the PR is opened as a draft.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code (Anthropic) running as an unattended scheduled task. The conversion mirrors the exact idiom used in previously merged ULP migrations authored by the PR author (e.g. #14302, #14472), and the ULP bound was measured empirically against the existing Julia fixtures for the JavaScript implementation.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqLxC1CYmvaZzPBjqzzu6o)_