### PR TITLE
test: migrate `stats/base/dists/betaprime/variance` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/variance/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var variance = require( './../lib' );
 
 
@@ -105,10 +104,8 @@ tape( 'if provided `beta <= 2`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the variance of a beta prime distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -117,13 +114,7 @@ tape( 'the function returns the variance of a beta prime distribution', function
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = variance( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/variance/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/variance/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -114,10 +113,8 @@ tape( 'if provided `beta <= 2`, the function returns `NaN`', opts, function test
 
 tape( 'the function returns the variance of a beta prime distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -126,13 +123,7 @@ tape( 'the function returns the variance of a beta prime distribution', opts, fu
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = variance( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/betaprime/variance` from relative tolerance (`EPS`-scaled) assertions to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per the tracking issue #11352.
-   updates both `test/test.js` and `test/test.native.js`, replacing the `delta`/`tol` comparison with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );`.
-   removes the now-unused `abs` and `EPS` imports and the `delta`/`tol` variable declarations.

### ULP bound

The ULP constant used is **`3`** in both `test/test.js` and `test/test.native.js`, and this is the measured minimum.

Measured over the full 1000-value Julia fixture set (`test/fixtures/julia/data.json`, 1017 total assertions in `test.js`):

| ULP | Result |
| --- | --- |
| `0` | 319 failing |
| `1` | 42 failing |
| `2` | 1 failing |
| `3` | passing |

The tightest failing case is `alpha = 14.489223536479688`, `beta = 17.78458152077814`, where the implementation returns `0.10189942409114981` against an expected `0.10189942409114985` (a 3 ULP difference).

The same bound applies to the native test file: the C implementation in `src/main.c` evaluates the identical expression in the identical order, and, when compiled and run over the same fixture inputs, it agrees with the JavaScript implementation bit-for-bit across all 1000 values (max ULP difference against the fixtures is likewise `3`). The native tests themselves skip locally, as the add-on was not built in this environment.

The suite was run twice at the final ULP value to confirm determinism; both runs reported 1017 passing, 0 failing.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Only the two test files are modified; no source, documentation, benchmark, or fixture files are touched.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. The test migration and the ULP bound measurement (including the C/JS bit-for-bit cross-check) were performed automatically, following the idiom established in previously merged conversions for this tracking issue.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_018rbiC59nvVmhtDX1RcGcWu)_