### PR TITLE
docs: add Git note

### DIFF
--- a/docs/git-notes/5e0c6b9cec22a1ae63b53f0f4d866f04478be7ef.txt
+++ b/docs/git-notes/5e0c6b9cec22a1ae63b53f0f4d866f04478be7ef.txt
@@ -1,0 +1,14 @@
+---
+type: amend-message
+---
+feat!: add `fromIndex` support to `blas/ext/base/ndarray/cindex-of-truthy`
+
+BREAKING CHANGE: add `fromIndex` support
+
+To maintain previous behavior, provide a zero-dimensional ndarray containing the value `0`.
+
+PR-URL: https://github.com/stdlib-js/stdlib/pull/14405
+Co-authored-by: Athan Reines <kgryte@gmail.com>
+Reviewed-by: Athan Reines <kgryte@gmail.com>
+Signed-off-by: Athan Reines <kgryte@gmail.com>
+Closes: https://github.com/stdlib-js/metr-issue-tracker/issues/1172


### PR DESCRIPTION
Resolves stdlib-js/todo#2811.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds a Git note (`docs/git-notes/5e0c6b9cec22a1ae63b53f0f4d866f04478be7ef.txt`, `type: amend-message`) amending the commit message of 5e0c6b9cec22a1ae63b53f0f4d866f04478be7ef to use a `feat!` header instead of `feat`, as the commit includes a `BREAKING CHANGE` footer. The amended message is otherwise identical to the original (all body text and trailers preserved; a stray trailing space after the `Reviewed-by` trailer is removed). The sibling commits from the same change series (e.g., f4274318b, fb7d2761f) already use `feat!`.

## Related Issues

> Does this pull request have any related issues?

This pull request does not have any related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   The note file matches the exact format produced by the `git_note_amend_message` workflow (`.github/workflows/git_note_amend_message.yml`) and the existing `amend-message` notes in `docs/git-notes/`.
-   Verified locally that `make apply-git-notes` applies the note cleanly and that `git notes show 5e0c6b9cec22a1ae63b53f0f4d866f04478be7ef` returns the amended `feat!` message.
-   No semver reclassification results from this change: the original commit already carries a `BREAKING CHANGE:` footer, so this note normalizes the header for consistency.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored entirely by Claude Code as part of an automated issue-resolution run: it researched the repository's Git-note conventions, generated the note file, and verified it against the `apply-git-notes` tooling.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Zas6RyAAjNixR8uu7nLtr

---
_Generated by [Claude Code](https://claude.ai/code/session_017Zas6RyAAjNixR8uu7nLtr)_