### PR TITLE
docs: add missing throws annotation

### DIFF
--- a/lib/node_modules/@stdlib/random/iter/triangular/lib/main.js
+++ b/lib/node_modules/@stdlib/random/iter/triangular/lib/main.js
@@ -53,6 +53,7 @@ var format = require( '@stdlib/string/format' );
 * @param {NonNegativeInteger} [options.iter] - number of iterations
 * @throws {TypeError} `a` must be a number
 * @throws {TypeError} `b` must be a number
+* @throws {TypeError} `c` must be a number
 * @throws {RangeError} arguments must satisfy `a <= c <= b`
 * @throws {TypeError} options argument must be an object
 * @throws {TypeError} must provide valid options


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request adds a `@throws` annotation that was missing from `random/iter/triangular` relative to every other iterator factory in the `random/iter` namespace.

### `random/iter/triangular`

The `triangular` iterator validates its `c` argument (the distribution mode) and throws a `TypeError` when `c` is not a number, yet the function JSDoc documented only the `a` and `b` argument throws. Every sibling `random/iter` package that validates positional arguments documents a `@throws` tag for each such argument (40/40 conformance among packages with positional parameters); `triangular` was the sole outlier. This change adds the single missing `@throws {TypeError}` tag for `c` in code order, between the `b` type-check and the `a <= c <= b` range-check annotations. Documentation only — no executable code, error messages, or test expectations change.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Conformance: 40/40 (100%) of `random/iter` packages that validate positional arguments document one `@throws` tag per argument; `triangular` was the only package documenting fewer tags than it throws. The deviation was surfaced by an automated cross-package drift analysis of the namespace (structural + semantic feature extraction, majority vote at a 75% threshold, per-outlier validation) and confirmed against the package's source, tests, and examples. The fix is a single-line JSDoc addition confined to `random/iter/triangular/lib/main.js`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by an automated cross-package drift-detection routine running in Claude Code. The routine extracted structural and semantic features from every package in the `random/iter` namespace, computed the majority documentation pattern, flagged the single deviating package, and validated the finding before applying a one-line JSDoc fix. A maintainer should review before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_016UXJxuA1VxVaRD4aVGAFyz)_