### PR TITLE
test: migrate `stats/base/dists/bernoulli/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/bernoulli/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bernoulli/stdev/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -78,8 +77,6 @@ tape( 'if provided a success probability `p` outside of `[0,1]`, the function re
 
 tape( 'the function returns the standard deviation of a Bernoulli distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -88,13 +85,7 @@ tape( 'the function returns the standard deviation of a Bernoulli distribution',
 	p = data.p;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/bernoulli/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bernoulli/stdev/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -87,8 +86,6 @@ tape( 'if provided a success probability `p` outside of `[0,1]`, the function re
 
 tape( 'the function returns the standard deviation of a Bernoulli distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -97,13 +94,7 @@ tape( 'the function returns the standard deviation of a Bernoulli distribution',
 	p = data.p;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates `stats/base/dists/bernoulli/stdev` tests from relative-tolerance (`EPS`-based `delta`/`tol`) comparisons to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`, per the RFC in #11352.
-   Updates both `test/test.js` and `test/test.native.js`.
-   The fixture-driven test (`the function returns the standard deviation of a Bernoulli distribution`) was tightened to the minimum ULP bound that still passes over the full fixture set (1000 cases): all computed values match the Python-generated fixtures exactly, so `isAlmostSameValue( y, expected[ i ], 0 )` is sufficient. Verified deterministic by running the suite twice.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, which searched the repository for a qualifying package (no existing open/merged ULP-migration PR), studied prior art from already-converted `stats/base/dists` packages (e.g. `weibull/stdev`, `arcsine/entropy`) to mirror the established idiom, converted the tests, and determined the minimum passing ULP bound empirically against the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_015iKeq6zZUdBWZENWwNqSuK)_