### PR TITLE
test: migrate `math/base/special/cfloorn` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cfloorn/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cfloorn/test/test.js
@@ -21,14 +21,13 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var PI = require( '@stdlib/constants/float64/pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var randu = require( '@stdlib/random/base/randu' );
 var round = require( '@stdlib/math/base/special/round' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
@@ -262,8 +261,6 @@ tape( 'if `n > 308` and a component is greater than or equal to zero, the functi
 
 tape( 'the function supports rounding very small numbers (including subnormals)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var n;
 	var v;
@@ -297,17 +294,8 @@ tape( 'the function supports rounding very small numbers (including subnormals)'
 
 	for ( i = 0; i < n.length; i++ ) {
 		v = cfloorn( new Complex128( x, x ), n[i] );
-		if ( real( v ) === expected[i] ) {
-			t.strictEqual( real( v ), expected[i], 'returns '+expected[i]+' when provided re='+x+', im='+x+', and n='+n[i]+'.' );
-		} else {
-			delta = abs( real( v ) - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 're: '+x+'. n: '+n[i]+'. v: '+real( v )+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
-
-			delta = abs( imag( v ) - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'im: '+x+'. n: '+n[i]+'. v: '+imag( v )+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( real( v ), expected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( v ), expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cfloorn/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cfloorn/test/test.native.js
@@ -22,13 +22,12 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var PI = require( '@stdlib/constants/float64/pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var randu = require( '@stdlib/random/base/randu' );
 var round = require( '@stdlib/math/base/special/round' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
@@ -234,8 +233,6 @@ tape( 'if `n > 308` and a component is greater than or equal to zero, the functi
 
 tape( 'the function supports rounding very small numbers (including subnormals)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var n;
 	var v;
@@ -269,17 +266,8 @@ tape( 'the function supports rounding very small numbers (including subnormals)'
 
 	for ( i = 0; i < n.length; i++ ) {
 		v = cfloorn( new Complex128( x, x ), n[i] );
-		if ( real( v ) === expected[i] ) {
-			t.strictEqual( real( v ), expected[i], 'returns '+expected[i]+' when provided re='+x+', im='+x+', and n='+n[i]+'.' );
-		} else {
-			delta = abs( real( v ) - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 're: '+x+'. n: '+n[i]+'. v: '+real( v )+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
-
-			delta = abs( imag( v ) - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'im: '+x+'. n: '+n[i]+'. v: '+imag( v )+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( real( v ), expected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( v ), expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates `math/base/special/cfloorn` test cases from relative-tolerance (`EPS`-based) comparisons to ULP-difference-based assertions, per the RFC in #11352.
-   In `test/test.js` and `test/test.native.js`, the single test case using the old `delta = abs( ... ); tol = EPS * abs( ... ); t.strictEqual( delta <= tol, true, ... )` idiom (subnormal-rounding test) is replaced with `t.strictEqual( isAlmostSameValue( ..., ..., 1 ), true, 'returns expected value' )`, dropping the now-unused `EPS` and `abs` requires in favor of `@stdlib/assert/is-almost-same-value`.
-   The ULP bound was tightened empirically: `1` passes the full fixture set (890 assertions in `test.js`); `0` (exact equality) fails 12 of those assertions, so `1` is the minimum required bound.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

`test/test.native.js` mirrors the same conversion for the native addon test file; those tests are skipped in this environment (no compiled native addon available), but `test/test.js` was run twice to confirm deterministic results at ULP=1.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, mirroring the ULP-migration idiom from prior merged PRs in the same package family (e.g. `math/base/special/cceiln`, `math/base/special/floorn`) and empirically tightening the ULP bound as described above.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_019nsBjCLFdasc1247SvS3Zw)_