### PR TITLE
test: migrate `stats/base/dists/uniform/mean` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mean = require( './../lib' );
 
 
@@ -72,8 +71,6 @@ tape( 'if provided `a >= b`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function returns the mean of a uniform distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -84,13 +81,7 @@ tape( 'the function returns the mean of a uniform distribution', function test( 
 	b = data.b;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = mean( a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -83,8 +82,6 @@ tape( 'if provided `a >= b`, the function returns `NaN`', opts, function test( t
 
 tape( 'the function returns the mean of a uniform distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -95,13 +92,7 @@ tape( 'the function returns the mean of a uniform distribution', opts, function 
 	b = data.b;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = mean( a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the test suite for `stats/base/dists/uniform/mean` from relative-tolerance comparisons to ULP-based assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   Replaces the `abs( y - expected[i] ) <= tol` (where `tol = 1.0 * EPS * abs( expected[i] )`) idiom, along with its `y === expected[i]` fast-path branch, with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' )` and removes the now-unused `abs` and `EPS` imports.
-   Applies the same change to both `test/test.js` and `test/test.native.js`.

The ULP bound was tightened to the minimum integer that passes over the full fixture set (1000 fixture values): **0 ULPs**, i.e. bit-for-bit equality. This is the tightest bound possible, so no smaller value exists to fail against. Both implementations reproduce the Julia fixtures exactly, which is expected given that the JavaScript implementation computes `0.5 * ( a + b )` and the C implementation computes `( a + b ) / 2.0` — the same correctly-rounded addition followed by an exact scaling by a power of two, leaving no room for FMA or arch-dependent divergence.

The native addon was built locally so that `test/test.native.js` actually executed rather than skipping; both suites were run twice at the final bound and pass deterministically (1008/1008 assertions each, per file, per run). Only the test files are modified.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The repository's `editorconfig-checker` lint step could not run in this environment, as the tool is downloaded on demand from a third-party GitHub release that was unreachable from the sandbox. The two changed files were instead verified by hand against `.editorconfig` (LF endings, UTF-8, tab indentation, no trailing whitespace, final newline). ESLint (tests configuration), the license-header lint, and the commit-message lint all ran and passed.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code, following the migration pattern established in prior ULP-conversion PRs. The minimum ULP bound was measured empirically against the package's fixtures.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_017VdGfaj1wJXg166nT4CQMq)_