### PR TITLE
test: migrate `math/base/special/binomcoeff` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/binomcoeff/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoeff/test/test.native.js
@@ -22,8 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var absf = require( '@stdlib/math/base/special/absf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -52,8 +51,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function evaluates the binomial coefficient for integers `n` and `k`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var n;
 	var k;
 	var v;
@@ -65,15 +62,9 @@ tape( 'the function evaluates the binomial coefficient for integers `n` and `k`'
 	for ( i = 0; i < n.length; i++ ) {
 		v = binomcoeff( n[ i ], k[ i ] );
 		expected[ i ] = float64ToFloat32( expected[ i ] );
-		if ( expected[ i ] === v ) {
-			t.strictEqual( v, expected[ i ], 'returns expected value' );
-			continue;
-		}
-		delta = absf( v - expected[ i ] );
 
 		// NOTE: Exact comparison fails for large values due to single-precision floating-point rounding errors when intermediate results exceed the maximum safe integer for a 32-bit float.
-		tol = 1.25 * EPS * absf( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n[ i ] + '. k: ' + k[ i ] + '. actual: ' + v + '. expected: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.native.js` for `math/base/special/binomcoeff` from a manual `delta`/`tol` tolerance comparison to `isAlmostSameValue`-based (ULP) assertions, mirroring the pattern already used in `test/test.js` for the same package
-   the tightest ULP bound found is `2`, matching the bound already established in the JS binding's tests (`test/test.js`)

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

`test/test.js` for this package was already converted to use `isAlmostSameValue` with `N=2`; only `test/test.native.js` still used the old manual tolerance idiom. This PR brings `test/test.native.js` in line with `test/test.js`. The minimum ULP bound was found by testing `N=0` (111 failures), `N=1` (3 failures), and `N=2` (0 failures, 2006/2006 passing), then confirmed deterministic by running the suite twice at `N=2`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, running as a scheduled/automated task to migrate stdlib packages to ULP-based test assertions per #11352.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPpvoSD89JHirhDwd2dwXS)_