### PR TITLE
test: migrate `math/base/tools/normhermitepoly` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/tools/normhermitepoly/test/test.factory.js
+++ b/lib/node_modules/@stdlib/math/base/tools/normhermitepoly/test/test.factory.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var factory = require( './../lib' ).factory;
 
@@ -67,8 +66,6 @@ tape( 'the function returns a function', function test( t ) {
 
 tape( 'the function returns a function which accurately computes `Hen(x)` for random `n` and `x`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -82,17 +79,13 @@ tape( 'the function returns a function which accurately computes `Hen(x)` for ra
 	for ( i = 0; i < x.length; i++ ) {
 		f = factory( n[ i ] );
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n[ i ] + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He1(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -107,17 +100,13 @@ tape( 'the function returns a function which accurately computes `He1(x)` for sm
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -132,17 +121,13 @@ tape( 'the function accurately computes `He2(x)` for small positive numbers', fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He5(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -157,17 +142,13 @@ tape( 'the function returns a function which accurately computes `He5(x)` for sm
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He1(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -182,17 +163,13 @@ tape( 'the function returns a function which accurately computes `He1(x)` for sm
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He2(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -207,17 +184,13 @@ tape( 'the function returns a function which accurately computes `He2(x)` for sm
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He5(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -232,17 +205,13 @@ tape( 'the function returns a function which accurately computes `He5(x)` for sm
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He1(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -257,17 +226,13 @@ tape( 'the function returns a function which accurately computes `He1(x)` for ti
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He2(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -282,17 +247,13 @@ tape( 'the function returns a function which accurately computes `He2(x)` for ti
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He5(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -307,17 +268,13 @@ tape( 'the function returns a function which accurately computes `He5(x)` for ti
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He1(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -332,17 +289,13 @@ tape( 'the function returns a function which accurately computes `He1(x)` for po
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He2(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -357,17 +310,13 @@ tape( 'the function returns a function which accurately computes `He2(x)` for po
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He5(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -382,17 +331,13 @@ tape( 'the function returns a function which accurately computes `He5(x)` for po
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He1(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -407,17 +352,13 @@ tape( 'the function returns a function which accurately computes `He1(x)` for ne
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He2(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -432,17 +373,13 @@ tape( 'the function returns a function which accurately computes `He2(x)` for ne
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He5(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -457,9 +394,7 @@ tape( 'the function returns a function which accurately computes `He5(x)` for ne
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/tools/normhermitepoly/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/tools/normhermitepoly/test/test.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var normhermitepoly = require( './../lib' );
 
@@ -67,8 +66,6 @@ tape( 'attached to the main export is a `factory` method', function test( t ) {
 
 tape( 'the function accurately computes `Hen(x)` for random `n` and `x`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -80,17 +77,13 @@ tape( 'the function accurately computes `Hen(x)` for random `n` and `x`', functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n[ i ], x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n[ i ] + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He1(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -102,17 +95,13 @@ tape( 'the function accurately computes `He1(x)` for small positive numbers', fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -124,17 +113,13 @@ tape( 'the function accurately computes `He2(x)` for small positive numbers', fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He5(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -146,17 +131,13 @@ tape( 'the function accurately computes `He5(x)` for small positive numbers', fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He1(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -168,17 +149,13 @@ tape( 'the function accurately computes `He1(x)` for small negative numbers', fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -190,17 +167,13 @@ tape( 'the function accurately computes `He2(x)` for small negative numbers', fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He5(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -212,17 +185,13 @@ tape( 'the function accurately computes `He5(x)` for small negative numbers', fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He1(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -234,17 +203,13 @@ tape( 'the function accurately computes `He1(x)` for tiny numbers', function tes
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -256,17 +221,13 @@ tape( 'the function accurately computes `He2(x)` for tiny numbers', function tes
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He5(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -278,17 +239,13 @@ tape( 'the function accurately computes `He5(x)` for tiny numbers', function tes
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He1(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -300,17 +257,13 @@ tape( 'the function accurately computes `He1(x)` for positive medium numbers', f
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -322,17 +275,13 @@ tape( 'the function accurately computes `He2(x)` for positive medium numbers', f
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He5(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -344,17 +293,13 @@ tape( 'the function accurately computes `He5(x)` for positive medium numbers', f
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He1(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -366,17 +311,13 @@ tape( 'the function accurately computes `He1(x)` for negative medium numbers', f
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -388,17 +329,13 @@ tape( 'the function accurately computes `He2(x)` for negative medium numbers', f
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He5(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -410,9 +347,7 @@ tape( 'the function accurately computes `He5(x)` for negative medium numbers', f
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/tools/normhermitepoly` from relative-tolerance assertions (`delta <= tol`, with `delta = abs( v - expected[ i ] )` and `tol = EPS * abs( expected[ i ] )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the same migration to both `test/test.js` and `test/test.factory.js` (16 fixture blocks in each).
-   preserves all existing test cases, structure, and non-tolerance assertions (e.g., the special-case values for `n = 0`, `NaN` inputs, negative integer `n`, and non-integer `n`).

The minimum ULP bound used per fixture block (identical for `test.js` and `test.factory.js`) is:

| Fixture block                                          | ULP |
| ------------------------------------------------------ | :-: |
| `random2` (random `n` and `x`)                          |  0  |
| `small_positive_{1,2,5}`                                |  0  |
| `small_negative_{1,2,5}`                                |  0  |
| `tiny_{1,2,5}`                                          |  0  |
| `medium_positive_{1,2,5}`                               |  0  |
| `medium_negative_{1,2,5}`                               |  0  |

Each ULP value is the minimum integer `N` such that `isAlmostSameValue( actual, expected, N )` holds for every fixture entry in that block. Starting from `N = 64` and tightening, every one of the 16,000 fixture values per file is bit-for-bit identical to the expected value, so `0` is the measured minimum (and the floor). This is expected here: the implementation evaluates the probabilists' Hermite recurrence using only IEEE 754 double-precision addition, subtraction, and multiplication, all of which are exactly specified by the ECMAScript standard, so results are bit-reproducible across engines and architectures. There is no C implementation for this package and therefore no `test/test.native.js` to migrate.

Tests were run twice at the final `N` to confirm deterministic passing (32,020 assertions, all passing on both runs). Linting was checked before and after the change and is unchanged (the pre-existing reports are identical in count and rule breakdown), and the only files changed are the two test files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code: the assistant mechanically converted the tolerance-based assertions to `isAlmostSameValue`, agentically searched for the minimum ULP bound per fixture block, verified determinism across two full runs, and ran the local lint and test suites before submitting.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNZw1dA5vqEcTShZYjkq6A)_