### PR TITLE
docs: add Git notes

### DIFF
--- a/docs/git-notes/c04a8bc15913cb8d3130e255eea3078a82276e4e.txt
+++ b/docs/git-notes/c04a8bc15913cb8d3130e255eea3078a82276e4e.txt
@@ -1,0 +1,14 @@
+---
+type: amend-message
+---
+remove: remove `utils/any-own-by`
+
+This commit removes `@stdlib/utils/any-own-by` in favor of
+`@stdlib/object/any-own-by`.
+
+BREAKING CHANGE: remove `utils/any-own-by`
+
+To migrate, users should update their require/import paths to use
+`@stdlib/object/any-own-by` which provides the same API and implementation.
+
+Ref: https://github.com/stdlib-js/stdlib/issues/6756

--- a/docs/git-notes/e3ff363a73067533e3479ba237d8e3d1cd76c45b.txt
+++ b/docs/git-notes/e3ff363a73067533e3479ba237d8e3d1cd76c45b.txt
@@ -1,0 +1,14 @@
+---
+type: amend-message
+---
+remove: remove `anyOwnBy` from namespace
+
+This commit removes the `anyOwnBy` symbol from the `@stdlib/utils`
+namespace due to a package migration.
+
+BREAKING CHANGE: remove `anyOwnBy`
+
+To migrate, users should access the same symbol via the
+`@stdlib/object` namespace.
+
+Ref: https://github.com/stdlib-js/stdlib/issues/6756


### PR DESCRIPTION
Resolves stdlib-js/todo#2682.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds a Git note (`type: amend-message`) for commit e3ff363a73067533e3479ba237d8e3d1cd76c45b, whose message referred to the removed namespace symbol by the package name `` `any-own-by` `` instead of the symbol name `` `anyOwnBy` `` (in the subject, body, and `BREAKING CHANGE` line)
-   adds a Git note (`type: amend-message`) for commit c04a8bc15913cb8d3130e255eea3078a82276e4e, whose message contained the typo `` `@stdlib/objects/any-own-by` `` instead of `` `@stdlib/object/any-own-by` `` in the migration instructions

Both corrected messages are taken verbatim from the maintainer's review comments on the original pull request:

-   https://github.com/stdlib-js/stdlib/pull/8658#issuecomment-3594907539
-   https://github.com/stdlib-js/stdlib/pull/8658#issuecomment-3594913359

The note files follow the exact format produced by the `git_note_amend_message.yml` workflow and consumed by `make apply-git-notes` and the changelog tooling.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   stdlib-js/todo#2682
-   #8658 (the pull request whose merged commit messages are amended)
-   #6756 (the migration issue referenced by the amended commits)

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   The amended commits are the rebase-merged copies on `develop` (committer date equal to PR #8658's merge time), not the pre-rebase pull-request branch SHAs.
-   Verified that `git notes add -f -F <file> <hash>` (the exact command run by `make apply-git-notes`) applies both notes cleanly, and that the changelog parser's front-matter extraction yields exactly the corrected messages. A diff of original vs. amended messages shows only the intended corrections (three lines in the first commit, one line in the second).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored entirely by Claude Code, run as a scheduled automation on behalf of Philipp Burckhardt: it identified the target commits on `develop`, created the note files from the maintainer's corrected messages verbatim, and verified format and applicability against the repository's Git-notes tooling.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqU92c7mMD1615k6QcSmBq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqU92c7mMD1615k6QcSmBq)_