### PR TITLE
chore: remove unnecessary `format` calls

### DIFF
--- a/lib/node_modules/@stdlib/array/mskfilter/lib/main.js
+++ b/lib/node_modules/@stdlib/array/mskfilter/lib/main.js
@@ -65,7 +65,7 @@ function mskfilter( x, mask ) {
 		throw new TypeError( format( 'invalid argument. Second argument must be an array-like object. Value: `%s`.', mask ) );
 	}
 	if ( x.length !== mask.length ) {
-		throw new Error( format( 'invalid arguments. Must provide equal length array-like objects.' ) );
+		throw new Error( 'invalid arguments. Must provide equal length array-like objects.' );
 	}
 	dt = dtype( x );
 	if ( dt === 'generic' || dt === null ) {

--- a/lib/node_modules/@stdlib/array/mskreject/lib/main.js
+++ b/lib/node_modules/@stdlib/array/mskreject/lib/main.js
@@ -65,7 +65,7 @@ function mskreject( x, mask ) {
 		throw new TypeError( format( 'invalid argument. Second argument must be an array-like object. Value: `%s`.', mask ) );
 	}
 	if ( x.length !== mask.length ) {
-		throw new Error( format( 'invalid arguments. Must provide equal length array-like objects.' ) );
+		throw new Error( 'invalid arguments. Must provide equal length array-like objects.' );
 	}
 	dt = dtype( x );
 	if ( dt === 'generic' || dt === null ) {

--- a/lib/node_modules/@stdlib/array/struct-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/struct-factory/lib/main.js
@@ -208,7 +208,7 @@ function factory( arg ) { // eslint-disable-line stdlib/jsdoc-require-throws-tag
 				len = arg.length;
 				buf = fromArray( Struct, new ArrayBuffer( len*BYTES_PER_ELEMENT ), arg );
 				if ( buf === null ) {
-					throw new TypeError( format( 'invalid argument. Each element of a provided input array must be a valid object or a struct instance having the same layout as elements in the desired output array.' ) );
+					throw new TypeError( 'invalid argument. Each element of a provided input array must be a valid object or a struct instance having the same layout as elements in the desired output array.' );
 				}
 			}
 			// Case: new StructArray( ArrayBuffer )
@@ -235,7 +235,7 @@ function factory( arg ) { // eslint-disable-line stdlib/jsdoc-require-throws-tag
 				len = tmp.length;
 				buf = fromArray( Struct, new ArrayBuffer( len*BYTES_PER_ELEMENT ), tmp );
 				if ( buf === null ) {
-					throw new TypeError( format( 'invalid argument. Each element of a provided input iterable must be either a valid object or a struct instance having the same layout as elements in the desired output array.' ) );
+					throw new TypeError( 'invalid argument. Each element of a provided input iterable must be either a valid object or a struct instance having the same layout as elements in the desired output array.' );
 				}
 			}
 			// Case: new StructArray( ???? )

--- a/lib/node_modules/@stdlib/array/to-fancy/lib/prop2slice.js
+++ b/lib/node_modules/@stdlib/array/to-fancy/lib/prop2slice.js
@@ -122,7 +122,7 @@ function parseSubsequence( raw, str, max, strict ) {
 		// NOTE: the following error check must come last due to fall-through when in non-strict mode...
 		if ( s.code === 'ERR_SLICE_OUT_OF_BOUNDS' ) {
 			if ( strict ) {
-				throw new RangeError( format( 'invalid operation. Slice exceeds array bounds.' ) );
+				throw new RangeError( 'invalid operation. Slice exceeds array bounds.' );
 			}
 			// Repeat parsing, this time allowing for out-of-bounds slices:
 			s = seq2slice( str, max, false );

--- a/lib/node_modules/@stdlib/array/to-fancy/lib/resolve_index.js
+++ b/lib/node_modules/@stdlib/array/to-fancy/lib/resolve_index.js
@@ -21,7 +21,6 @@
 // MODULES //
 
 var normalizeIndex = require( '@stdlib/ndarray/base/normalize-index' );
-var format = require( '@stdlib/string/format' );
 
 
 // MAIN //
@@ -52,7 +51,7 @@ function resolveIndex( str, max, strict ) {
 	i = normalizeIndex( idx, max-1 );
 	if ( i === -1 ) {
 		if ( strict ) {
-			throw new RangeError( format( 'invalid operation. Index exceeds array bounds.' ) );
+			throw new RangeError( 'invalid operation. Index exceeds array bounds.' );
 		}
 		// Return the non-normalized index, as this should fallback to default property handling and returning "undefined":
 		return idx;

--- a/lib/node_modules/@stdlib/blas/ddot/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ddot/lib/main.js
@@ -96,10 +96,10 @@ function ddot( x, y ) {
 
 	// Validate that we've been provided non-zero-dimensional arrays...
 	if ( xsh.length < 1 ) {
-		throw new TypeError( format( 'invalid argument. First argument must have at least one dimension.' ) );
+		throw new TypeError( 'invalid argument. First argument must have at least one dimension.' );
 	}
 	if ( ysh.length < 1 ) {
-		throw new TypeError( format( 'invalid argument. Second argument must have at least one dimension.' ) );
+		throw new TypeError( 'invalid argument. Second argument must have at least one dimension.' );
 	}
 	// Validate that the dimension argument is a negative integer...
 	if ( arguments.length > 2 ) {

--- a/lib/node_modules/@stdlib/blas/ext/cusum/lib/assign.js
+++ b/lib/node_modules/@stdlib/blas/ext/cusum/lib/assign.js
@@ -114,7 +114,7 @@ function assign( x ) {
 			if ( isndarrayLike( v ) ) {
 				// As the operation is performed across all dimensions, `v` is assumed to be a zero-dimensional ndarray...
 				if ( ndims( v ) !== 0 ) {
-					throw new TypeError( format( 'invalid argument. Second argument must be a zero-dimensional ndarray.' ) );
+					throw new TypeError( 'invalid argument. Second argument must be a zero-dimensional ndarray.' );
 				}
 				return base( x, v, out );
 			}
@@ -142,7 +142,7 @@ function assign( x ) {
 		if ( hasOwnProp( opts, 'dims' ) ) {
 			v = maybeBroadcastArray( v, nonCoreShape( getShape( x ), opts.dims ) ); // eslint-disable-line max-len
 		} else if ( ndims( v ) !== 0 ) {
-			throw new TypeError( format( 'invalid argument. Second argument must be a zero-dimensional ndarray.' ) );
+			throw new TypeError( 'invalid argument. Second argument must be a zero-dimensional ndarray.' );
 		}
 	}
 	// Case: assign( x, initial_scalar, out, opts )

--- a/lib/node_modules/@stdlib/blas/ext/cusum/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/cusum/lib/main.js
@@ -102,7 +102,7 @@ function cusum( x ) {
 		if ( isndarrayLike( v ) ) {
 			// As the operation is performed across all dimensions, `v` must be a zero-dimensional ndarray...
 			if ( ndims( v ) !== 0 ) {
-				throw new TypeError( format( 'invalid argument. Second argument must be a zero-dimensional ndarray.' ) );
+				throw new TypeError( 'invalid argument. Second argument must be a zero-dimensional ndarray.' );
 			}
 			return base( x, v );
 		}
@@ -126,7 +126,7 @@ function cusum( x ) {
 		if ( hasOwnProp( opts, 'dims' ) ) {
 			v = maybeBroadcastArray( v, nonCoreShape( getShape( x ), opts.dims ) ); // eslint-disable-line max-len
 		} else if ( ndims( v ) !== 0 ) {
-			throw new TypeError( format( 'invalid argument. Second argument must be a zero-dimensional ndarray.' ) );
+			throw new TypeError( 'invalid argument. Second argument must be a zero-dimensional ndarray.' );
 		}
 	}
 	// Case: cusum( x, initial_scalar, opts )

--- a/lib/node_modules/@stdlib/blas/sdot/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/sdot/lib/main.js
@@ -96,10 +96,10 @@ function sdot( x, y ) {
 
 	// Validate that we've been provided non-zero-dimensional arrays...
 	if ( xsh.length < 1 ) {
-		throw new TypeError( format( 'invalid argument. First argument must have at least one dimension.' ) );
+		throw new TypeError( 'invalid argument. First argument must have at least one dimension.' );
 	}
 	if ( ysh.length < 1 ) {
-		throw new TypeError( format( 'invalid argument. Second argument must have at least one dimension.' ) );
+		throw new TypeError( 'invalid argument. Second argument must have at least one dimension.' );
 	}
 	// Validate that the dimension argument is a negative integer...
 	if ( arguments.length > 2 ) {

--- a/lib/node_modules/@stdlib/blas/tools/swap-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/tools/swap-factory/lib/main.js
@@ -136,10 +136,10 @@ function factory( base, dtype ) {
 
 		// Validate that we've been provided non-zero-dimensional arrays...
 		if ( xsh.length < 1 ) {
-			throw new TypeError( format( 'invalid argument. First argument must have at least one dimension.' ) );
+			throw new TypeError( 'invalid argument. First argument must have at least one dimension.' );
 		}
 		if ( ysh.length < 1 ) {
-			throw new TypeError( format( 'invalid argument. Second argument must have at least one dimension.' ) );
+			throw new TypeError( 'invalid argument. Second argument must have at least one dimension.' );
 		}
 		// Validate that the arrays have the same shape...
 		if ( !hasEqualValues( xsh, ysh ) ) {

--- a/lib/node_modules/@stdlib/ndarray/base/binary-reduce-strided1d-dispatch/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/binary-reduce-strided1d-dispatch/lib/main.js
@@ -128,13 +128,13 @@ function BinaryStrided1dDispatch( table, idtypes, odtypes, policies ) {
 		throw new TypeError( format( 'invalid argument. First argument must be an object. Value: `%s`.', table ) );
 	}
 	if ( !isFunction( table.default ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must be an object having a "default" property and an associated method.' ) );
+		throw new TypeError( 'invalid argument. First argument must be an object having a "default" property and an associated method.' );
 	}
 	if ( hasProp( table, 'types' ) && !isCollection( table.types ) && !isEmptyCollection( table.types ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must be an object having a "types" property whose associated value is an array-like object.' ) );
+		throw new TypeError( 'invalid argument. First argument must be an object having a "types" property whose associated value is an array-like object.' );
 	}
 	if ( hasProp( table, 'fcns' ) && !isFunctionArray( table.fcns ) && !isEmptyCollection( table.fcns ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must be an object having a "fcns" property whose associated value is an array-like object containing functions.' ) );
+		throw new TypeError( 'invalid argument. First argument must be an object having a "fcns" property whose associated value is an array-like object containing functions.' );
 	}
 	if ( !isCollection( idtypes ) ) {
 		throw new TypeError( format( 'invalid argument. Second argument must be an array-like object. Value: `%s`.', idtypes ) );

--- a/lib/node_modules/@stdlib/ndarray/base/every/scripts/predicate_loops.js
+++ b/lib/node_modules/@stdlib/ndarray/base/every/scripts/predicate_loops.js
@@ -347,7 +347,7 @@ function createSourceFile( signature ) {
 			tmp = format( 'f( (%s)v )', ct1 );
 		}
 	} else { // e.g., c, z, f, d, b, etc
-		tmp = format( 'f( v )' );
+		tmp = 'f( v )';
 	}
 	file = replace( file, '{{CALLBACK_EXPRESSION_0D}}', tmp );
 

--- a/lib/node_modules/@stdlib/ndarray/base/nullary-strided1d-dispatch/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nullary-strided1d-dispatch/lib/main.js
@@ -110,13 +110,13 @@ function NullaryStrided1dDispatch( table, idtypes, odtypes, options ) {
 		throw new TypeError( format( 'invalid argument. First argument must be an object. Value: `%s`.', table ) );
 	}
 	if ( !isFunction( table.default ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must be an object having a "default" property and an associated method.' ) );
+		throw new TypeError( 'invalid argument. First argument must be an object having a "default" property and an associated method.' );
 	}
 	if ( hasProp( table, 'types' ) && !isCollection( table.types ) && !isEmptyCollection( table.types ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must be an object having a "types" property whose associated value is an array-like object.' ) );
+		throw new TypeError( 'invalid argument. First argument must be an object having a "types" property whose associated value is an array-like object.' );
 	}
 	if ( hasProp( table, 'fcns' ) && !isFunctionArray( table.fcns ) && !isEmptyCollection( table.fcns ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must be an object having a "fcns" property whose associated value is an array-like object containing functions.' ) );
+		throw new TypeError( 'invalid argument. First argument must be an object having a "fcns" property whose associated value is an array-like object containing functions.' );
 	}
 	if ( !isCollection( idtypes ) ) {
 		throw new TypeError( format( 'invalid argument. Second argument must be an array-like object. Value: `%s`.', idtypes ) );

--- a/lib/node_modules/@stdlib/ndarray/base/nullary/scripts/loops.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nullary/scripts/loops.js
@@ -561,7 +561,7 @@ function createSourceFile( signature ) {
 			tmp = format( '(%s)f()', dtype2c( t1 ) );
 		}
 	} else { // e.g., c, z, f, d, b, etc
-		tmp = format( 'f()' );
+		tmp = 'f()';
 	}
 	file = replace( file, '{{CALLBACK_EXPRESSION_0D}}', tmp );
 

--- a/lib/node_modules/@stdlib/ndarray/base/unary-reduce-strided1d-dispatch-by/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary-reduce-strided1d-dispatch-by/lib/main.js
@@ -126,13 +126,13 @@ function UnaryStrided1dDispatchBy( table, idtypes, odtypes, policies ) {
 		throw new TypeError( format( 'invalid argument. First argument must be an object. Value: `%s`.', table ) );
 	}
 	if ( !isFunction( table.default ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must be an object having a "default" property and an associated method.' ) );
+		throw new TypeError( 'invalid argument. First argument must be an object having a "default" property and an associated method.' );
 	}
 	if ( hasProp( table, 'types' ) && !isCollection( table.types ) && !isEmptyCollection( table.types ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must be an object having a "types" property whose associated value is an array-like object.' ) );
+		throw new TypeError( 'invalid argument. First argument must be an object having a "types" property whose associated value is an array-like object.' );
 	}
 	if ( hasProp( table, 'fcns' ) && !isFunctionArray( table.fcns ) && !isEmptyCollection( table.fcns ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must be an object having a "fcns" property whose associated value is an array-like object containing functions.' ) );
+		throw new TypeError( 'invalid argument. First argument must be an object having a "fcns" property whose associated value is an array-like object containing functions.' );
 	}
 	if ( !isCollection( idtypes ) ) {
 		throw new TypeError( format( 'invalid argument. Second argument must be an array-like object. Value: `%s`.', idtypes ) );

--- a/lib/node_modules/@stdlib/ndarray/base/unary-reduce-strided1d-dispatch/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary-reduce-strided1d-dispatch/lib/main.js
@@ -122,13 +122,13 @@ function UnaryStrided1dDispatch( table, idtypes, odtypes, policies ) {
 		throw new TypeError( format( 'invalid argument. First argument must be an object. Value: `%s`.', table ) );
 	}
 	if ( !isFunction( table.default ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must be an object having a "default" property and an associated method.' ) );
+		throw new TypeError( 'invalid argument. First argument must be an object having a "default" property and an associated method.' );
 	}
 	if ( hasProp( table, 'types' ) && !isCollection( table.types ) && !isEmptyCollection( table.types ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must be an object having a "types" property whose associated value is an array-like object.' ) );
+		throw new TypeError( 'invalid argument. First argument must be an object having a "types" property whose associated value is an array-like object.' );
 	}
 	if ( hasProp( table, 'fcns' ) && !isFunctionArray( table.fcns ) && !isEmptyCollection( table.fcns ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must be an object having a "fcns" property whose associated value is an array-like object containing functions.' ) );
+		throw new TypeError( 'invalid argument. First argument must be an object having a "fcns" property whose associated value is an array-like object containing functions.' );
 	}
 	if ( !isCollection( idtypes ) ) {
 		throw new TypeError( format( 'invalid argument. Second argument must be an array-like object. Value: `%s`.', idtypes ) );

--- a/lib/node_modules/@stdlib/ndarray/base/unary-strided1d-dispatch/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary-strided1d-dispatch/lib/main.js
@@ -127,13 +127,13 @@ function UnaryStrided1dDispatch( table, idtypes, odtypes, policies, options ) {
 		throw new TypeError( format( 'invalid argument. First argument must be an object. Value: `%s`.', table ) );
 	}
 	if ( !isFunction( table.default ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must be an object having a "default" property and an associated method.' ) );
+		throw new TypeError( 'invalid argument. First argument must be an object having a "default" property and an associated method.' );
 	}
 	if ( hasProp( table, 'types' ) && !isCollection( table.types ) && !isEmptyCollection( table.types ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must be an object having a "types" property whose associated value is an array-like object.' ) );
+		throw new TypeError( 'invalid argument. First argument must be an object having a "types" property whose associated value is an array-like object.' );
 	}
 	if ( hasProp( table, 'fcns' ) && !isFunctionArray( table.fcns ) && !isEmptyCollection( table.fcns ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must be an object having a "fcns" property whose associated value is an array-like object containing functions.' ) );
+		throw new TypeError( 'invalid argument. First argument must be an object having a "fcns" property whose associated value is an array-like object containing functions.' );
 	}
 	if ( !isCollection( idtypes ) ) {
 		throw new TypeError( format( 'invalid argument. Second argument must be an array-like object. Value: `%s`.', idtypes ) );

--- a/lib/node_modules/@stdlib/ndarray/iter/column-entries/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/column-entries/lib/main.js
@@ -110,7 +110,7 @@ function nditerColumnEntries( x ) {
 			}
 			opts.writable = !options.readonly;
 			if ( opts.writable && isReadOnly( x ) ) {
-				throw new Error( format( 'invalid option. Cannot write to read-only array.' ) );
+				throw new Error( 'invalid option. Cannot write to read-only array.' );
 			}
 		}
 	}

--- a/lib/node_modules/@stdlib/ndarray/iter/columns/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/columns/lib/main.js
@@ -110,7 +110,7 @@ function nditerColumns( x ) {
 			}
 			opts.writable = !options.readonly;
 			if ( opts.writable && isReadOnly( x ) ) {
-				throw new Error( format( 'invalid option. Cannot write to read-only array.' ) );
+				throw new Error( 'invalid option. Cannot write to read-only array.' );
 			}
 		}
 	}

--- a/lib/node_modules/@stdlib/ndarray/iter/matrices/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/matrices/lib/main.js
@@ -104,7 +104,7 @@ function nditerMatrices( x ) {
 			}
 			opts.writable = !options.readonly;
 			if ( opts.writable && isReadOnly( x ) ) {
-				throw new Error( format( 'invalid option. Cannot write to read-only array.' ) );
+				throw new Error( 'invalid option. Cannot write to read-only array.' );
 			}
 		}
 	}

--- a/lib/node_modules/@stdlib/ndarray/iter/matrix-entries/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/matrix-entries/lib/main.js
@@ -110,7 +110,7 @@ function nditerMatrixEntries( x ) {
 			}
 			opts.writable = !options.readonly;
 			if ( opts.writable && isReadOnly( x ) ) {
-				throw new Error( format( 'invalid option. Cannot write to read-only array.' ) );
+				throw new Error( 'invalid option. Cannot write to read-only array.' );
 			}
 		}
 	}

--- a/lib/node_modules/@stdlib/ndarray/iter/row-entries/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/row-entries/lib/main.js
@@ -110,7 +110,7 @@ function nditerRowEntries( x ) {
 			}
 			opts.writable = !options.readonly;
 			if ( opts.writable && isReadOnly( x ) ) {
-				throw new Error( format( 'invalid option. Cannot write to read-only array.' ) );
+				throw new Error( 'invalid option. Cannot write to read-only array.' );
 			}
 		}
 	}

--- a/lib/node_modules/@stdlib/ndarray/iter/rows/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/rows/lib/main.js
@@ -110,7 +110,7 @@ function nditerRows( x ) {
 			}
 			opts.writable = !options.readonly;
 			if ( opts.writable && isReadOnly( x ) ) {
-				throw new Error( format( 'invalid option. Cannot write to read-only array.' ) );
+				throw new Error( 'invalid option. Cannot write to read-only array.' );
 			}
 		}
 	}

--- a/lib/node_modules/@stdlib/ndarray/iter/select-dimension/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/select-dimension/lib/main.js
@@ -112,7 +112,7 @@ function nditerSelectDimension( x, dim ) {
 			}
 			opts.writable = !options.readonly;
 			if ( opts.writable && isReadOnly( x ) ) {
-				throw new Error( format( 'invalid option. Cannot write to read-only array.' ) );
+				throw new Error( 'invalid option. Cannot write to read-only array.' );
 			}
 		}
 		if ( hasOwnProp( options, 'keepdim' ) ) {

--- a/lib/node_modules/@stdlib/ndarray/iter/stacks/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/stacks/lib/main.js
@@ -115,7 +115,7 @@ function nditerStacks( x, dims ) {
 			}
 			opts.writable = !options.readonly;
 			if ( opts.writable && isReadOnly( x ) ) {
-				throw new Error( format( 'invalid option. Cannot write to read-only array.' ) );
+				throw new Error( 'invalid option. Cannot write to read-only array.' );
 			}
 		}
 	}

--- a/lib/node_modules/@stdlib/ndarray/iter/subarrays/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/subarrays/lib/main.js
@@ -110,7 +110,7 @@ function nditerSubarrays( x, ndims ) {
 			}
 			opts.writable = !options.readonly;
 			if ( opts.writable && isReadOnly( x ) ) {
-				throw new Error( format( 'invalid option. Cannot write to read-only array.' ) );
+				throw new Error( 'invalid option. Cannot write to read-only array.' );
 			}
 		}
 	}

--- a/lib/node_modules/@stdlib/ndarray/to-fancy/lib/resolve_index.js
+++ b/lib/node_modules/@stdlib/ndarray/to-fancy/lib/resolve_index.js
@@ -21,7 +21,6 @@
 // MODULES //
 
 var normalizeIndex = require( '@stdlib/ndarray/base/normalize-index' );
-var format = require( '@stdlib/string/format' );
 
 
 // MAIN //
@@ -55,7 +54,7 @@ function resolveIndex( str, max, strict ) {
 	idx = parseInt( str, 10 );
 	i = normalizeIndex( idx, max-1 );
 	if ( i === -1 && strict ) {
-		throw new RangeError( format( 'invalid operation. Index exceeds ndarray bounds.' ) );
+		throw new RangeError( 'invalid operation. Index exceeds ndarray bounds.' );
 	}
 	return i;
 }

--- a/lib/node_modules/@stdlib/stats/array/mskmax/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/array/mskmax/lib/main.js
@@ -73,7 +73,7 @@ function mskmax( x, mask ) {
 		throw new TypeError( format( 'invalid argument. Second argument must have one of the following data types: "%s". Data type: `%s`.', join( IDTYPES, '", "' ), dt ) );
 	}
 	if ( x.length !== mask.length ) {
-		throw new RangeError( format( 'invalid arguments. First and second arguments must have the same length.' ) );
+		throw new RangeError( 'invalid arguments. First and second arguments must have the same length.' );
 	}
 	return strided( x.length, x, 1, 0, mask, 1, 0 );
 }

--- a/lib/node_modules/@stdlib/stats/array/mskmaxabs/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/array/mskmaxabs/lib/main.js
@@ -73,7 +73,7 @@ function mskmaxabs( x, mask ) {
 		throw new TypeError( format( 'invalid argument. Second argument must have one of the following data types: "%s". Data type: `%s`.', join( IDTYPES, '", "' ), dt ) );
 	}
 	if ( x.length !== mask.length ) {
-		throw new RangeError( format( 'invalid arguments. First and second arguments must have the same length.' ) );
+		throw new RangeError( 'invalid arguments. First and second arguments must have the same length.' );
 	}
 	return strided( x.length, x, 1, 0, mask, 1, 0 );
 }

--- a/lib/node_modules/@stdlib/stats/array/mskmidrange/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/array/mskmidrange/lib/main.js
@@ -73,7 +73,7 @@ function mskmidrange( x, mask ) {
 		throw new TypeError( format( 'invalid argument. Second argument must have one of the following data types: "%s". Data type: `%s`.', join( IDTYPES, '", "' ), dt ) );
 	}
 	if ( x.length !== mask.length ) {
-		throw new RangeError( format( 'invalid arguments. First and second arguments must have the same length.' ) );
+		throw new RangeError( 'invalid arguments. First and second arguments must have the same length.' );
 	}
 	return strided( x.length, x, 1, 0, mask, 1, 0 );
 }

--- a/lib/node_modules/@stdlib/stats/array/mskmin/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/array/mskmin/lib/main.js
@@ -73,7 +73,7 @@ function mskmin( x, mask ) {
 		throw new TypeError( format( 'invalid argument. Second argument must have one of the following data types: "%s". Data type: `%s`.', join( IDTYPES, '", "' ), dt ) );
 	}
 	if ( x.length !== mask.length ) {
-		throw new RangeError( format( 'invalid arguments. First and second arguments must have the same length.' ) );
+		throw new RangeError( 'invalid arguments. First and second arguments must have the same length.' );
 	}
 	return strided( x.length, x, 1, 0, mask, 1, 0 );
 }

--- a/lib/node_modules/@stdlib/stats/array/mskminabs/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/array/mskminabs/lib/main.js
@@ -73,7 +73,7 @@ function mskminabs( x, mask ) {
 		throw new TypeError( format( 'invalid argument. Second argument must have one of the following data types: "%s". Data type: `%s`.', join( IDTYPES, '", "' ), dt ) );
 	}
 	if ( x.length !== mask.length ) {
-		throw new RangeError( format( 'invalid arguments. First and second arguments must have the same length.' ) );
+		throw new RangeError( 'invalid arguments. First and second arguments must have the same length.' );
 	}
 	return strided( x.length, x, 1, 0, mask, 1, 0 );
 }

--- a/lib/node_modules/@stdlib/stats/array/mskrange/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/array/mskrange/lib/main.js
@@ -73,7 +73,7 @@ function mskrange( x, mask ) {
 		throw new TypeError( format( 'invalid argument. Second argument must have one of the following data types: "%s". Data type: `%s`.', join( IDTYPES, '", "' ), dt ) );
 	}
 	if ( x.length !== mask.length ) {
-		throw new RangeError( format( 'invalid arguments. First and second arguments must have the same length.' ) );
+		throw new RangeError( 'invalid arguments. First and second arguments must have the same length.' );
 	}
 	return strided( x.length, x, 1, 0, mask, 1, 0 );
 }

--- a/lib/node_modules/@stdlib/stats/array/nanmskmax/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/array/nanmskmax/lib/main.js
@@ -73,7 +73,7 @@ function nanmskmax( x, mask ) {
 		throw new TypeError( format( 'invalid argument. Second argument must have one of the following data types: "%s". Data type: `%s`.', join( IDTYPES, '", "' ), dt ) );
 	}
 	if ( x.length !== mask.length ) {
-		throw new RangeError( format( 'invalid arguments. First and second arguments must have the same length.' ) );
+		throw new RangeError( 'invalid arguments. First and second arguments must have the same length.' );
 	}
 	return strided( x.length, x, 1, 0, mask, 1, 0 );
 }

--- a/lib/node_modules/@stdlib/stats/array/nanmskmidrange/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/array/nanmskmidrange/lib/main.js
@@ -73,7 +73,7 @@ function nanmskmidrange( x, mask ) {
 		throw new TypeError( format( 'invalid argument. Second argument must have one of the following data types: "%s". Data type: `%s`.', join( IDTYPES, '", "' ), dt ) );
 	}
 	if ( x.length !== mask.length ) {
-		throw new RangeError( format( 'invalid arguments. First and second arguments must have the same length.' ) );
+		throw new RangeError( 'invalid arguments. First and second arguments must have the same length.' );
 	}
 	return strided( x.length, x, 1, 0, mask, 1, 0 );
 }

--- a/lib/node_modules/@stdlib/stats/array/nanmskmin/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/array/nanmskmin/lib/main.js
@@ -73,7 +73,7 @@ function nanmskmin( x, mask ) {
 		throw new TypeError( format( 'invalid argument. Second argument must have one of the following data types: "%s". Data type: `%s`.', join( IDTYPES, '", "' ), dt ) );
 	}
 	if ( x.length !== mask.length ) {
-		throw new RangeError( format( 'invalid arguments. First and second arguments must have the same length.' ) );
+		throw new RangeError( 'invalid arguments. First and second arguments must have the same length.' );
 	}
 	return strided( x.length, x, 1, 0, mask, 1, 0 );
 }

--- a/lib/node_modules/@stdlib/stats/array/nanmskrange/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/array/nanmskrange/lib/main.js
@@ -73,7 +73,7 @@ function nanmskrange( x, mask ) {
 		throw new TypeError( format( 'invalid argument. Second argument must have one of the following data types: "%s". Data type: `%s`.', join( IDTYPES, '", "' ), dt ) );
 	}
 	if ( x.length !== mask.length ) {
-		throw new RangeError( format( 'invalid arguments. First and second arguments must have the same length.' ) );
+		throw new RangeError( 'invalid arguments. First and second arguments must have the same length.' );
 	}
 	return strided( x.length, x, 1, 0, mask, 1, 0 );
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   replaces calls to `format` where the format string contains no placeholders with the string literal directly, as the format function returns the input string unchanged in these cases.
-   removes the now-unused `format` require in two files where no other format calls remain.

These changes were auto-fixed by the `no-useless-format` ESLint rule proposed in #14519.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #14519 (the `no-useless-format` ESLint rule that surfaced these)

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

37 files across `array`, `blas`, `ndarray`, and `stats` packages. Each change is a mechanical replacement of `format( 'static string' )` with `'static string'`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code under my direction and instructions. Changes are auto-fixes from the `no-useless-format` ESLint rule.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md