### PR TITLE
chore: fix EditorConfig lint errors (issue #14500)

### DIFF
--- a/lib/node_modules/@stdlib/plot/ctor/lib/props/x-rug-orient/orientations.json
+++ b/lib/node_modules/@stdlib/plot/ctor/lib/props/x-rug-orient/orientations.json
@@ -1,4 +1,4 @@
 [
-	"bottom",
-	"top"
+    "bottom",
+    "top"
 ]


### PR DESCRIPTION
Resolves #14500 

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes the EditorConfig indentation errors in lib/node_modules/@stdlib/plot/ctor/lib/props/x-rug-orient/orientations.json by replacing tab indentation with four spaces.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #14500 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

   No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
