### PR TITLE
test: migrate `stats/base/dists/frechet/skewness` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/skewness/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/skewness/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var skewness = require( './../lib' );
 
 
@@ -97,8 +96,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', function test
 tape( 'the function returns the skewness of a Fréchet distribution', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var y;
 	var i;
@@ -109,13 +106,7 @@ tape( 'the function returns the skewness of a Fréchet distribution', function t
 	for ( i = 0; i < alpha.length; i++ ) {
 		y = skewness( alpha[i], s[i], 0.0 );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'alpha:'+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 140.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. s: '+s[i]+'. m: 0. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 244 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/skewness/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/skewness/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -112,8 +111,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', opts, functio
 tape( 'the function returns the skewness of a Fréchet distribution', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var y;
 	var i;
@@ -124,13 +121,7 @@ tape( 'the function returns the skewness of a Fréchet distribution', opts, func
 	for ( i = 0; i < alpha.length; i++ ) {
 		y = skewness( alpha[i], s[i], 0.0 );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'alpha:'+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 140.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. s: '+s[i]+'. m: 0. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 244 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suites for `stats/base/dists/frechet/skewness` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `delta`/`tol` comparisons in `test/test.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 244 ), true, 'returns expected value' );`, adding the `@stdlib/assert/is-almost-same-value` require and dropping the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires. The existing `expected[i] !== null` guard (Julia emits `null` for parameter combinations having infinite skewness) is preserved.

**ULP bound: `244` (both `test/test.js` and `test/test.native.js`), the measured minimum over the fixture set.**

The bound was determined empirically rather than assumed: for every fixture, the minimum admissible bound was found by bisection over `isAlmostSameValue`, and the maximum over the full Julia fixture set (44 of 100 values are non-`null` and therefore compared) is exactly `244`. The worst case is `alpha = 4.750849820273925`, `s = 3.748713063341589` (`y = 3.837909707867179` vs. expected `3.8379097078670705`). Re-running the suite at `243` fails that single case, confirming `244` cannot be tightened further. The JS suite was then run twice at the final bound with identical results (59/59 passing), so the bound is not sensitive to run-to-run variation.

The previous relative tolerance was `140.0 * EPS`, which is of comparable magnitude (`140 * EPS` corresponds to roughly `140`–`280` ULP depending on where a value falls within its binade), so this is not a loosening of the prior accuracy budget.

The native addon is not built in this environment, so `test/test.native.js` is skipped locally. To confirm that `244` is also correct for the C implementation, `src/main.c` was compiled directly against its transitive C dependency closure (`math/base/special/gamma`, `math/base/special/pow`, etc.) and evaluated over the same fixtures; its maximum ULP difference is likewise `244`, attained on the same input. This matches the sibling conversions in this family (`frechet/variance`, `frechet/kurtosis`), which likewise use a single bound across both suites.

Only the two test files are modified; no implementation, fixture, or documentation changes are included.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. It studied previously merged conversions under #11352 (including the `frechet/variance` and `frechet/kurtosis` siblings) to match the established idiom, applied the migration, measured the minimum ULP bound empirically against the fixtures (including a direct compilation of the C source to cover the skipped native suite), and verified that the tests pass and that the files lint cleanly.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md