### PR TITLE
fix(@stdlib/string/base/atob): guard against `ReferenceError` when `atob` global is absent

### DIFF
--- a/lib/node_modules/@stdlib/string/base/atob/lib/global.js
+++ b/lib/node_modules/@stdlib/string/base/atob/lib/global.js
@@ -20,7 +20,7 @@
 
 // MAIN //
 
-var main = ( typeof atob === 'function' ) ? atob : null;
+var main = ( typeof atob === 'function' ) ? atob : null; // eslint-disable-line n/no-unsupported-features/node-builtins
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/string/base/atob/lib/global.js
+++ b/lib/node_modules/@stdlib/string/base/atob/lib/global.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MAIN //
+
+var main = ( typeof atob === 'function' ) ? atob : null;
+
+
 // EXPORTS //
 
-module.exports = atob;
+module.exports = main;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes `lib/node_modules/@stdlib/string/base/atob/lib/global.js`: `module.exports = atob;` referenced the bare `atob` global unconditionally. Node.js only defines `atob` globally starting in v16; on Node.js 12/14, evaluating the undeclared identifier threw a `ReferenceError` at module load, not at call time. Since `lib/main.js` requires this module eagerly, and the package's test files require `lib/main.js` at top level, the crash happened before the existing `hasAtobSupport()`-gated `tape` skip logic could run, breaking the `linux_test` workflow's Node.js v12 and v14 jobs on every scheduled run (https://github.com/stdlib-js/stdlib/actions/runs/32710852762). Fix: guard the reference with `var main = ( typeof atob === 'function' ) ? atob : null;`, matching the existing idiom in `@stdlib/assert/has-atob-support/lib/atob.js`. `require('@stdlib/string/base/atob')` in production is unaffected — that path resolves through `lib/index.js` via `hasAtobSupport()` and never hits this file's bug.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Diff: one file, 6 lines added, 1 removed.

No `node_modules` install was possible in this environment, so verification used Node's `vm` module to evaluate the file in a fresh V8 context: no throw and correct `null` fallback with `atob` absent from globals, correct pass-through with `atob` present.

Reviewed independently across correctness, regression scope, and style/conventions before opening. All three passes flagged the same non-blocking issue from an early draft: an `// eslint-disable-line stdlib/no-redeclare` comment was unnecessary — that rule only fires on declarations shadowing a global of the same name, and `var main` doesn't shadow `atob` — and would have tripped `--report-unused-disable-directives`. Removed before commit.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was investigated, written, and validated by Claude Code as part of an automated CI-failure triage routine: it identified the failing `linux_test` jobs, traced the root cause, implemented the fix, and validated it via three independent automated review passes (correctness, regression scope, style/conventions) before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01R5CgLCiQAMQB8ojHwfsrGw)_