### PR TITLE
test: migrate `stats/base/dists/erlang/mean` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/mean/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mean = require( './../lib' );
 
 
@@ -106,8 +105,6 @@ tape( 'if provided `lambda <= 0`, the function returns `NaN`', function test( t 
 tape( 'the function returns the mean of an Erlang distribution', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -117,13 +114,7 @@ tape( 'the function returns the mean of an Erlang distribution', function test( 
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = mean( k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/mean/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -109,8 +108,6 @@ tape( 'if provided `lambda <= 0`, the function returns `NaN`', opts, function te
 tape( 'the function returns the mean of an Erlang distribution', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -120,13 +117,7 @@ tape( 'the function returns the mean of an Erlang distribution', opts, function 
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = mean( k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the test suite for `stats/base/dists/erlang/mean` from relative-tolerance comparisons to ULP-based assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   Replaces the `abs( y - expected[i] ) <= tol` (where `tol = 1.0 * EPS * abs( expected[i] )`) idiom, along with its `y === expected[i]` fast-path branch, with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' )` and removes the now-unused `abs` and `EPS` imports.
-   Applies the same change to both `test/test.js` and `test/test.native.js`.

The ULP bound was tightened to the minimum integer which passes over the full fixture set (200 fixture values): **1 ULP**, for both `test/test.js` and `test/test.native.js`. The bound is genuinely minimal — at a bound of `0` ULPs, 44 of the 200 fixture values fail for both the JavaScript and the native implementation, so the bound cannot be lowered further.

The JavaScript and C implementations agree exactly here: sweeping each fixture value individually, both require a maximum of 1 ULP and both diverge from the Julia fixtures on the same 44 values, which is consistent with both computing a single division `k / lambda` and the fixtures having been generated in a different order of operations.

The native addon was built locally so that `test/test.native.js` actually executed rather than skipping. Both suites were run twice at the final bound and pass deterministically (217 assertions in `test/test.js` and 215 in `test/test.native.js`, per run, no failures). Only the test files are modified.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The repository's `editorconfig-checker` lint step could not run in this environment, as the tool is downloaded on demand from a third-party GitHub release which was unreachable from the sandbox. The two changed files were instead verified by hand against `.editorconfig` (LF endings, UTF-8, tab indentation, no trailing whitespace, final newline). ESLint (tests configuration), the license-header lint, and the filename lint all ran and passed.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code, following the migration pattern established in prior ULP-conversion PRs. The minimum ULP bound was measured empirically against the package's fixtures.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01US1ntgyJ2B7Je3egfPMKXi)_