### PR TITLE
test: migrate `stats/base/dists/beta/entropy` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/beta/entropy/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/entropy/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var entropy = require( './../lib' );
 
 
@@ -96,10 +95,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the differential entropy of a beta distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -108,13 +105,7 @@ tape( 'the function returns the differential entropy of a beta distribution', fu
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 250.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 384 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/entropy/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/entropy/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -105,10 +104,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 
 tape( 'the function returns the differential entropy of a beta distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -117,13 +114,7 @@ tape( 'the function returns the differential entropy of a beta distribution', op
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 250.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 384 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suites for `stats/base/dists/beta/entropy` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `delta`/`tol` comparisons in `test/test.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 384 ), true, 'returns expected value' );`, adding the `@stdlib/assert/is-almost-same-value` require and dropping the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**ULP bound: `384` (both `test/test.js` and `test/test.native.js`), the measured minimum over the fixture set.**

The bound was determined empirically rather than assumed. Starting from a high bound and bisecting downward over `isAlmostSameValue` across the full Julia fixture set (1000 values), the minimum admissible bound is exactly `384`: 401 of the 1000 returned values are bit-identical to the Julia reference, and the largest ULP difference among the remainder is `384`, attained at `alpha = 10.003231427967421`, `beta = 13.875047324311737`. Lowering the bound to `383` was confirmed to fail (3 failing assertions out of 1014), so the bound cannot be tightened further. The suite was then run twice at the final bound with identical results (1014/1014 passing per suite in each run), so the bound is not sensitive to run-to-run variation.

The previous relative tolerance was `250.0 * EPS * abs( expected[ i ] )`, which corresponds to roughly 250–500 ULP depending on where the expected value falls within its binade, so `384` sits within the prior accuracy budget rather than loosening it.

To confirm that `384` is also correct for the C implementation, the native addon was compiled locally via `make install-node-addons NODE_ADDONS_PATTERN="stats/base/dists/beta/entropy"` and `test/test.native.js` was executed against the real addon rather than being skipped: it likewise passes all 1014 assertions at `384` ULP, twice, and bisecting the native results independently also yields `384` as the minimum. This matches the sibling conversions in this family (`weibull/entropy`, `normal/entropy`, `logistic/entropy`), which likewise use a single bound across both suites.

Only the two test files are modified; no implementation, fixture, or documentation changes are included.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Notes on local verification:

-   `make install-node-modules` initially failed in this environment because the local npm cache held a stale packument for `es-object-atoms`, causing `es-object-atoms@^1.1.2` to resolve as nonexistent. Clearing the npm cache resolved it; no repository files were involved.
-   `make lint-editorconfig-files` (run via the pre-commit hook) could not execute because the `editorconfig-checker` binary download is blocked in this environment. The changed files were instead checked manually for indentation (tabs), trailing whitespace, line endings (LF), and final newline, and match the surrounding files exactly.
-   `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/beta/entropy/.*"` reports no problems for either file.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. It studied previously merged conversions under #11352 (including the `weibull/entropy` and `rayleigh/cdf` siblings) to match the established idiom, applied the migration, measured the minimum ULP bound empirically against the fixtures for both the JavaScript and the locally compiled C implementation, and verified that the tests pass and that the files lint cleanly.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_017haVpPP3C1QAFz8H5KETYQ)_