### PR TITLE
feat!: add `fromIndex` support to `blas/ext/base/ndarray/zindex-of-falsy`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/README.md
@@ -42,25 +42,38 @@ Returns the index of the first falsy element in a one-dimensional double-precisi
 
 ```javascript
 var Complex128Vector = require( '@stdlib/ndarray/vector/complex128' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 
 var x = new Complex128Vector( [ 1.0, 2.0, 0.0, 0.0, 4.0, 5.0 ] );
 
-var idx = zindexOfFalsy( [ x ] );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var idx = zindexOfFalsy( [ x, fromIndex ] );
 // returns 1
 ```
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing a one-dimensional input ndarray.
+-   **arrays**: array-like object containing the following ndarrays:
+
+    -   a one-dimensional input ndarray.
+    -   a zero-dimensional ndarray containing the index from which to begin searching.
 
 If the function is unable to find a falsy element, the function returns `-1`.
 
 ```javascript
 var Complex128Vector = require( '@stdlib/ndarray/vector/complex128' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 
 var x = new Complex128Vector( [ 1.0, 2.0, 3.0, 4.0 ] );
 
-var idx = zindexOfFalsy( [ x ] );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var idx = zindexOfFalsy( [ x, fromIndex ] );
 // returns -1
 ```
 
@@ -74,6 +87,7 @@ var idx = zindexOfFalsy( [ x ] );
 
 -   A complex number is falsy when its real and imaginary components are both falsy.
 -   The function treats `NaN` values as falsy.
+-   If a specified starting search index is negative, the function resolves the starting search index by counting backward from the last element (where `-1` refers to the last element).
 
 </section>
 
@@ -88,6 +102,7 @@ var idx = zindexOfFalsy( [ x ] );
 ```javascript
 var bernoulli = require( '@stdlib/random/array/bernoulli' );
 var Complex128Vector = require( '@stdlib/ndarray/vector/complex128' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var zindexOfFalsy = require( '@stdlib/blas/ext/base/ndarray/zindex-of-falsy' );
 
@@ -97,7 +112,11 @@ var buf = bernoulli( 10*2, 0.7, {
 var x = new Complex128Vector( buf.buffer );
 console.log( ndarray2array( x ) );
 
-var idx = zindexOfFalsy( [ x ] );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var idx = zindexOfFalsy( [ x, fromIndex ] );
 console.log( idx );
 ```
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var ones = require( '@stdlib/ndarray/ones' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var zindexOfFalsy = require( './../lib' );
@@ -46,7 +47,13 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = ones( [ len ], options );
+	var fromIndex;
+	var x;
+
+	x = ones( [ len ], options );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 	return benchmark;
 
 	/**
@@ -61,7 +68,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			out = zindexOfFalsy( [ x ] );
+			out = zindexOfFalsy( [ x, fromIndex ] );
 			if ( out !== out ) {
 				b.fail( 'should return an integer' );
 			}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/docs/repl.txt
@@ -3,17 +3,25 @@
     Returns the index of the first falsy element in a one-dimensional double-
     precision complex floating-point ndarray.
 
-    If unable to find a falsy element, the function returns `-1`.
-
     A complex number is falsy when its real and imaginary components are both
     falsy.
 
     The function treats `NaN` values as falsy.
 
+    If a specified starting search index is negative, the function resolves the
+    starting search index by counting backward from the last element (where `-1`
+    refers to the last element).
+
+    If unable to find a falsy element, the function returns `-1`.
+
     Parameters
     ----------
     arrays: ArrayLikeObject<ndarray>
-        Array-like object containing a one-dimensional input ndarray.
+        Array-like object containing the following ndarrays:
+
+        - a one-dimensional input ndarray.
+        - a zero-dimensional ndarray containing the index from which to begin
+        searching.
 
     Returns
     -------
@@ -23,7 +31,8 @@
     Examples
     --------
     > var x = new {{alias:@stdlib/ndarray/vector/complex128}}( [ 1.0, 2.0, 0.0, 0.0 ] );
-    > {{alias}}( [ x ] )
+    > var i = {{alias:@stdlib/ndarray/from-scalar}}( 0, { 'dtype': 'generic' } );
+    > {{alias}}( [ x, i ] )
     1
 
     See Also

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/docs/types/index.d.ts
@@ -20,23 +20,35 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { complex128ndarray } from '@stdlib/types/ndarray';
+import { complex128ndarray, typedndarray } from '@stdlib/types/ndarray';
 
 /**
 * Returns the index of the first falsy element in a one-dimensional double-precision complex floating-point ndarray.
+*
+* ## Notes
+*
+* -   The function expects the following ndarrays:
+*
+*     -   a one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * @param arrays - array-like object containing ndarrays
 * @returns index
 *
 * @example
 * var Complex128Vector = require( '@stdlib/ndarray/vector/complex128' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 *
 * var x = new Complex128Vector( [ 1.0, 2.0, 0.0, 0.0, 4.0, 5.0 ] );
 *
-* var idx = zindexOfFalsy( [ x ] );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var idx = zindexOfFalsy( [ x, fromIndex ] );
 * // returns 1
 */
-declare function zindexOfFalsy( arrays: [ complex128ndarray ] ): number;
+declare function zindexOfFalsy( arrays: [ complex128ndarray, typedndarray<number> ] ): number;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/docs/types/test.ts
@@ -19,6 +19,7 @@
 /* eslint-disable space-in-parens */
 
 import zeros = require( '@stdlib/ndarray/zeros' );
+import scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 import zindexOfFalsy = require( './index' );
 
 
@@ -29,8 +30,11 @@ import zindexOfFalsy = require( './index' );
 	const x = zeros( [ 10 ], {
 		'dtype': 'complex128'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	zindexOfFalsy( [ x ] ); // $ExpectType number
+	zindexOfFalsy( [ x, fromIndex ] ); // $ExpectType number
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
@@ -51,7 +55,10 @@ import zindexOfFalsy = require( './index' );
 	const x = zeros( [ 10 ], {
 		'dtype': 'complex128'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	zindexOfFalsy(); // $ExpectError
-	zindexOfFalsy( [ x ], {} ); // $ExpectError
+	zindexOfFalsy( [ x, fromIndex ], {} ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/examples/index.js
@@ -20,6 +20,7 @@
 
 var bernoulli = require( '@stdlib/random/array/bernoulli' );
 var Complex128Vector = require( '@stdlib/ndarray/vector/complex128' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var zindexOfFalsy = require( './../lib' );
 
@@ -29,5 +30,9 @@ var buf = bernoulli( 10*2, 0.7, {
 var x = new Complex128Vector( buf.buffer );
 console.log( ndarray2array( x ) );
 
-var idx = zindexOfFalsy( [ x ] );
+var fromIndex = scalar2ndarray( 0, {
+	'dtype': 'generic'
+});
+
+var idx = zindexOfFalsy( [ x, fromIndex ] );
 console.log( idx );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/lib/index.js
@@ -25,11 +25,16 @@
 *
 * @example
 * var Complex128Vector = require( '@stdlib/ndarray/vector/complex128' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var zindexOfFalsy = require( '@stdlib/blas/ext/base/ndarray/zindex-of-falsy' );
 *
 * var x = new Complex128Vector( [ 1.0, 2.0, 0.0, 0.0, 4.0, 5.0 ] );
 *
-* var idx = zindexOfFalsy( [ x ] );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var idx = zindexOfFalsy( [ x, fromIndex ] );
 * // returns 1
 */
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/lib/main.js
@@ -20,10 +20,12 @@
 
 // MODULES //
 
+var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
 var getStride = require( '@stdlib/ndarray/base/stride' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
+var clipIndex = require( '@stdlib/ndarray/base/clip-index' );
 var strided = require( '@stdlib/blas/ext/base/zindex-of-falsy' ).ndarray;
 
 
@@ -37,21 +39,50 @@ var strided = require( '@stdlib/blas/ext/base/zindex-of-falsy' ).ndarray;
 * -   The function expects the following ndarrays:
 *
 *     -   a one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
 * @returns {integer} index
 *
 * @example
 * var Complex128Vector = require( '@stdlib/ndarray/vector/complex128' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 *
 * var x = new Complex128Vector( [ 1.0, 2.0, 0.0, 0.0, 4.0, 5.0 ] );
 *
-* var idx = zindexOfFalsy( [ x ] );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var idx = zindexOfFalsy( [ x, fromIndex ] );
 * // returns 1
 */
 function zindexOfFalsy( arrays ) {
-	var x = arrays[ 0 ];
-	return strided( numelDimension( x, 0 ), getData( x ), getStride( x, 0 ), getOffset( x ) ); // eslint-disable-line max-len
+	var fromIndex;
+	var stride;
+	var offset;
+	var idx;
+	var N;
+	var x;
+
+	x = arrays[ 0 ];
+	fromIndex = ndarraylike2scalar( arrays[ 1 ] );
+
+	N = numelDimension( x, 0 );
+	fromIndex = clipIndex( fromIndex, N );
+	if ( fromIndex >= N ) {
+		return -1;
+	}
+	N -= fromIndex;
+
+	stride = getStride( x, 0 );
+	offset = getOffset( x ) + ( stride*fromIndex );
+
+	idx = strided( N, getData( x ), stride, offset );
+	if ( idx >= 0 ) {
+		idx += fromIndex;
+	}
+	return idx;
 }
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of-falsy/test/test.js
@@ -22,6 +22,7 @@
 
 var tape = require( 'tape' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
 var zindexOfFalsy = require( './../lib' );
 
@@ -52,6 +53,7 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function returns the index of the first falsy element', function test( t ) {
+	var fromIndex;
 	var actual;
 	var xbuf;
 	var x;
@@ -71,8 +73,11 @@ tape( 'the function returns the index of the first falsy element', function test
 		7.0
 	]);
 	x = vector( xbuf, 6, 1, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = zindexOfFalsy( [ x ] );
+	actual = zindexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, 2, 'returns expected value' );
 
 	xbuf = new Complex128Array([
@@ -84,14 +89,110 @@ tape( 'the function returns the index of the first falsy element', function test
 		6.0
 	]);
 	x = vector( xbuf, 3, 1, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = zindexOfFalsy( [ x ] );
+	actual = zindexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, 0, 'returns expected value' );
 
 	t.end();
 });
 
+tape( 'the function supports a `fromIndex` parameter (nonnegative)', function test( t ) {
+	var fromIndex;
+	var actual;
+	var xbuf;
+	var x;
+
+	xbuf = new Complex128Array([
+		0.0,
+		0.0,
+		1.0,
+		1.0,
+		0.0,
+		0.0,
+		1.0,
+		1.0,
+		0.0,
+		0.0,
+		1.0,
+		1.0
+	]);
+	x = vector( xbuf, 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	actual = zindexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 0, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 1, {
+		'dtype': 'generic'
+	});
+	actual = zindexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 2, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
+	actual = zindexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 4, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a `fromIndex` parameter (negative)', function test( t ) {
+	var fromIndex;
+	var actual;
+	var xbuf;
+	var x;
+
+	xbuf = new Complex128Array([
+		1.0,
+		1.0,
+		0.0,
+		0.0,
+		1.0,
+		1.0,
+		0.0,
+		0.0,
+		1.0,
+		1.0,
+		0.0,
+		0.0
+	]);
+	x = vector( xbuf, 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( -1, {
+		'dtype': 'generic'
+	});
+	actual = zindexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -2, {
+		'dtype': 'generic'
+	});
+	actual = zindexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -3, {
+		'dtype': 'generic'
+	});
+	actual = zindexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -7, {
+		'dtype': 'generic'
+	});
+	actual = zindexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 1, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function returns `-1` if unable to find a falsy element', function test( t ) {
+	var fromIndex;
 	var actual;
 	var xbuf;
 	var x;
@@ -107,14 +208,18 @@ tape( 'the function returns `-1` if unable to find a falsy element', function te
 		8.0
 	]);
 	x = vector( xbuf, 4, 1, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = zindexOfFalsy( [ x ] );
+	actual = zindexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function ignores truthy elements (e.g., `1+1i`, `0+1i`, `1+0i`)', function test( t ) {
+	var fromIndex;
 	var actual;
 	var xbuf;
 	var x;
@@ -130,14 +235,18 @@ tape( 'the function ignores truthy elements (e.g., `1+1i`, `0+1i`, `1+0i`)', fun
 		0.0
 	]);
 	x = vector( xbuf, 4, 1, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = zindexOfFalsy( [ x ] );
+	actual = zindexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, 3, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having non-unit strides', function test( t ) {
+	var fromIndex;
 	var actual;
 	var xbuf;
 	var x;
@@ -157,8 +266,11 @@ tape( 'the function supports one-dimensional ndarrays having non-unit strides', 
 		0.0
 	]);
 	x = vector( xbuf, 3, 2, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = zindexOfFalsy( [ x ] );
+	actual = zindexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	xbuf = new Complex128Array([
@@ -176,14 +288,18 @@ tape( 'the function supports one-dimensional ndarrays having non-unit strides', 
 		0.0
 	]);
 	x = vector( xbuf, 3, 2, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = zindexOfFalsy( [ x ] );
+	actual = zindexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, 0, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having negative strides', function test( t ) {
+	var fromIndex;
 	var actual;
 	var xbuf;
 	var x;
@@ -203,14 +319,18 @@ tape( 'the function supports one-dimensional ndarrays having negative strides', 
 		7.0
 	]);
 	x = vector( xbuf, 6, -1, 5 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = zindexOfFalsy( [ x ] );
+	actual = zindexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, 1, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having non-zero offsets', function test( t ) {
+	var fromIndex;
 	var actual;
 	var xbuf;
 	var x;
@@ -230,20 +350,58 @@ tape( 'the function supports one-dimensional ndarrays having non-zero offsets', 
 		0.0
 	]);
 	x = vector( xbuf, 3, 1, 1 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = zindexOfFalsy( [ x ] );
+	actual = zindexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, 2, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `-1` if provided an empty one-dimensional ndarray', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
 	x = vector( new Complex128Array( [] ), 0, 1, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = zindexOfFalsy( [ x ] );
+	actual = zindexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, -1, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `-1` if provided a starting search index which is greater than or equal to number of elements in the input ndarray', function test( t ) {
+	var fromIndex;
+	var actual;
+	var xbuf;
+	var x;
+
+	xbuf = new Complex128Array([
+		0.0,
+		0.0,
+		1.0,
+		1.0,
+		0.0,
+		0.0,
+		1.0,
+		1.0,
+		0.0,
+		0.0,
+		1.0,
+		1.0
+	]);
+	x = vector( xbuf, 6, 1, 0 );
+	fromIndex = scalar2ndarray( 7, {
+		'dtype': 'generic'
+	});
+
+	actual = zindexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1200.

## Description

> What is the purpose of this pull request?

This pull request:

-   add `fromIndex` support to `blas/ext/base/ndarray/zindex-of-falsy`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1200.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Primarily written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
