### PR TITLE
test: migrate `stats/base/dists/bradford/median` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/median/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/median/test/test.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var median = require( './../lib' );
 
 
@@ -64,8 +63,6 @@ tape( 'if provided `c <= 0`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function returns the median of a Bradford distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var c;
 	var y;
@@ -74,13 +71,7 @@ tape( 'the function returns the median of a Bradford distribution', function tes
 	c = data.x;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = median( c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 7.2 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 14 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/median/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/median/test/test.native.js
@@ -22,10 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -88,8 +87,6 @@ tape( 'if provided `c <= 0`, the function returns `NaN`', opts, function test( t
 
 tape( 'the function returns the median of a Bradford distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var c;
 	var y;
@@ -98,13 +95,7 @@ tape( 'the function returns the median of a Bradford distribution', opts, functi
 	c = data.x;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = median( c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 7.2 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 14 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the test suite for `stats/base/dists/bradford/median` from relative-tolerance comparisons to ULP-based assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   Replaces the `abs( y - expected[i] ) <= tol` (where `tol = 7.2 * EPS * abs( expected[i] )`) idiom with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 14 ), true, 'returns expected value' )` and removes the now-unused `abs` and `EPS` imports.
-   Applies the same change to both `test/test.js` and `test/test.native.js`.

The ULP bound was tightened to the minimum integer that passes over the full fixture set: **14 ULPs** (`N = 13` fails on one fixture; `N = 14` passes deterministically across repeated runs). Only the test files are modified.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code, following the migration pattern established in prior ULP-conversion PRs. The minimum ULP bound was measured empirically against the package's fixtures.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpFyFNqQ3hZwejNzPP5VnD)_