### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/slice-dimension-from/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/slice-dimension-from/test/test.js
@@ -488,13 +488,17 @@ tape( 'in non-strict mode, the function returns an empty array when a starting i
 	var start;
 	var i;
 
+	/* eslint-disable stdlib/line-closing-bracket-spacing */
+
 	values = [
-		zeros( [ 1 ], { 'dtype': 'float64' }),
-		zeros( [ 1, 1 ], { 'dtype': 'float32' }),
-		zeros( [ 1, 1, 1 ], { 'dtype': 'int32' }),
-		zeros( [ 1, 1, 1, 1 ], { 'dtype': 'uint32' }),
-		zeros( [ 1, 1, 1, 1, 1 ], { 'dtype': 'complex128' })
+		zeros( [ 1 ], { 'dtype': 'float64' } ),
+		zeros( [ 1, 1 ], { 'dtype': 'float32' } ),
+		zeros( [ 1, 1, 1 ], { 'dtype': 'int32' } ),
+		zeros( [ 1, 1, 1, 1 ], { 'dtype': 'uint32' } ),
+		zeros( [ 1, 1, 1, 1, 1 ], { 'dtype': 'complex128' } )
 	];
+
+	/* eslint-enable stdlib/line-closing-bracket-spacing */
 
 	start = [
 		10,
@@ -521,13 +525,17 @@ tape( 'in non-strict mode, the function returns an empty array when a starting i
 	var dim;
 	var i;
 
+	/* eslint-disable stdlib/line-closing-bracket-spacing */
+
 	values = [
-		zeros( [ 1 ], { 'dtype': 'float64' }),
-		zeros( [ 1, 1 ], { 'dtype': 'float32' }),
-		zeros( [ 1, 1, 1 ], { 'dtype': 'int32' }),
-		zeros( [ 1, 1, 1, 1 ], { 'dtype': 'uint32' }),
-		zeros( [ 1, 1, 1, 1, 1 ], { 'dtype': 'complex128' })
+		zeros( [ 1 ], { 'dtype': 'float64' } ),
+		zeros( [ 1, 1 ], { 'dtype': 'float32' } ),
+		zeros( [ 1, 1, 1 ], { 'dtype': 'int32' } ),
+		zeros( [ 1, 1, 1, 1 ], { 'dtype': 'uint32' } ),
+		zeros( [ 1, 1, 1, 1, 1 ], { 'dtype': 'complex128' } )
 	];
+
+	/* eslint-enable stdlib/line-closing-bracket-spacing */
 
 	dim = [
 		0,

--- a/lib/node_modules/@stdlib/ndarray/slice-dimension-from/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/slice-dimension-from/test/test.js
@@ -489,11 +489,11 @@ tape( 'in non-strict mode, the function returns an empty array when a starting i
 	var i;
 
 	values = [
-		zeros( [ 1 ], { 'dtype': 'float64' } ),
-		zeros( [ 1, 1 ], { 'dtype': 'float32' } ),
-		zeros( [ 1, 1, 1 ], { 'dtype': 'int32' } ),
-		zeros( [ 1, 1, 1, 1 ], { 'dtype': 'uint32' } ),
-		zeros( [ 1, 1, 1, 1, 1 ], { 'dtype': 'complex128' } )
+		zeros( [ 1 ], { 'dtype': 'float64' }),
+		zeros( [ 1, 1 ], { 'dtype': 'float32' }),
+		zeros( [ 1, 1, 1 ], { 'dtype': 'int32' }),
+		zeros( [ 1, 1, 1, 1 ], { 'dtype': 'uint32' }),
+		zeros( [ 1, 1, 1, 1, 1 ], { 'dtype': 'complex128' })
 	];
 
 	start = [
@@ -522,11 +522,11 @@ tape( 'in non-strict mode, the function returns an empty array when a starting i
 	var i;
 
 	values = [
-		zeros( [ 1 ], { 'dtype': 'float64' } ),
-		zeros( [ 1, 1 ], { 'dtype': 'float32' } ),
-		zeros( [ 1, 1, 1 ], { 'dtype': 'int32' } ),
-		zeros( [ 1, 1, 1, 1 ], { 'dtype': 'uint32' } ),
-		zeros( [ 1, 1, 1, 1, 1 ], { 'dtype': 'complex128' } )
+		zeros( [ 1 ], { 'dtype': 'float64' }),
+		zeros( [ 1, 1 ], { 'dtype': 'float32' }),
+		zeros( [ 1, 1, 1 ], { 'dtype': 'int32' }),
+		zeros( [ 1, 1, 1, 1 ], { 'dtype': 'uint32' }),
+		zeros( [ 1, 1, 1, 1, 1 ], { 'dtype': 'complex128' })
 	];
 
 	dim = [


### PR DESCRIPTION
## Description

Fixes the JavaScript lint errors reported in the automated lint workflow for issue #14574.

All 10 errors were `stdlib/line-closing-bracket-spacing` violations in a single file, `lib/node_modules/@stdlib/ndarray/slice-dimension-from/test/test.js` (lines 492–496 and 525–529): spaces between the closing `}` of the trailing options object and the closing `)` of the `zeros(...)` call. Applied the rule's own autofix, removing those spaces (`} ),` → `}),`), matching the project's established style elsewhere.

## Related Issues

resolves #14574

## Verification

- Reproduced locally against the same commit using stdlib's own `line-closing-bracket-spacing` rule (eslint 8.57): exact same 10 errors at the same lines as the CI report.
- Applied the rule's built-in autofix (`--fix`) and re-ran: 0 errors.
- `node --check` passes on the modified file.
- Diff is whitespace-only: 1 file, 10 insertions, 10 deletions.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
