### PR TITLE
test: migrate `stats/base/dists/f/quantile` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/f/quantile/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/quantile/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -166,8 +165,6 @@ tape( 'if provided a nonpositive `d1`, the created function always returns `NaN`
 tape( 'the created function evaluates the quantile for `p` given large `d1` and `d2`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var d1;
 	var d2;
 	var i;
@@ -181,13 +178,7 @@ tape( 'the created function evaluates the quantile for `p` given large `d1` and 
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( d1[i], d2[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', d1: '+d1[i]+', d2: '+d2[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. d1: '+d1[i]+'. d2: '+d2[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 23 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -195,8 +186,6 @@ tape( 'the created function evaluates the quantile for `p` given large `d1` and 
 tape( 'the created function evaluates the quantile for `p` given large parameter `d1`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var d1;
 	var d2;
 	var p;
@@ -210,13 +199,7 @@ tape( 'the created function evaluates the quantile for `p` given large parameter
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( d1[i], d2[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', d1: '+d1[i]+', d2: '+d2[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 30.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. d1: '+d1[i]+'. d2: '+d2[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 20 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -224,8 +207,6 @@ tape( 'the created function evaluates the quantile for `p` given large parameter
 tape( 'the created function evaluates the quantile for `p` given large parameter `d2`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var d1;
 	var d2;
 	var i;
@@ -239,13 +220,7 @@ tape( 'the created function evaluates the quantile for `p` given large parameter
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( d1[i], d2[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', d1: '+d1[i]+', d2: '+d2[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. d1: '+d1[i]+'. d2: '+d2[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 14 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/f/quantile/test/test.quantile.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/quantile/test/test.quantile.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var quantile = require( './../lib' );
 
 
@@ -118,8 +117,6 @@ tape( 'if provided a nonpositive `d2`, the function returns `NaN`', function tes
 
 tape( 'the function evaluates the quantile for `x` given large parameters `d1` and `d2`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var d1;
 	var d2;
 	var i;
@@ -132,21 +129,13 @@ tape( 'the function evaluates the quantile for `x` given large parameters `d1` a
 	d2 = bothLarge.d2;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], d1[i], d2[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', d1: '+d1[i]+', d2: '+d2[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. d1: '+d1[i]+'. d2: '+d2[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 23 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the quantile for `x` given large parameter `d1`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var d1;
 	var d2;
 	var i;
@@ -159,21 +148,13 @@ tape( 'the function evaluates the quantile for `x` given large parameter `d1`', 
 	d2 = largeD1.d2;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], d1[i], d2[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', d1: '+d1[i]+', d2: '+d2[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 30.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. d1: '+d1[i]+'. d2: '+d2[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 20 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the quantile for `x` given large parameter `d2`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var d1;
 	var d2;
 	var i;
@@ -186,13 +167,7 @@ tape( 'the function evaluates the quantile for `x` given large parameter `d2`', 
 	d2 = largeD2.d2;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], d1[i], d2[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', d1: '+d1[i]+', d2: '+d2[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. d1: '+d1[i]+'. d2: '+d2[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 14 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/f/quantile` from relative tolerance (`EPS`-scaled `delta <= tol`) assertions to ULP difference assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].

Both `test/test.quantile.js` and `test/test.factory.js` are updated. The package has no `test/test.native.js`. The `abs` and `EPS` imports are no longer needed and have been removed, along with the now unused `delta` and `tol` locals. Only test files are changed; no source or fixture changes.

Each fixture-driven test block now asserts

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], N ), true, 'returns expected value' );
```

The following ULP bounds are used, corresponding to the previous relative tolerances:

| Fixture | Test block | Previous tolerance | ULP bound |
| --- | --- | --- | --- |
| `cpp/both_large.json` | large `d1` and `d2` | `20.0 * EPS` | `23` |
| `cpp/large_d1.json` | large `d1` | `30.0 * EPS` | `20` |
| `cpp/large_d2.json` | large `d2` | `20.0 * EPS` | `14` |

The same bounds apply to the corresponding `test.factory.js` blocks, as the measured maximum ULP difference is identical for the main and factory code paths.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The ULP bounds above are the **measured minimums** over the full fixture sets (1000 values each), determined by computing, for every fixture value and for both the `quantile` and `factory` code paths, the smallest `N` for which `isAlmostSameValue( actual, expected, N )` returns `true`, and taking the maximum over each fixture set. Each bound was confirmed to be tight: `N - 1` fails for at least one value in the corresponding fixture set (worst-case index 431 for `both_large`, 419 for `large_d1`, 429 for `large_d2`).

The test suite was run twice at the final bounds; both runs pass identically (3021 assertions in `test.quantile.js`, 3024 in `test.factory.js`), so the bounds are not sensitive to run-to-run nondeterminism on this machine. `eslint` (using `etc/eslint/.eslintrc.tests.js`) reports no problems for either changed file.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated batch migration for #11352. The conversion mirrors the idiom established in previously merged migration PRs (e.g. #14543, #14373), and the ULP bounds were measured empirically as described above rather than guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzWD5xwuqcJFAKukLxoEsZ)_