### PR TITLE
feat!: add `fromIndex` support to `blas/ext/base/ndarray/sfirst-index-equal`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/README.md
@@ -42,11 +42,16 @@ Returns the index of the first element in a one-dimensional single-precision flo
 
 ```javascript
 var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 
 var x = new Float32Vector( [ 1.0, 2.0, 3.0, 4.0 ] );
 var y = new Float32Vector( [ 0.0, 0.0, 3.0, 0.0 ] );
 
-var idx = sfirstIndexEqual( [ x, y ] );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var idx = sfirstIndexEqual( [ x, y, fromIndex ] );
 // returns 2
 ```
 
@@ -56,16 +61,22 @@ The function has the following parameters:
 
     -   first one-dimensional input ndarray.
     -   second one-dimensional input ndarray.
+    -   a zero-dimensional ndarray containing the index from which to begin searching.
 
 If the function is unable to find an element in the first one-dimensional input ndarray equal to a corresponding element in the second one-dimensional input ndarray, the function returns `-1`.
 
 ```javascript
 var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 
 var x = new Float32Vector( [ 1.0, 2.0, 3.0, 4.0 ] );
 var y = new Float32Vector( [ 5.0, 6.0, 7.0, 8.0 ] );
 
-var idx = sfirstIndexEqual( [ x, y ] );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var idx = sfirstIndexEqual( [ x, y, fromIndex ] );
 // returns -1
 ```
 
@@ -77,6 +88,7 @@ var idx = sfirstIndexEqual( [ x, y ] );
 
 ## Notes
 
+-   If a specified starting search index is negative, the function resolves the starting search index by counting backward from the last element (where `-1` refers to the last element).
 -   When comparing elements, the function checks for equality using the strict equality operator `===`. As a consequence, `NaN` values are considered distinct, and `-0` and `+0` are considered the same.
 
 </section>
@@ -91,7 +103,9 @@ var idx = sfirstIndexEqual( [ x, y ] );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/discrete-uniform' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var ndarraylike2scalar = require( '@stdlib/ndarray/ndarraylike2scalar' );
 var sfirstIndexEqual = require( '@stdlib/blas/ext/base/ndarray/sfirst-index-equal' );
 
 var opts = {
@@ -103,7 +117,12 @@ console.log( ndarray2array( x ) );
 var y = discreteUniform( [ 10 ], 0, 10, opts );
 console.log( ndarray2array( y ) );
 
-var idx = sfirstIndexEqual( [ x, y ] );
+var fromIndex = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+console.log( 'From Index:', ndarraylike2scalar( fromIndex ) );
+
+var idx = sfirstIndexEqual( [ x, y, fromIndex ] );
 console.log( idx );
 ```
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/benchmark/benchmark.js
@@ -23,9 +23,9 @@
 var bench = require( '@stdlib/bench' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var pow = require( '@stdlib/math/base/special/pow' );
-var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
-var oneTo = require( '@stdlib/array/one-to' );
-var zeros = require( '@stdlib/array/zeros' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+var oneTo = require( '@stdlib/blas/ext/one-to' );
+var zeros = require( '@stdlib/ndarray/zeros' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var sfirstIndexEqual = require( './../lib' );
@@ -48,8 +48,15 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Float32Vector( oneTo( len, options.dtype ) );
-	var y = new Float32Vector( zeros( len, options.dtype ) );
+	var fromIndex;
+	var x;
+	var y;
+
+	x = oneTo( [ len ], options );
+	y = zeros( [ len ], options );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 	return benchmark;
 
 	/**
@@ -64,7 +71,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			out = sfirstIndexEqual( [ x, y ] );
+			out = sfirstIndexEqual( [ x, y, fromIndex ] );
 			if ( out !== out ) {
 				b.fail( 'should return an integer' );
 			}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/docs/repl.txt
@@ -4,6 +4,10 @@
     precision floating-point ndarray equal to a corresponding element in
     another one-dimensional single-precision floating-point ndarray.
 
+    If a specified starting search index is negative, the function resolves the
+    starting search index by counting backward from the last element (where `-1`
+    refers to the last element).
+
     When comparing elements, the function checks for equality using the strict
     equality operator `===`. As a consequence, `NaN` values are considered
     distinct, and `-0` and `+0` are considered the same.
@@ -15,6 +19,8 @@
 
         - first one-dimensional input ndarray.
         - second one-dimensional input ndarray.
+        - a zero-dimensional ndarray containing the index from which to begin
+        searching.
 
     Returns
     -------
@@ -25,7 +31,8 @@
     --------
     > var x = new {{alias:@stdlib/ndarray/vector/float32}}( [ 1.0, 2.0, 3.0, 4.0 ] );
     > var y = new {{alias:@stdlib/ndarray/vector/float32}}( [ 0.0, 0.0, 3.0, 0.0 ] );
-    > {{alias}}( [ x, y ] )
+    > var i = {{alias:@stdlib/ndarray/from-scalar}}( 0, { 'dtype': 'generic' } );
+    > {{alias}}( [ x, y, i ] )
     2
 
     See Also

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { float32ndarray } from '@stdlib/types/ndarray';
+import { float32ndarray, typedndarray } from '@stdlib/types/ndarray';
 
 /**
 * Returns the index of the first element in a one-dimensional single-precision floating-point ndarray equal to a corresponding element in another one-dimensional single-precision floating-point ndarray.
@@ -31,6 +31,7 @@ import { float32ndarray } from '@stdlib/types/ndarray';
 *
 *     -   first one-dimensional input ndarray.
 *     -   second one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * -   When comparing elements, the function checks for equality using the strict equality operator `===`. As a consequence, `NaN` values are considered distinct, and `-0` and `+0` are considered the same.
 *
@@ -39,14 +40,19 @@ import { float32ndarray } from '@stdlib/types/ndarray';
 *
 * @example
 * var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 *
 * var x = new Float32Vector( [ 1.0, 2.0, 3.0, 4.0 ] );
 * var y = new Float32Vector( [ 0.0, 0.0, 3.0, 0.0 ] );
 *
-* var idx = sfirstIndexEqual( [ x, y ] );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var idx = sfirstIndexEqual( [ x, y, fromIndex ] );
 * // returns 2
 */
-declare function sfirstIndexEqual( arrays: [ float32ndarray, float32ndarray ] ): number;
+declare function sfirstIndexEqual( arrays: [ float32ndarray, float32ndarray, typedndarray<number> ] ): number;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/docs/types/test.ts
@@ -19,6 +19,7 @@
 /* eslint-disable space-in-parens */
 
 import zeros = require( '@stdlib/ndarray/zeros' );
+import scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 import sfirstIndexEqual = require( './index' );
 
 
@@ -32,8 +33,11 @@ import sfirstIndexEqual = require( './index' );
 	const y = zeros( [ 10 ], {
 		'dtype': 'float32'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	sfirstIndexEqual( [ x, y ] ); // $ExpectType number
+	sfirstIndexEqual( [ x, y, fromIndex ] ); // $ExpectType number
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
@@ -57,7 +61,10 @@ import sfirstIndexEqual = require( './index' );
 	const y = zeros( [ 10 ], {
 		'dtype': 'float32'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	sfirstIndexEqual(); // $ExpectError
-	sfirstIndexEqual( [ x, y ], {} ); // $ExpectError
+	sfirstIndexEqual( [ x, y, fromIndex ], {} ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/examples/index.js
@@ -19,7 +19,9 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/discrete-uniform' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var ndarraylike2scalar = require( '@stdlib/ndarray/ndarraylike2scalar' );
 var sfirstIndexEqual = require( './../lib' );
 
 var opts = {
@@ -31,5 +33,10 @@ console.log( ndarray2array( x ) );
 var y = discreteUniform( [ 10 ], 0, 10, opts );
 console.log( ndarray2array( y ) );
 
-var idx = sfirstIndexEqual( [ x, y ] );
+var fromIndex = scalar2ndarray( 0, {
+	'dtype': 'generic'
+});
+console.log( 'From Index:', ndarraylike2scalar( fromIndex ) );
+
+var idx = sfirstIndexEqual( [ x, y, fromIndex ] );
 console.log( idx );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/lib/index.js
@@ -25,12 +25,17 @@
 *
 * @example
 * var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var sfirstIndexEqual = require( '@stdlib/blas/ext/base/ndarray/sfirst-index-equal' );
 *
 * var x = new Float32Vector( [ 1.0, 2.0, 3.0, 4.0 ] );
 * var y = new Float32Vector( [ 0.0, 0.0, 3.0, 0.0 ] );
 *
-* var idx = sfirstIndexEqual( [ x, y ] );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var idx = sfirstIndexEqual( [ x, y, fromIndex ] );
 * // returns 2
 */
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/lib/main.js
@@ -20,10 +20,12 @@
 
 // MODULES //
 
+var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
 var getStride = require( '@stdlib/ndarray/base/stride' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
+var clipIndex = require( '@stdlib/ndarray/base/clip-index' );
 var strided = require( '@stdlib/blas/ext/base/sfirst-index-equal' ).ndarray;
 
 
@@ -38,6 +40,7 @@ var strided = require( '@stdlib/blas/ext/base/sfirst-index-equal' ).ndarray;
 *
 *     -   first one-dimensional input ndarray.
 *     -   second one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * -   When comparing elements, the function checks for equality using the strict equality operator `===`. As a consequence, `NaN` values are considered distinct, and `-0` and `+0` are considered the same.
 *
@@ -46,17 +49,50 @@ var strided = require( '@stdlib/blas/ext/base/sfirst-index-equal' ).ndarray;
 *
 * @example
 * var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 *
 * var x = new Float32Vector( [ 1.0, 2.0, 3.0, 4.0 ] );
 * var y = new Float32Vector( [ 0.0, 0.0, 3.0, 0.0 ] );
 *
-* var idx = sfirstIndexEqual( [ x, y ] );
+* var fromIndex = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var idx = sfirstIndexEqual( [ x, y, fromIndex ] );
 * // returns 2
 */
 function sfirstIndexEqual( arrays ) {
-	var x = arrays[ 0 ];
-	var y = arrays[ 1 ];
-	return strided( numelDimension( x, 0 ), getData( x ), getStride( x, 0 ), getOffset( x ), getData( y ), getStride( y, 0 ), getOffset( y ) ); // eslint-disable-line max-len
+	var fromIndex;
+	var idx;
+	var sx;
+	var sy;
+	var ox;
+	var oy;
+	var N;
+	var x;
+	var y;
+
+	x = arrays[ 0 ];
+	y = arrays[ 1 ];
+	fromIndex = ndarraylike2scalar( arrays[ 2 ] );
+
+	N = numelDimension( x, 0 );
+	fromIndex = clipIndex( fromIndex, N );
+	if ( fromIndex >= N ) {
+		return -1;
+	}
+	N -= fromIndex;
+
+	sx = getStride( x, 0 );
+	ox = getOffset( x ) + ( sx*fromIndex );
+	sy = getStride( y, 0 );
+	oy = getOffset( y ) + ( sy*fromIndex );
+
+	idx = strided( N, getData( x ), sx, ox, getData( y ), sy, oy );
+	if ( idx >= 0 ) {
+		idx += fromIndex;
+	}
+	return idx;
 }
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfirst-index-equal/test/test.js
@@ -23,6 +23,7 @@
 var tape = require( 'tape' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
 var Float32Array = require( '@stdlib/array/float32' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var sfirstIndexEqual = require( './../lib' );
 
 
@@ -52,55 +53,70 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function returns the index of the first element in a one-dimensional ndarray equal to a corresponding element in another one-dimensional ndarray', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
 
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+
 	x = vector( new Float32Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] ), 6, 1, 0 );
 	y = vector( new Float32Array( [ 1.0, 0.0, 3.0, 0.0, 5.0, 0.0 ] ), 6, 1, 0 );
 
-	actual = sfirstIndexEqual( [ x, y ] );
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, 0, 'returns expected value' );
 
 	x = vector( new Float32Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] ), 6, 1, 0 );
 	y = vector( new Float32Array( [ 0.0, 2.0, 3.0, 0.0, 0.0, 0.0 ] ), 6, 1, 0 );
 
-	actual = sfirstIndexEqual( [ x, y ] );
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, 1, 'returns expected value' );
 
 	x = vector( new Float32Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] ), 6, 1, 0 );
 	y = vector( new Float32Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 6.0 ] ), 6, 1, 0 );
 
-	actual = sfirstIndexEqual( [ x, y ] );
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, 5, 'returns expected value' );
 
 	x = vector( new Float32Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] ), 6, 1, 0 );
 	y = vector( new Float32Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] ), 6, 1, 0 );
 
-	actual = sfirstIndexEqual( [ x, y ] );
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `-1` if unable to find an element in the first one-dimensional input ndarray equal to a corresponding element in the second one-dimensional input ndarray', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
 
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+
 	x = vector( new Float32Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] ), 6, 1, 0 );
 	y = vector( new Float32Array( [ 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ] ), 6, 1, 0 );
 
-	actual = sfirstIndexEqual( [ x, y ] );
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having non-unit strides', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	x = new Float32Array([
 		1.0,  // 0
@@ -123,16 +139,21 @@ tape( 'the function supports one-dimensional ndarrays having non-unit strides', 
 		8.0
 	]);
 
-	actual = sfirstIndexEqual( [ vector( x, 4, 2, 0 ), vector( y, 4, 2, 0 ) ] );
+	actual = sfirstIndexEqual( [ vector( x, 4, 2, 0 ), vector( y, 4, 2, 0 ), fromIndex ] );
 
 	t.strictEqual( actual, 2, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having negative strides', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	x = new Float32Array([
 		1.0,  // 3
@@ -155,16 +176,21 @@ tape( 'the function supports one-dimensional ndarrays having negative strides', 
 		8.0
 	]);
 
-	actual = sfirstIndexEqual( [ vector( x, 4, -2, 6 ), vector( y, 4, -2, 6 ) ] );
+	actual = sfirstIndexEqual( [ vector( x, 4, -2, 6 ), vector( y, 4, -2, 6 ), fromIndex ] );
 
 	t.strictEqual( actual, 2, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having non-zero offsets', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	x = new Float32Array([
 		0.0,
@@ -187,36 +213,144 @@ tape( 'the function supports one-dimensional ndarrays having non-zero offsets', 
 		4.0   // 3
 	]);
 
-	actual = sfirstIndexEqual( [ vector( x, 4, 2, 1 ), vector( y, 4, 2, 1 ) ] );
+	actual = sfirstIndexEqual( [ vector( x, 4, 2, 1 ), vector( y, 4, 2, 1 ), fromIndex ] );
 	t.strictEqual( actual, 1, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function considers NaN values as distinct', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
 
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+
 	x = vector( new Float32Array( [ NaN, NaN, NaN ] ), 3, 1, 0 );
 	y = vector( new Float32Array( [ NaN, NaN, NaN ] ), 3, 1, 0 );
 
-	actual = sfirstIndexEqual( [ x, y ] );
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function considers -0 and +0 as the same', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
 
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+
 	x = vector( new Float32Array( [ 1.0, -0.0, 3.0 ] ), 3, 1, 0 );
 	y = vector( new Float32Array( [ 0.0, 0.0, 0.0 ] ), 3, 1, 0 );
 
-	actual = sfirstIndexEqual( [ x, y ] );
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, 1, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a nonnegative starting search index', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+	var y;
+
+	x = vector( new Float32Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] ), 6, 1, 0 );
+	y = vector( new Float32Array( [ 1.0, 2.0, 0.0, 4.0, 0.0, 6.0 ] ), 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 0, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 1, {
+		'dtype': 'generic'
+	});
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 1, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative starting search index', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+	var y;
+
+	x = vector( new Float32Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] ), 6, 1, 0 );
+	y = vector( new Float32Array( [ 1.0, 2.0, 0.0, 4.0, 0.0, 6.0 ] ), 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( -1, {
+		'dtype': 'generic'
+	});
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -2, {
+		'dtype': 'generic'
+	});
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -3, {
+		'dtype': 'generic'
+	});
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -7, {
+		'dtype': 'generic'
+	});
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `-1` if provided a starting search index which is greater than or equal to number of elements in the input ndarray', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+	var y;
+
+	x = vector( new Float32Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] ), 6, 1, 0 );
+	y = vector( new Float32Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] ), 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( 6, {
+		'dtype': 'generic'
+	});
+
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, -1, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 7, {
+		'dtype': 'generic'
+	});
+
+	actual = sfirstIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1193.

## Description

> What is the purpose of this pull request?

This pull request:

-   add `fromIndex` support to `blas/ext/base/ndarray/sfirst-index-equal`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1193.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Primarily written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
