### PR TITLE
test: migrate `stats/base/dists/t/pdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -131,9 +130,7 @@ tape( 'if provided a nonpositive `v`, the created function always returns `NaN`'
 
 tape( 'the created function evaluates the pdf for `x` given parameter `v` (when `x` and `v` are small)', function test( t ) {
 	var expected;
-	var delta;
 	var pdf;
-	var tol;
 	var i;
 	var v;
 	var x;
@@ -145,22 +142,14 @@ tape( 'the created function evaluates the pdf for `x` given parameter `v` (when 
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( v[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 9 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` is large and `v` small)', function test( t ) {
 	var expected;
-	var delta;
 	var pdf;
-	var tol;
 	var i;
 	var v;
 	var x;
@@ -172,22 +161,14 @@ tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` is l
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( v[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 12 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` is small and `v` large)', function test( t ) {
 	var expected;
-	var delta;
 	var pdf;
-	var tol;
 	var i;
 	var v;
 	var x;
@@ -199,22 +180,14 @@ tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` is s
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( v[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 52 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` and `v` are large)', function test( t ) {
 	var expected;
-	var delta;
 	var pdf;
-	var tol;
 	var i;
 	var v;
 	var x;
@@ -226,13 +199,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` and 
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( v[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 57 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -112,8 +111,6 @@ tape( 'if provided a nonpositive `v`, the function always returns `NaN`', opts, 
 
 tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` and `v` are small)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -124,21 +121,13 @@ tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` and 
 	v = smallSmall.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[ i ], v[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + ', v: ' + v[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. v: ' + v[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 9 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` is large and `v` small)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -149,21 +138,13 @@ tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` is l
 	v = largeSmall.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[ i ], v[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + ', v: ' + v[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. v: ' + v[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 12 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` is small and `v` large)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -174,21 +155,13 @@ tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` is s
 	v = smallLarge.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[ i ], v[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + ', v: ' + v[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. v: ' + v[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 52 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` and `v` are large)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -199,13 +172,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` and 
 	v = largeLarge.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[ i ], v[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + ', v: ' + v[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. v: ' + v[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 57 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/test/test.pdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( './../lib' );
 
 
@@ -103,8 +102,6 @@ tape( 'if provided a nonpositive `v`, the function always returns `NaN`', functi
 
 tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` and `v` are small)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -115,21 +112,13 @@ tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` and 
 	v = smallSmall.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], v[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 9 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` is large and `v` small)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -140,21 +129,13 @@ tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` is l
 	v = largeSmall.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], v[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 12 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` is small and `v` large)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -165,21 +146,13 @@ tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` is s
 	v = smallLarge.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], v[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 52 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` and `v` are large)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -190,13 +163,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `v` (when `x` and 
 	v = largeLarge.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], v[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 57 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/t/pdf` from relative tolerance testing (`delta <= tol`, where `tol = {10.0,40.0} * EPS * abs( expected[ i ] )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].

Changes are limited to test files:

-   `test/test.pdf.js`
-   `test/test.factory.js`
-   `test/test.native.js`

In each of the four fixture loops in each file, the `if ( y === expected[i] ) { ... } else { delta/tol ... }` branch was replaced with

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], N ), true, 'returns expected value' );
```

The `@stdlib/assert/is-almost-same-value` require was added, and the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires (along with the `delta` and `tol` locals) were removed. Unlike some sibling packages, `EPS` is not otherwise referenced in any of these three files, so it is removed from all three.

`test/test.js` is unchanged, as it contains no tolerance-based assertions.

### ULP constants

The bound differs per fixture, matching the per-fixture tolerances it replaces. The measured **minimum** ULP values are:

| Fixture | Previous tolerance | ULP |
| --- | --- | --- |
| `small_small.json` | `10.0 * EPS` | 9 |
| `large_small.json` | `10.0 * EPS` | 12 |
| `small_large.json` | `40.0 * EPS` | 52 |
| `large_large.json` | `40.0 * EPS` | 57 |

The same four values apply to all three converted files (`test/test.pdf.js`, `test/test.factory.js`, `test/test.native.js`).

Each bound was tightened by measuring the exact worst-case ULP difference over the full Julia fixture set (4 fixtures × 1001 values = 4004 values). For every bound, exactly one assertion fails at `N-1`, confirming each value is the minimum admissible integer bound:

| Fixture | Values | Exact (0 ULP) | Max observed ULP | Cases at max | Failures at `N-1` |
| --- | --- | --- | --- | --- | --- |
| `small_small.json` | 1001 | 194 | 9 | 1 | 1 |
| `large_small.json` | 1001 | 154 | 12 | 1 | 1 |
| `small_large.json` | 1001 | 74 | 52 | 1 | 1 |
| `large_large.json` | 1001 | 68 | 57 | 1 | 1 |

Notably, the JavaScript implementation, the factory-generated function, and the native implementation return **bit-identical** results for all 4004 fixture values, so the same bounds are the measured minima for all three files.

For reference, the previous `10.0 * EPS` and `40.0 * EPS` relative tolerances correspond to roughly 10–20 ULP and 40–80 ULP respectively, so the new bounds are consistent with the tolerances they replace.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed locally on `linux/x64`, Node.js v22:

-   `make test TESTS_FILTER=".*/stats/base/dists/t/pdf/.*"` — 12057 assertions passing, 0 failing (`test.pdf.js` 4018, `test.factory.js` 4018, `test.js` 3, `test.native.js` 4018). The native add-on was compiled locally via `node-gyp rebuild`, so the `test.native.js` assertions actually executed rather than being skipped.
-   The full suite was run twice at the final ULP values with identical results, confirming no FMA/architecture-dependent flakiness locally.
-   `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/t/pdf/.*"` — clean.
-   The only files changed are the three test files.

One environment note: the `lint-editorconfig-files` pre-commit hook could not run locally, as it downloads the `editorconfig-checker` binary from a GitHub release that was not reachable from the sandbox. The changed files were instead checked by hand for tab indentation, absence of trailing whitespace, LF line endings, and a final newline — all clean, and consistent with the files' pre-existing formatting.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task. The tolerance-to-ULP conversion mirrors the idiom of already-migrated packages in the same family (e.g., `stats/base/dists/chi/pdf` and `stats/base/dists/gamma/pdf`); the ULP bound search and the local verification runs were performed by the agent.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2vUyEdPo6h4923rGJsp8W)_