### PR TITLE
fix(@stdlib/blas/ext/find-index): supply default `fromIndex` to `gfindIndex`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/find-index/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/ext/find-index/lib/base.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var dtypes = require( '@stdlib/ndarray/dtypes' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var gfindIndex = require( '@stdlib/blas/ext/base/ndarray/gfind-index' );
 var factory = require( '@stdlib/ndarray/base/unary-reduce-strided1d-dispatch-by-factory' );
 
@@ -33,8 +34,14 @@ var policies = {
 	'output': 'integer_index_and_generic',
 	'casting': 'none'
 };
+
+// Zero-dimensional ndarray specifying the default starting search index expected by `gfindIndex`:
+var FROM_INDEX = scalar2ndarray( 0, {
+	'dtype': 'generic'
+});
+
 var table = {
-	'default': gfindIndex
+	'default': indexOf
 };
 
 
@@ -86,6 +93,21 @@ var table = {
 * // returns <ndarray>[ 1 ]
 */
 var findIndex = factory( table, [ idtypes ], odtypes, policies );
+
+
+// FUNCTIONS //
+
+/**
+* Invokes `gfindIndex` with a default starting search index.
+*
+* @private
+* @param {ArrayLikeObject<Object>} arrays - array-like object containing a one-dimensional input ndarray
+* @param {Function} clbk - callback function
+* @returns {integer} index
+*/
+function indexOf( arrays, clbk ) {
+	return gfindIndex( [ arrays[ 0 ], FROM_INDEX ], clbk );
+}
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes a `TypeError: Cannot read properties of undefined (reading 'data')` in `blas/ext/find-index/test/test.assign.js` and `test.main.js`, thrown from `ndarraylike2scalar` via `data-buffer` via `gfindIndex`
-   #14478 changed `gfindIndex(arrays, clbk, thisArg)` to require `arrays[1]` be a zero-dimensional ndarray specifying a starting search index, calling `ndarraylike2scalar(arrays[1])` unconditionally
-   `blas/ext/find-index` registers `gfindIndex` directly as the `default` entry in a `@stdlib/ndarray/base/unary-reduce-strided1d-dispatch-by-factory` table; the shared dispatch machinery (`@stdlib/ndarray/base/unary-reduce-strided1d-by`) always calls table functions with a single-element `arrays` array containing only the input view, with no concept of a `fromIndex` parameter — so `arrays[1]` was `undefined`
-   in `blas/ext/find-index/lib/base.js`, wraps `gfindIndex` in a local `indexOf(arrays, clbk)` that supplies a constant zero-dimensional `fromIndex` ndarray (value `0`) via `scalar2ndarray(0, {dtype: 'generic'})`, restoring pre-#14478 default behavior (search the whole array from the start)
-   the fix is scoped entirely to the one broken consumer package; the shared dispatch factory and the `gfind-index` kernel are untouched

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Failing run: https://github.com/stdlib-js/stdlib/actions/runs/32550930877 (`run_affected_tests` / "Run JavaScript tests"), also reproduced in a macOS Node.js v16 scheduled run (32564148576).

Diff is one file: `lib/node_modules/@stdlib/blas/ext/find-index/lib/base.js` (+23/-1).

Validation:

-   `find-index` suites pass: `test.js` (3/3), `test.main.js` (162/162), `test.assign.js` (200/200)
-   confirmed via `git stash` that the crash reproduces on pre-fix code and disappears with the fix applied
-   `make eslint-files` on the changed file is clean
-   `blas/ext/find-last-index` checked and unaffected — its kernel `gfind-last-index` has not yet received the analogous breaking change (pending in unmerged #14479)
-   no other file in the repo reaches into `find-index/lib/base.js` directly

Reviewed independently by three reviewers (correctness, regression scope, style/conventions); all three approved, no blocking findings.

Non-blocking notes for follow-up:

-   `unary-reduce-strided1d-by/lib/nd.js` calls `fcn(v, f, opts)`, inconsistent with the `fcn(v, opts, f)` order used by ~40 sibling call sites. Pre-existing, unrelated to this fix, not touched here. Worth a separate issue if a maintainer thinks it's worth fixing.
-   once #14479 merges (`fromIndex` for `gfind-last-index`), `blas/ext/find-last-index/lib/base.js` will hit the identical `arrays[1]` crash — that PR does not update the consumer. Flagging on #14479 directly.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored autonomously by an AI agent (a scheduled CI-monitoring routine, using Claude) based on failure analysis of the linked GitHub Actions run. Root-cause analysis, the fix, and validation were performed by the agent; changes were reviewed by three independent review passes before submission.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_012nqttoW58kShuKcCb6SYai)_