### PR TITLE
test: migrate `stats/base/dists/rayleigh/cdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/cdf/test/test.cdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( './../lib' );
 
 
@@ -93,9 +92,7 @@ tape( 'if provided `sigma` equals `0`, the function evaluates a degenerate distr
 
 tape( 'the function evaluates the cdf for `x` given small scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -105,22 +102,14 @@ tape( 'the function evaluates the cdf for `x` given small scale parameter `sigma
 	sigma = smallScale.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given medium scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -130,22 +119,14 @@ tape( 'the function evaluates the cdf for `x` given medium scale parameter `sigm
 	sigma = mediumScale.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given large scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -155,13 +136,7 @@ tape( 'the function evaluates the cdf for `x` given large scale parameter `sigma
 	sigma = largeScale.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/cdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -126,10 +125,8 @@ tape( 'if `sigma` equals `0`, the created function evaluates a degenerate distri
 
 tape( 'the created function evaluates the cdf for `x` given small scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
 	var cdf;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -140,23 +137,15 @@ tape( 'the created function evaluates the cdf for `x` given small scale paramete
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( sigma[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given medium scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
 	var cdf;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -167,23 +156,15 @@ tape( 'the created function evaluates the cdf for `x` given medium scale paramet
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( sigma[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given large scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
 	var cdf;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -194,13 +175,7 @@ tape( 'the created function evaluates the cdf for `x` given large scale paramete
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( sigma[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/cdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -102,9 +101,7 @@ tape( 'if provided `sigma` equals `0`, the function evaluates a degenerate distr
 
 tape( 'the function evaluates the cdf for `x` given small scale parameter `sigma`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -114,22 +111,14 @@ tape( 'the function evaluates the cdf for `x` given small scale parameter `sigma
 	sigma = smallScale.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given medium scale parameter `sigma`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -139,22 +128,14 @@ tape( 'the function evaluates the cdf for `x` given medium scale parameter `sigm
 	sigma = mediumScale.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given large scale parameter `sigma`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -164,13 +145,7 @@ tape( 'the function evaluates the cdf for `x` given large scale parameter `sigma
 	sigma = largeScale.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the fixture-based tests for `stats/base/dists/rayleigh/cdf` from relative-tolerance (EPS-based) comparisons to ULP-difference based assertions using `@stdlib/assert/is-almost-same-value`, per the tracking issue.
-   Updates `test/test.cdf.js`, `test/test.factory.js`, and `test/test.native.js`. Each fixture-loop test case now uses `t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' )`.
-   The minimum ULP bound was determined empirically by starting from a generous bound and lowering it until the smallest value that still passes the full fixture set (small/medium/large scale fixtures) was found: **0 ULPs** (bit-exact match against the Julia-computed fixtures) for both the JavaScript implementation and the native C implementation (`test.native.js`, verified after building the add-on locally). Verified deterministic by running the suite twice at this bound.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored autonomously by Claude Code, run as a scheduled task by the repository maintainer (@Planeshifter) to convert one package's tests to ULP-based assertions, following the exact idiom established in prior merged conversions in the same package family (e.g. `stats/base/dists/rayleigh/pdf`, `stats/base/dists/normal/cdf`). The minimum ULP bound was determined empirically by running the test suite, not guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01KE8saM3X9my3Dj3cTCLrs9)_