### PR TITLE
test: migrate `stats/incr/nancovariance` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nancovariance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nancovariance/test/test.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var incrnancovariance = require( './../lib' );
 
 
@@ -101,7 +100,6 @@ tape( 'the accumulator function skips pairs containing NaN', function test( t ) 
 
 tape( 'the accumulator function computes correct covariance for multiple valid pairs interspersed with invalid pairs', function test( t ) {
 	var expected = 14.0/3.0;
-	var delta;
 	var data = [
 		[ 2.0, 1.0 ],
 		[ NaN, 4.0 ],
@@ -112,14 +110,11 @@ tape( 'the accumulator function computes correct covariance for multiple valid p
 	];
 	var acc = incrnancovariance();
 	var cov;
-	var tol;
 	var i;
 	for ( i = 0; i < data.length; i++ ) {
 		cov = acc( data[ i ][ 0 ], data[ i ][ 1 ] );
 	}
-	delta = abs( cov - expected );
-	tol = EPS * abs( expected );
 	t.equal( typeof cov, 'number', 'returns a number' );
-	t.ok( delta < tol, 'within tolerance. Actual: '+cov+'. Expected: '+expected+'. delta: '+delta+'. tol: '+tol+'.' );
+	t.strictEqual( isAlmostSameValue( cov, expected, 0 ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/incr/nancovariance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nancovariance/test/test.js
@@ -35,17 +35,17 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function returns an accumulator function', function test( t ) {
 	var acc = incrnancovariance();
-	t.strictEqual( typeof acc, 'function', 'returns a function' );
+	t.strictEqual( typeof acc, 'function', 'returns expected value' );
 	t.end();
 });
 
 tape( 'the accumulator function returns null if no valid pairs have been provided', function test( t ) {
 	var acc = incrnancovariance();
-	t.equal( acc(), null, 'returns null initially' );
+	t.strictEqual( acc(), null, 'returns expected value' );
 
 	// Provide an invalid pair:
 	acc( NaN, 5.0 );
-	t.equal( acc(), null, 'still null after invalid pair' );
+	t.strictEqual( acc(), null, 'returns expected value' );
 	t.end();
 });
 
@@ -54,53 +54,63 @@ tape( 'the accumulator function returns null if only one valid pair has been pro
 
 	// Add the first valid pair:
 	acc( 2.0, 1.0 );
-	t.equal( acc(), null, 'returns null for single valid pair' );
+	t.strictEqual( acc(), null, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the accumulator function computes sample covariance once two valid pairs have been provided', function test( t ) {
-	var acc = incrnancovariance();
+	var acc;
 	var cov;
+
+	acc = incrnancovariance();
 
 	// Pair #1:
 	cov = acc( 2.0, 1.0 );
-	t.equal( cov, null, 'still null with only one valid pair' );
+	t.strictEqual( cov, null, 'returns expected value' );
 
 	// Pair #2:
 	cov = acc( 4.0, 5.0 );
-	t.equal( cov, 4.0, 'returns sample covariance after second valid pair' );
+	t.strictEqual( cov, 4.0, 'returns expected value' );
 
 	// Current covariance with no arguments:
-	t.equal( acc(), 4.0, 'returns current covariance' );
+	t.strictEqual( acc(), 4.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the accumulator function skips pairs containing NaN', function test( t ) {
-	var acc = incrnancovariance();
+	var acc;
 	var cov;
+
+	acc = incrnancovariance();
 
 	// Provide first valid pair:
 	cov = acc( 2.0, 1.0 );
-	t.equal( cov, null, 'null with only one valid pair' );
+	t.strictEqual( cov, null, 'returns expected value' );
 
 	// Invalid pair => skip:
 	cov = acc( NaN, 10.0 );
-	t.equal( cov, null, 'still null, as second pair is invalid' );
+	t.strictEqual( cov, null, 'returns expected value' );
 
 	// Provide second valid pair:
 	cov = acc( 2.0, 5.0 );
+
 	// For (2,1) and (2,5): same X => covariance=0
-	t.equal( cov, 0.0, 'returns 0.0 for these pairs' );
+	t.strictEqual( cov, 0.0, 'returns expected value' );
 
 	// Provide third valid pair:
 	cov = acc( 5.0, 9.0 );
-	t.equal( typeof cov, 'number', 'returns a number after third valid pair' );
+	t.strictEqual( typeof cov, 'number', 'returns expected value' );
 	t.end();
 });
 
 tape( 'the accumulator function computes correct covariance for multiple valid pairs interspersed with invalid pairs', function test( t ) {
-	var expected = 14.0/3.0;
-	var data = [
+	var expected;
+	var data;
+	var acc;
+	var cov;
+	var i;
+
+	data = [
 		[ 2.0, 1.0 ],
 		[ NaN, 4.0 ],
 		[ 4.0, 5.0 ],
@@ -108,13 +118,13 @@ tape( 'the accumulator function computes correct covariance for multiple valid p
 		[ NaN, NaN ],
 		[ 5.0, 11.0 ]
 	];
-	var acc = incrnancovariance();
-	var cov;
-	var i;
+	acc = incrnancovariance();
 	for ( i = 0; i < data.length; i++ ) {
 		cov = acc( data[ i ][ 0 ], data[ i ][ 1 ] );
 	}
-	t.equal( typeof cov, 'number', 'returns a number' );
+	t.strictEqual( typeof cov, 'number', 'returns expected value' );
+
+	expected = 14.0/3.0;
 	t.strictEqual( isAlmostSameValue( cov, expected, 0 ), true, 'returns expected value' );
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for `stats/incr/nancovariance` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `delta`/`tol` comparison in `test/test.js` with `t.strictEqual( isAlmostSameValue( cov, expected, 0 ), true, 'returns expected value' );`, adding the `@stdlib/assert/is-almost-same-value` require and dropping the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**ULP bound: `0`, the measured minimum.** The package has no `test/test.native.js`, so `test/test.js` is the only test file changed.

The bound was determined empirically rather than assumed. Starting from a high bound and lowering it, the accumulated covariance for the fixture sequence in the affected test is bit-identical to the expected value `14/3`: the measured ULP difference between the returned value (`4.666666666666667`) and the expected value is exactly `0`, so the bound cannot be tightened further. The suite was then run twice at the final bound with identical results (15/15 passing in each run), so the bound is not sensitive to run-to-run variation.

A bound of `0` is stable here because the accumulator is pure double-precision JavaScript arithmetic: `stats/incr/nancovariance` delegates to `stats/incr/covariance`, whose Welford-style update uses only IEEE-754 addition, subtraction, multiplication, and division, all of which are correctly rounded and reproducible across platforms (JavaScript performs no FMA contraction). The previous relative tolerance was `EPS * abs( expected )`, i.e. roughly one ULP at this magnitude, so `0` sits within the prior accuracy budget rather than loosening it.

Only the one test file is modified; no implementation, fixture, or documentation changes are included.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Notes on local verification:

-   `make test TESTS_FILTER=".*/stats/incr/nancovariance/.*"` passes 15/15 assertions, run twice.
-   `make lint-javascript-tests TESTS_FILTER=".*/stats/incr/nancovariance/.*"` reports no problems.
-   `make install-node-modules` initially failed in this environment because the local npm cache held a stale packument for `es-object-atoms`, causing `es-object-atoms@^1.1.2` to resolve as nonexistent. Clearing the npm cache resolved it; no repository files were involved.
-   `make lint-editorconfig-files` (run via the pre-commit hook) could not execute because the `editorconfig-checker` binary download is blocked in this environment. The changed file was instead checked manually for indentation (tabs), trailing whitespace, line endings (LF), and final newline, and matches the surrounding files exactly.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. It studied previously merged conversions under #11352 (including the `stats/incr/nanskewness` sibling) to match the established idiom, applied the migration, measured the minimum ULP bound empirically against the values exercised by the test, and verified that the tests pass and that the file lints cleanly.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuySsNNMLd6DU7uuU4kLHc)_