### PR TITLE
test: migrate `stats/base/dists/chisquare/median` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/median/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/median/test/test.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var median = require( './../lib' );
 
 
@@ -61,8 +60,6 @@ tape( 'if provided a degrees of freedom `k` that is not a nonnegative number, th
 
 tape( 'the function returns the median of chi-squared distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -71,13 +68,7 @@ tape( 'the function returns the median of chi-squared distribution', function te
 	k = data.k;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = median( k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k: '+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 25.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 39 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `stats/base/dists/chisquare/median` tests from relative tolerance testing to ULP difference testing.
-   replaces `var delta`/`var tol` tolerance math (previously `tol = 25.0 * EPS * abs( expected[ i ] )`) and the associated `t.ok( delta <= tol, ... )` assertion with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 39 ), true, 'returns expected value' );`.
-   adds the `@stdlib/assert/is-almost-same-value` require and drops the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

Only `test/test.js` is modified; the package has no `test/test.native.js`.

**Final ULP constant:** `39` for the `test/test.js` fixture loop (`test/fixtures/julia/data.json`, 50 values).

**Measured minimum:** `39` is the tightest bound. Running the package test suite at `38` fails one assertion (worst case: `k = 0.20785020415982736`, returned `0.0015467191018913129` vs. expected `0.0015467191018913044`); `39` passes all 55 assertions. The suite was run twice at `39` to confirm the result is deterministic on this machine.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task: it selected the package, studied already-migrated packages to mirror the project's idiom, applied the test changes, and searched for the minimum passing ULP bound by running the package test suite.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01MAEBRF5LEKrKy5oLKGLSHB)_