### PR TITLE
test: migrate `math/base/special/sincosdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sincosdf/test/test.assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincosdf/test/test.assign.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var Float32Array = require( '@stdlib/array/float32' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
 var sincosdf = require( './../lib/assign.js' );
@@ -51,9 +50,7 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the sine and cosine (for -256*180.0 < x < 0)', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var z;
@@ -70,29 +67,15 @@ tape( 'the function computes the sine and cosine (for -256*180.0 < x < 0)', func
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[ 0 ] === sine[ i ] ) {
-			t.strictEqual( y[ 0 ], sine[ i ], 'x: ' + x[ i ] + '. Expected: ' + sine[ i ] );
-		} else {
-			delta = absf( y[ 0 ] - sine[ i ] );
-			tol = EPS * absf( sine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 0 ] + '. Expected: ' + sine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
-		if ( y[ 1 ] === cosine[ i ] ) {
-			t.strictEqual( y[ 1 ], cosine[ i ], 'x: ' + x[ i ] + '. Expected: ' + cosine[ i ] );
-		} else {
-			delta = absf( y[ 1 ] - cosine[ i ] );
-			tol = 1.01 * EPS * absf( cosine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 1 ] + '. Expected: ' + cosine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 } );
 
 tape( 'the function computes the sine and cosine (for 0 < x < 256*180.0)', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -109,29 +92,15 @@ tape( 'the function computes the sine and cosine (for 0 < x < 256*180.0)', funct
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[ 0 ] === sine[ i ] ) {
-			t.strictEqual( y[ 0 ], sine[ i ], 'x: ' + x[ i ] + '. Expected: ' + sine[ i ] );
-		} else {
-			delta = absf( y[ 0 ] - sine[ i ] );
-			tol = EPS * absf( sine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 0 ] + '. Expected: ' + sine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
-		if ( y[ 1 ] === cosine[ i ] ) {
-			t.strictEqual( y[ 1 ], cosine[ i ], 'x: ' + x[ i ] + '. Expected: ' + cosine[ i ] );
-		} else {
-			delta = absf( y[ 1 ] - cosine[ i ] );
-			tol = 1.01 * EPS * absf( cosine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 1 ] + '. Expected: ' + cosine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 } );
 
 tape( 'the function computes the sine and cosine (for -2**60 (180.0/2) < x < -2**20 (180.0/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -148,29 +117,15 @@ tape( 'the function computes the sine and cosine (for -2**60 (180.0/2) < x < -2*
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[ 0 ] === sine[ i ] ) {
-			t.strictEqual( y[ 0 ], sine[ i ], 'x: ' + x[ i ] + '. Expected: ' + sine[ i ] );
-		} else {
-			delta = absf( y[ 0 ] - sine[ i ] );
-			tol = EPS * absf( sine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 0 ] + '. Expected: ' + sine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
-		if ( y[ 1 ] === cosine[ i ] ) {
-			t.strictEqual( y[ 1 ], cosine[ i ], 'x: ' + x[ i ] + '. Expected: ' + cosine[ i ] );
-		} else {
-			delta = absf( y[ 1 ] - cosine[ i ] );
-			tol = EPS * absf( cosine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 1 ] + '. Expected: ' + cosine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 } );
 
 tape( 'the function computes the sine and cosine (for 2**20 (180.0/2) < x < 2**60 (180.0/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -187,29 +142,15 @@ tape( 'the function computes the sine and cosine (for 2**20 (180.0/2) < x < 2**6
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[ 0 ] === sine[ i ] ) {
-			t.strictEqual( y[ 0 ], sine[ i ], 'x: ' + x[ i ] + '. Expected: ' + sine[ i ] );
-		} else {
-			delta = absf( y[ 0 ] - sine[ i ] );
-			tol = EPS * absf( sine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 0 ] + '. Expected: ' + sine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
-		if ( y[ 1 ] === cosine[ i ] ) {
-			t.strictEqual( y[ 1 ], cosine[ i ], 'x: ' + x[ i ] + '. Expected: ' + cosine[ i ] );
-		} else {
-			delta = absf( y[ 1 ] - cosine[ i ] );
-			tol = EPS * absf( cosine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 1 ] + '. Expected: ' + cosine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 } );
 
 tape( 'the function computes the sine and cosine (for x <= -2**60 (180.0/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -226,29 +167,15 @@ tape( 'the function computes the sine and cosine (for x <= -2**60 (180.0/2))', f
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[ 0 ] === sine[ i ] ) {
-			t.strictEqual( y[ 0 ], sine[ i ], 'x: ' + x[ i ] + '. Expected: ' + sine[ i ] );
-		} else {
-			delta = absf( y[ 0 ] - sine[ i ] );
-			tol = EPS * absf( sine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 0 ] + '. Expected: ' + sine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
-		if ( y[ 1 ] === cosine[ i ] ) {
-			t.strictEqual( y[ 1 ], cosine[ i ], 'x: ' + x[ i ] + '. Expected: ' + cosine[ i ] );
-		} else {
-			delta = absf( y[ 1 ] - cosine[ i ] );
-			tol = EPS * absf( cosine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 1 ] + '. Expected: ' + cosine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 } );
 
 tape( 'the function computes the sine and cosine (for x >= 2**60 (180.0/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -265,20 +192,8 @@ tape( 'the function computes the sine and cosine (for x >= 2**60 (180.0/2))', fu
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[ 0 ] === sine[ i ] ) {
-			t.strictEqual( y[ 0 ], sine[ i ], 'x: ' + x[ i ] + '. Expected: ' + sine[ i ] );
-		} else {
-			delta = absf( y[ 0 ] - sine[ i ] );
-			tol = EPS * absf( sine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 0 ] + '. Expected: ' + sine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
-		if ( y[ 1 ] === cosine[ i ] ) {
-			t.strictEqual( y[ 1 ], cosine[ i ], 'x: ' + x[ i ] + '. Expected: ' + cosine[ i ] );
-		} else {
-			delta = absf( y[ 1 ] - cosine[ i ] );
-			tol = EPS * absf( cosine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 1 ] + '. Expected: ' + cosine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 } );

--- a/lib/node_modules/@stdlib/math/base/special/sincosdf/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincosdf/test/test.main.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
 var sincosdf = require( './../lib/main.js' );
 
@@ -50,9 +49,7 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the sine and cosine (for -256*180.0 < x < 0)', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -66,29 +63,15 @@ tape( 'the function computes the sine and cosine (for -256*180.0 < x < 0)', func
 		y = sincosdf( x[ i ] );
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
-		if ( y[ 0 ] === sine[ i ] ) {
-			t.strictEqual( y[ 0 ], sine[ i ], 'x: ' + x[ i ] + '. Expected: ' + sine[ i ]);
-		} else {
-			delta = absf( y[ 0 ] - sine[ i ] );
-			tol = EPS * absf( sine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 0 ] + '. Expected: ' + sine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
-		if ( y[ 1 ] === cosine[ i ] ) {
-			t.strictEqual( y[ 1 ], cosine[ i ], 'x: ' + x[ i ] + '. Expected: ' + cosine[ i ] );
-		} else {
-			delta = absf( y[ 1 ] - cosine[ i ] );
-			tol = 1.01 * EPS * absf( cosine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 1 ] + '. Expected: ' + cosine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 } );
 
 tape( 'the function computes the sine and cosine (for 0 < x < 256*180.0)', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -102,29 +85,15 @@ tape( 'the function computes the sine and cosine (for 0 < x < 256*180.0)', funct
 		y = sincosdf( x[ i ] );
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
-		if ( y[ 0 ] === sine[ i ] ) {
-			t.strictEqual( y[ 0 ], sine[ i ], 'x: ' + x[ i ] + '. Expected: ' + sine[ i ] );
-		} else {
-			delta = absf( y[ 0 ] - sine[ i ] );
-			tol = EPS * absf( sine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 0 ] + '. Expected: ' + sine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
-		if ( y[ 1 ] === cosine[ i ] ) {
-			t.strictEqual( y[ 1 ], cosine[ i ], 'x: ' + x[ i ] + '. Expected: ' + cosine[ i ] );
-		} else {
-			delta = absf( y[ 1 ] - cosine[ i ] );
-			tol = 1.01 * EPS * absf( cosine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 1 ] + '. Expected: ' + cosine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 } );
 
 tape( 'the function computes the sine and cosine (for -2**60 (180.0/2) < x < -2**20 (180.0/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -138,29 +107,15 @@ tape( 'the function computes the sine and cosine (for -2**60 (180.0/2) < x < -2*
 		y = sincosdf( x[ i ] );
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
-		if ( y[ 0 ] === sine[ i ] ) {
-			t.strictEqual( y[ 0 ], sine[ i ], 'x: ' + x[ i ] + '. Expected: ' + sine[ i ] );
-		} else {
-			delta = absf( y[ 0 ] - sine[ i ] );
-			tol = EPS * absf( sine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 0 ] + '. Expected: ' + sine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
-		if ( y[ 1 ] === cosine[ i ] ) {
-			t.strictEqual( y[ 1 ], cosine[ i ], 'x: ' + x[ i ] + '. Expected: ' + cosine[ i ] );
-		} else {
-			delta = absf( y[ 1 ] - cosine[ i ] );
-			tol = EPS * absf( cosine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 1 ] + '. Expected: ' + cosine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 } );
 
 tape( 'the function computes the sine and cosine (for 2**20 (180.0/2) < x < 2**60 (180.0/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -174,29 +129,15 @@ tape( 'the function computes the sine and cosine (for 2**20 (180.0/2) < x < 2**6
 		y = sincosdf( x[ i ] );
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
-		if ( y[ 0 ] === sine[ i ] ) {
-			t.strictEqual( y[ 0 ], sine[ i ], 'x: ' + x[ i ] + '. Expected: ' + sine[ i ] );
-		} else {
-			delta = absf( y[ 0 ] - sine[ i ] );
-			tol = EPS * absf( sine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 0 ] + '. Expected: ' + sine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
-		if ( y[ 1 ] === cosine[ i ] ) {
-			t.strictEqual( y[ 1 ], cosine[ i ], 'x: ' + x[ i ] + '. Expected: ' + cosine[ i ] );
-		} else {
-			delta = absf( y[ 1 ] - cosine[ i ] );
-			tol = EPS * absf( cosine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 1 ] + '. Expected: ' + cosine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 } );
 
 tape( 'the function computes the sine and cosine (for x <= -2**60 (180.0/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -210,29 +151,15 @@ tape( 'the function computes the sine and cosine (for x <= -2**60 (180.0/2))', f
 		y = sincosdf( x[ i ] );
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
-		if ( y[ 0 ] === sine[ i ] ) {
-			t.strictEqual( y[ 0 ], sine[ i ], 'x: ' + x[ i ] + '. Expected: ' + sine[ i ] );
-		} else {
-			delta = absf( y[ 0 ] - sine[ i ] );
-			tol = EPS * absf( sine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 0 ] + '. Expected: ' + sine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
-		if ( y[ 1 ] === cosine[ i ] ) {
-			t.strictEqual( y[ 1 ], cosine[ i ], 'x: ' + x[ i ] + '. Expected: ' + cosine[ i ] );
-		} else {
-			delta = absf( y[ 1 ] - cosine[ i ] );
-			tol = EPS * absf( cosine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 1 ] + '. Expected: ' + cosine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 } );
 
 tape( 'the function computes the sine and cosine (for x >= 2**60 (180.0/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -246,20 +173,8 @@ tape( 'the function computes the sine and cosine (for x >= 2**60 (180.0/2))', fu
 		y = sincosdf( x[ i ] );
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
-		if ( y[ 0 ] === sine[ i ] ) {
-			t.strictEqual( y[ 0 ], sine[ i ], 'x: ' + x[ i ] + '. Expected: ' + sine[ i ] );
-		} else {
-			delta = absf( y[ 0 ] - sine[ i ] );
-			tol = EPS * absf( sine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 0 ] + '. Expected: ' + sine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
-		if ( y[ 1 ] === cosine[ i ] ) {
-			t.strictEqual( y[ 1 ], cosine[ i ], 'x: ' + x[ i ] + '. Expected: ' + cosine[ i ] );
-		} else {
-			delta = absf( y[ 1 ] - cosine[ i ] );
-			tol = EPS * absf( cosine[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + y[ 1 ] + '. Expected: ' + cosine[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 } );

--- a/lib/node_modules/@stdlib/math/base/special/sincosdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincosdf/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
 
@@ -59,9 +58,7 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the sine and cosine (for -256*180.0 < x < 0)', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -75,29 +72,15 @@ tape( 'the function computes the sine and cosine (for -256*180.0 < x < 0)', opts
 		y = sincosdf( x[ i ] );
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
-		if ( y[0] === sine[i] ) {
-			t.strictEqual( y[0], sine[i], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = absf( y[0] - sine[i] );
-			tol = EPS * absf( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[i] ) {
-			t.strictEqual( y[1], cosine[i], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = absf( y[1] - cosine[i] );
-			tol = 1.01 * EPS * absf( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for 0 < x < 256*180.0)', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -111,29 +94,15 @@ tape( 'the function computes the sine and cosine (for 0 < x < 256*180.0)', opts,
 		y = sincosdf( x[ i ] );
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
-		if ( y[0] === sine[i] ) {
-			t.strictEqual( y[0], sine[i], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = absf( y[0] - sine[i] );
-			tol = EPS * absf( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[i] ) {
-			t.strictEqual( y[1], cosine[i], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = absf( y[1] - cosine[i] );
-			tol = 1.01 * EPS * absf( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for -2**60 (180.0/2) < x < -2**20 (180.0/2))', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -147,29 +116,15 @@ tape( 'the function computes the sine and cosine (for -2**60 (180.0/2) < x < -2*
 		y = sincosdf( x[ i ] );
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
-		if ( y[0] === sine[i] ) {
-			t.strictEqual( y[0], sine[i], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = absf( y[0] - sine[i] );
-			tol = EPS * absf( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[i] ) {
-			t.strictEqual( y[1], cosine[i], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = absf( y[1] - cosine[i] );
-			tol = EPS * absf( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for 2**20 (180.0/2) < x < 2**60 (180.0/2))', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -183,29 +138,15 @@ tape( 'the function computes the sine and cosine (for 2**20 (180.0/2) < x < 2**6
 		y = sincosdf( x[ i ] );
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
-		if ( y[0] === sine[i] ) {
-			t.strictEqual( y[0], sine[i], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = absf( y[0] - sine[i] );
-			tol = EPS * absf( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[i] ) {
-			t.strictEqual( y[1], cosine[i], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = absf( y[1] - cosine[i] );
-			tol = EPS * absf( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for x <= -2**60 (180.0/2))', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -219,29 +160,15 @@ tape( 'the function computes the sine and cosine (for x <= -2**60 (180.0/2))', o
 		y = sincosdf( x[ i ] );
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
-		if ( y[0] === sine[i] ) {
-			t.strictEqual( y[0], sine[i], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = absf( y[0] - sine[i] );
-			tol = EPS * absf( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[i] ) {
-			t.strictEqual( y[1], cosine[i], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = absf( y[1] - cosine[i] );
-			tol = EPS * absf( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for x >= 2**60 (180.0/2))', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -255,20 +182,8 @@ tape( 'the function computes the sine and cosine (for x >= 2**60 (180.0/2))', op
 		y = sincosdf( x[i] );
 		sine[ i ] = f32( sine[ i ] );
 		cosine[ i ] = f32( cosine[ i ] );
-		if ( y[0] === sine[i] ) {
-			t.strictEqual( y[0], sine[i], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = absf( y[0] - sine[i] );
-			tol = EPS * absf( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[i] ) {
-			t.strictEqual( y[1], cosine[i], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = absf( y[1] - cosine[i] );
-			tol = EPS * absf( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/sincosdf` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `delta`/`tol` comparisons (and their `if ( y === expected ) { ... } else { ... }` wrappers) with `isAlmostSameValue( actual, expected, N )` assertions, using `@stdlib/number/float32/base/assert/is-almost-same-value`, as the package operates on single-precision values.
-   removes the now-unused `@stdlib/constants/float32/eps` and `@stdlib/math/base/special/absf` imports, along with the `delta` and `tol` local variables.
-   updates `test/test.main.js`, `test/test.assign.js`, and `test/test.native.js`. `test/test.js` is a smoke test which contains no tolerance-based assertions and is thus left unchanged.

The ULP bounds were measured against the full fixture set (6 fixture files x 4000 values, for both the sine and cosine outputs) and set to the minimum value which passes:

| Fixture | `sine` | `cosine` |
| --- | --- | --- |
| `medium_negative` | 1 | 1 |
| `medium_positive` | 1 | 1 |
| `large_negative` | 1 | 0 |
| `large_positive` | 1 | 0 |
| `huge_negative` | 1 | 0 |
| `huge_positive` | 1 | 0 |

Each bound is tight. For every bound of `1`, at least one fixture value differs from the expected value by exactly 1 ULP (e.g., 645 of 4000 sine values in `medium_negative`), so `0` fails. For every bound of `0`, all 4000 values match exactly.

The measured maxima are identical for the JavaScript implementation (`lib/main.js`), the `assign` implementation (`lib/assign.js`), and the C implementation (`lib/native.js`), so the same bounds are used in all three test files. The native addon was compiled locally in order to confirm this.

The full package test suite (`make test TESTS_FILTER=".*/math/base/special/sincosdf/.*"`) was run twice at the final bounds, with identical results both times (48008 / 72024 / 6 / 48008 assertions passing, 0 failing).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Only test files are changed; no source, documentation, or fixture files are modified.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. The test edits were applied mechanically, the ULP bounds were derived from measured per-fixture ULP-difference histograms rather than guessed, and the prior art in already-migrated packages (e.g., `math/base/special/sici`, `math/base/special/logitf`) was used to match the established idiom. Opened as a draft for human review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvpbWcLE9xcnWTcUDXxAeh)_