### PR TITLE
docs: add Git note

### DIFF
--- a/docs/git-notes/31c168c72351f2885bcf7361b9168cefb454f6dc.txt
+++ b/docs/git-notes/31c168c72351f2885bcf7361b9168cefb454f6dc.txt
@@ -1,0 +1,10 @@
+---
+type: amend-message
+---
+fix: add missing `f` suffix in `constants/float32/ln-two`
+
+PR-URL: https://github.com/stdlib-js/stdlib/pull/3110
+Ref: https://github.com/stdlib-js/stdlib/commit/893cb1b86ececb01085118705c19a842f70da511#r149027862
+Private-ref: https://github.com/stdlib-js/todo/issues/2288
+Reviewed-by: Athan Reines <kgryte@gmail.com>
+Signed-off-by: Gunj Joshi <gunjjoshi8372@gmail.com>


### PR DESCRIPTION
Closes: https://github.com/stdlib-js/todo/issues/2295

## Description

> What is the purpose of this pull request?

This pull request:

-   adds a Git note (`docs/git-notes/31c168c72351f2885bcf7361b9168cefb454f6dc.txt`) of type `amend-message` which touches up the message of commit [`31c168c`](https://github.com/stdlib-js/stdlib/commit/31c168c72351f2885bcf7361b9168cefb454f6dc) by replacing the `Closes:` token with `Private-ref:` for the reference to `https://github.com/stdlib-js/todo/issues/2288`. Per the [Git style guide](https://github.com/stdlib-js/stdlib/blob/develop/docs/style-guides/git/README.md), `Private-ref:` is the token reserved for links to private resources, and `stdlib-js/todo` is a private tracker. The rest of the commit message is reproduced verbatim (byte-identical), since the `amend-message` note type replaces the entire message when applied via `make apply-git-notes`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Private-ref: https://github.com/stdlib-js/todo/issues/2295 (the request for this Git note)
-   Private-ref: https://github.com/stdlib-js/todo/issues/2288 (the issue referenced by the amended commit message)

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Verification performed: the note body was diffed byte-for-byte against the original commit message (recovered from the commit's `.patch` endpoint, since the API strips trailer e-mail addresses; addresses cross-checked against `CONTRIBUTORS`) — the only difference is `Closes:` → `Private-ref:`. The note was applied in a scratch repository using the exact command form from `tools/make/lib/git/notes.mk` and re-extracted through the front-matter convention used by `@stdlib/_tools/changelog/parse-commits`; the resulting message is exactly the corrected one. The file format is byte-identical to what the `git_note_amend_message.yml` workflow would generate.
-   Generated changelog output is unchanged by this note: the URL-form `Closes:` reference was already excluded from the "Closed Issues" section (`closed_issues.js` requires a digit-string ref), so the effect of this change is style-guide conformance of the effective commit message and removal of a malformed mention (`.../stdlib/issues/https://github.com/stdlib-js/todo/issues/2288`) from the parsed commit model.
-   Observations for possible follow-ups (out of scope here): eleven 2026 `docs:`/`chore: add Git note …` meta-commits also use `Closes:` with private `stdlib-js/todo` URLs; three existing note files (`7fd86dd7…`, `8a0bdab1…`, `bacbb9b2…`) contain a second appended YAML document which the parser splices into the amended message; `apply-git-notes` exits 0 even when a note's commit hash does not resolve (`|| echo`), so a typo'd note filename would be a silent permanent no-op; and `docs/git-notes/` files have no semantic validation (hash resolvability, front-matter schema, message fidelity) in CI.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code: it researched the repository's Git-notes mechanism and style guide, authored the note file, and verified the result against the changelog tooling.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mv7vcSu2fiuMLniVQxBV1Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mv7vcSu2fiuMLniVQxBV1Z)_