### PR TITLE
fix: add missing arguments to `format` calls

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/count-if/lib/validate.js
+++ b/lib/node_modules/@stdlib/ndarray/count-if/lib/validate.js
@@ -77,7 +77,7 @@ function validate( opts, ndims, options ) {
 			return new Error( format( 'invalid option. `%s` option contains duplicate indices. Option: [%s].', 'dims', join( opts.dims, ',' ) ) );
 		}
 		if ( tmp.length > ndims ) {
-			return new RangeError( format( 'invalid option. `%s` option specifies more dimensions than exists in the input array. Number of dimensions: %d. Option: [%s].', ndims, join( opts.dims, ',' ) ) );
+			return new RangeError( format( 'invalid option. `%s` option specifies more dimensions than exists in the input array. Number of dimensions: %d. Option: [%s].', 'dims', ndims, join( opts.dims, ',' ) ) );
 		}
 		opts.dims = tmp;
 	}

--- a/lib/node_modules/@stdlib/stats/binomial-test/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/binomial-test/lib/main.js
@@ -123,7 +123,7 @@ function binomialTest() {
 			throw new TypeError( format( 'invalid argument. Must provide a nonnegative integer. Value: `%s`.', n ) );
 		}
 		if ( x > n ) {
-			throw new TypeError( format( 'invalid arguments. Number of successes cannot be larger than the total number of observations. x: `%u`. n: `%u`.' ) );
+			throw new TypeError( format( 'invalid arguments. Number of successes cannot be larger than the total number of observations. x: `%u`. n: `%u`.', x, n ) );
 		}
 		if ( arguments[ 2 ] ) {
 			err = validate( opts, arguments[ 2 ] );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes a `format` call in `ndarray/count-if` in which the format string expects three arguments (`%s`, `%d`, `%s`), but only two were provided, resulting in a malformed error message (the option name was omitted and subsequent arguments shifted).
-   fixes a `format` call in `stats/binomial-test` in which the format string expects two arguments (`%u`, `%u`), but none were provided, resulting in an error message with uninterpolated placeholders.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

These bugs were discovered while developing an ESLint rule which verifies that `string/format` calls are provided an expected number of arguments (proposed in #14518).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code under my direction and instructions; the bugs were detected via a prototype of the lint rule proposed in #14518.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)