### PR TITLE
test: migrate `stats/base/dists/invgamma/skewness` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var skewness = require( './../lib' );
 
 
@@ -96,10 +95,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the skewness of a gamma distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -108,13 +105,7 @@ tape( 'the function returns the skewness of a gamma distribution', function test
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = skewness( alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -105,10 +104,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 
 tape( 'the function returns the skewness of a gamma distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -117,13 +114,7 @@ tape( 'the function returns the skewness of a gamma distribution', opts, functio
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = skewness( alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suites for `stats/base/dists/invgamma/skewness` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `delta`/`tol` comparisons in `test/test.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );`, adding the `@stdlib/assert/is-almost-same-value` require and dropping the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**ULP bound: `0` (both `test/test.js` and `test/test.native.js`), the measured minimum over the fixture set.**

The bound was determined empirically rather than assumed: for every fixture, the minimum admissible bound was found by scanning `isAlmostSameValue` upward from `0`, and the maximum over the full Julia fixture set (all 200 values) is exactly `0`. That is, the implementation reproduces every fixture value bit-for-bit, so the bound is already at its floor and cannot be tightened further. The previous relative tolerance was `2.0 * EPS`, so this is a tightening, not a loosening, of the prior accuracy budget. Note that the removed `if ( y === expected[ i ] ) { ... } else { ... }` branch was therefore always taking the exact-equality path.

The suite was run twice at the final bound with identical results (214/214 passing each time), so the bound is not sensitive to run-to-run variation.

The native addon was built locally for this package, so `test/test.native.js` was actually exercised rather than skipped (214/214 passing, twice, with no skipped assertions). Evaluating the C implementation over the same fixtures gives a maximum ULP difference of `0` as well, attained with all 200 values matching exactly, so a single bound is correct across both suites. This matches the sibling conversions in this family (`erlang/skewness`, `gamma/kurtosis`, `weibull/entropy`), which likewise use a single bound across both suites.

Only the two test files are modified; no implementation, fixture, or documentation changes are included.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Two environment notes, neither of which affects the diff:

-   `make install-node-modules` initially failed in this sandbox because the npm registry mirror serves `string.prototype.trim@1.2.11` but not its `es-object-atoms@^1.1.2` dependency. Installation succeeded with a temporary, local-only `overrides` entry pinning `string.prototype.trim` to `1.2.10`; `package.json` was restored immediately afterwards and is unchanged in this PR.
-   The `lint-editorconfig` pre-commit hook could not run because the `editorconfig-checker` wrapper downloads its binary from GitHub releases, which is not reachable from this sandbox. The two changed files were instead verified manually against `.editorconfig` (LF endings, UTF-8, tab indentation, no trailing whitespace, final newline). `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/invgamma/skewness/.*"` passes cleanly.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. It studied previously merged conversions under #11352 (including the `erlang/skewness` sibling) to match the established idiom, applied the migration, measured the minimum ULP bound empirically against the fixtures for both the JS and the native implementations, and verified that the tests pass deterministically and that the files lint cleanly.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Po7gRdW6SWEn56LZSX96WL)_