### PR TITLE
feat: add float16 dtype support to `array/linspace`

### DIFF
--- a/lib/node_modules/@stdlib/array/linspace/benchmark/benchmark.assign.float16_real.length.js
+++ b/lib/node_modules/@stdlib/array/linspace/benchmark/benchmark.assign.float16_real.length.js
@@ -1,0 +1,96 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isArrayLikeObject = require( '@stdlib/assert/is-array-like-object' );
+var Float16Array = require( '@stdlib/array/float16' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var linspace = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var out = new Float16Array( len );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = linspace.assign( 0.0, 100.0, out );
+			if ( typeof v !== 'object' ) {
+				b.fail( 'should return an array-like object' );
+			}
+		}
+		b.toc();
+		if ( !isArrayLikeObject( v ) ) {
+			b.fail( 'should return an array-like object' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s::real:assign:dtype=float16,len=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/linspace/benchmark/benchmark.float16_real.length.js
+++ b/lib/node_modules/@stdlib/array/linspace/benchmark/benchmark.float16_real.length.js
@@ -1,0 +1,99 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isArrayLikeObject = require( '@stdlib/assert/is-array-like-object' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var linspace = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var opts;
+		var v;
+		var i;
+
+		opts = {
+			'dtype': 'float16'
+		};
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = linspace( 0.0, 100.0, len, opts );
+			if ( typeof v !== 'object' ) {
+				b.fail( 'should return an array-like object' );
+			}
+		}
+		b.toc();
+		if ( !isArrayLikeObject( v ) ) {
+			b.fail( 'should return an array-like object' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s::real:dtype=float16,len=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/linspace/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/linspace/benchmark/benchmark.js
@@ -122,6 +122,30 @@ bench( format( '%s::real:dtype=float32', pkg ), function benchmark( b ) {
 	b.end();
 });
 
+bench( format( '%s::real:dtype=float16', pkg ), function benchmark( b ) {
+	var opts;
+	var v;
+	var i;
+
+	opts = {
+		'dtype': 'float16'
+	};
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = linspace( 0.0, 100.0, 10, opts );
+		if ( typeof v !== 'object' ) {
+			b.fail( 'should return an array-like object' );
+		}
+	}
+	b.toc();
+	if ( !isArrayLikeObject( v ) ) {
+		b.fail( 'should return an array-like object' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
 bench( format( '%s::real:dtype=generic', pkg ), function benchmark( b ) {
 	var opts;
 	var v;

--- a/lib/node_modules/@stdlib/array/linspace/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/linspace/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { FloatingPointDataType as DataType, ArrayLike, FloatOrComplexTypedArray, Complex64Array, Complex128Array } from '@stdlib/types/array';
+import { FloatingPointDataType as DataType, ArrayLike, FloatOrComplexTypedArray, Float16Array, Complex64Array, Complex128Array } from '@stdlib/types/array';
 import { ComplexLike, Complex64, Complex128 } from '@stdlib/types/complex';
 
 /**
@@ -70,6 +70,16 @@ interface Float32Options extends BaseOptions {
 	* Output array data type.
 	*/
 	dtype: 'float32';
+}
+
+/**
+* Interface describing function options.
+*/
+interface Float16Options extends BaseOptions {
+	/**
+	* Output array data type.
+	*/
+	dtype: 'float16';
 }
 
 /**
@@ -149,6 +159,26 @@ interface Linspace {
 	* // returns <Float32Array>[ 0.0, 20.0, 40.0, 60.0, 80.0, 100.0 ]
 	*/
 	( start: number, stop: number, len: number, options: Float32Options ): Float32Array;
+
+	/**
+	* Generates a linearly spaced array over a specified interval.
+	*
+	* @param start - start of interval
+	* @param stop - end of interval
+	* @param len - length of output array
+	* @param options - function options
+	* @param options.dtype - output array data type
+	* @param options.endpoint - `boolean` indicating whether to include the `stop` value in the output array
+	* @returns linearly spaced array
+	*
+	* @example
+	* var opts = {
+	*     'dtype': 'float16'
+	* };
+	* var arr = linspace( 0.0, 100.0, 6, opts );
+	* // returns <Float16Array>[ 0.0, 20.0, 40.0, 60.0, 80.0, 100.0 ]
+	*/
+	( start: number, stop: number, len: number, options: Float16Options ): Float16Array;
 
 	/**
 	* Generates a linearly spaced array over a specified interval.
@@ -449,6 +479,25 @@ interface Linspace {
 	* // returns <Float32Array>[ 0.0, 20.0, 40.0, 60.0, 80.0, 100.0 ]
 	*/
 	assign( start: number, stop: number, out: Float32Array, options?: BaseOptions ): Float32Array;
+
+	/**
+	* Generates a linearly spaced sequence over a specified interval and assigns results to a provided output array.
+	*
+	* @param start - start of interval
+	* @param stop - end of interval
+	* @param out - output array
+	* @param options - function options
+	* @param options.endpoint - `boolean` indicating whether to include the `stop` value in the output array
+	* @returns output array
+	*
+	* @example
+	* var Float16Array = require( '@stdlib/array/float16' );
+	*
+	* var out = new Float16Array( 6 );
+	* var arr = linspace.assign( 0.0, 100.0, out );
+	* // returns <Float16Array>[ 0.0, 20.0, 40.0, 60.0, 80.0, 100.0 ]
+	*/
+	assign( start: number, stop: number, out: Float16Array, options?: BaseOptions ): Float16Array;
 
 	/**
 	* Generates a linearly spaced sequence over a specified interval and assigns results to a provided output array.

--- a/lib/node_modules/@stdlib/array/linspace/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/linspace/docs/types/test.ts
@@ -20,6 +20,7 @@ import Complex64 = require( '@stdlib/complex/float32/ctor' );
 import Complex128 = require( '@stdlib/complex/float64/ctor' );
 import Complex128Array = require( '@stdlib/array/complex128' );
 import Complex64Array = require( '@stdlib/array/complex64' );
+import Float16Array = require( '@stdlib/array/float16' );
 import linspace = require( './index' );
 
 
@@ -34,6 +35,7 @@ import linspace = require( './index' );
 
 	linspace( 0, 11, 20, { 'dtype': 'float64' } ); // $ExpectType Float64Array
 	linspace( 0, 11, 20, { 'dtype': 'float32' } ); // $ExpectType Float32Array
+	linspace( 0, 11, 20, { 'dtype': 'float16' } ); // $ExpectType Float16Array
 	linspace( 0, 11, 20, { 'dtype': 'complex64' } ); // $ExpectType Complex64Array
 	linspace( 0, 11, 20, { 'dtype': 'complex128' } ); // $ExpectType Complex128Array
 	linspace( 0, 11, 20, { 'dtype': 'generic' } ); // $ExpectType number[]
@@ -216,6 +218,7 @@ import linspace = require( './index' );
 	const o3 = [ 1, 2, 3, 4 ];
 	const o4 = new Complex128Array( 10 );
 	const o5 = new Complex64Array( 10 );
+	const o6 = new Float16Array( 10 );
 
 	linspace.assign( 0, 11, o1 ); // $ExpectType Float64Array
 
@@ -223,6 +226,7 @@ import linspace = require( './index' );
 	linspace.assign( 0, 11, o1, { 'endpoint': false } ); // $ExpectType Float64Array
 
 	linspace.assign( 0, 11, o2 ); // $ExpectType Float32Array
+	linspace.assign( 0, 11, o6 ); // $ExpectType Float16Array
 	linspace.assign( 0, 11, o3 ); // $ExpectType number[]
 	linspace.assign( 0, 11, o4 ); // $ExpectType Complex128Array
 	linspace.assign( 0, 11, o5 ); // $ExpectType Complex64Array

--- a/lib/node_modules/@stdlib/array/linspace/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/linspace/docs/types/test.ts
@@ -35,7 +35,7 @@ import linspace = require( './index' );
 
 	linspace( 0, 11, 20, { 'dtype': 'float64' } ); // $ExpectType Float64Array
 	linspace( 0, 11, 20, { 'dtype': 'float32' } ); // $ExpectType Float32Array
-	linspace( 0, 11, 20, { 'dtype': 'float16' } ); // $ExpectType Float16Array
+	linspace( 0, 11, 20, { 'dtype': 'float16' } ); // $ExpectType Float16ArrayFallback
 	linspace( 0, 11, 20, { 'dtype': 'complex64' } ); // $ExpectType Complex64Array
 	linspace( 0, 11, 20, { 'dtype': 'complex128' } ); // $ExpectType Complex128Array
 	linspace( 0, 11, 20, { 'dtype': 'generic' } ); // $ExpectType number[]
@@ -226,7 +226,7 @@ import linspace = require( './index' );
 	linspace.assign( 0, 11, o1, { 'endpoint': false } ); // $ExpectType Float64Array
 
 	linspace.assign( 0, 11, o2 ); // $ExpectType Float32Array
-	linspace.assign( 0, 11, o6 ); // $ExpectType Float16Array
+	linspace.assign( 0, 11, o6 ); // $ExpectType Float16ArrayFallback
 	linspace.assign( 0, 11, o3 ); // $ExpectType number[]
 	linspace.assign( 0, 11, o4 ); // $ExpectType Complex128Array
 	linspace.assign( 0, 11, o5 ); // $ExpectType Complex64Array

--- a/lib/node_modules/@stdlib/array/linspace/package.json
+++ b/lib/node_modules/@stdlib/array/linspace/package.json
@@ -57,8 +57,12 @@
     "math",
     "generic",
     "array",
+    "float16array",
     "matlab",
     "linear",
-    "linspace"
+    "linspace",
+    "half",
+    "half-precision",
+    "float16"
   ]
 }

--- a/lib/node_modules/@stdlib/array/linspace/package.json
+++ b/lib/node_modules/@stdlib/array/linspace/package.json
@@ -57,12 +57,8 @@
     "math",
     "generic",
     "array",
-    "float16array",
     "matlab",
     "linear",
-    "linspace",
-    "half",
-    "half-precision",
-    "float16"
+    "linspace"
   ]
 }

--- a/lib/node_modules/@stdlib/array/linspace/test/test.assign.js
+++ b/lib/node_modules/@stdlib/array/linspace/test/test.assign.js
@@ -381,15 +381,19 @@ tape( 'if the specified output array length is `0`, the function returns the out
 tape( 'if the specified output array length is `0`, the function returns the output array unchanged (dtype=float16)', function test( t ) {
 	var expected;
 	var actual;
+	var opts;
 	var out;
 
+	opts = {
+		'endpoint': true
+	};
 	out = new Float16Array( 0 );
-	actual = linspace( 0, 10, out );
+	actual = linspace( 0, 10, out, opts );
 	expected = new Float16Array( out.length );
 
 	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
 	t.strictEqual( actual, out, 'returns expected value' );
-	t.strictEqual( actual.length, expected.length, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -522,7 +526,7 @@ tape( 'if the specified output array length is `1`, the function returns an arra
 
 	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
 	t.strictEqual( actual, out, 'returns expected value' );
-	t.strictEqual( actual[ 0 ], expected[ 0 ], 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -807,6 +811,26 @@ tape( 'if the specified output array length is `1`, the function returns an arra
 	expected = new Float32Array( [ 10.0 ] );
 
 	t.strictEqual( isFloat32Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual, out, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if the specified output array length is `1`, the function returns an array containing a single element (dtype=float16; endpoint=true)', function test( t ) {
+	var expected;
+	var actual;
+	var opts;
+	var out;
+
+	opts = {
+		'endpoint': true
+	};
+	out = new Float16Array( 1 );
+	actual = linspace( 0, 10, out, opts );
+	expected = new Float16Array( [ 10.0 ] );
+
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
 	t.strictEqual( actual, out, 'returns expected value' );
 	t.deepEqual( actual, expected, 'returns expected value' );
 
@@ -1147,6 +1171,26 @@ tape( 'if the specified output array length is `1`, the function returns an arra
 	expected = new Float32Array( [ 0.0 ] );
 
 	t.strictEqual( isFloat32Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual, out, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if the specified output array length is `1`, the function returns an array containing a single element (dtype=float16; endpoint=false)', function test( t ) {
+	var expected;
+	var actual;
+	var opts;
+	var out;
+
+	opts = {
+		'endpoint': false
+	};
+	out = new Float16Array( 1 );
+	actual = linspace( 0, 10, out, opts );
+	expected = new Float16Array( [ 0.0 ] );
+
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
 	t.strictEqual( actual, out, 'returns expected value' );
 	t.deepEqual( actual, expected, 'returns expected value' );
 

--- a/lib/node_modules/@stdlib/array/linspace/test/test.assign.js
+++ b/lib/node_modules/@stdlib/array/linspace/test/test.assign.js
@@ -27,12 +27,14 @@ var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var Float64Array = require( '@stdlib/array/float64' );
 var Float32Array = require( '@stdlib/array/float32' );
+var Float16Array = require( '@stdlib/array/float16' );
 var Complex128Array = require( '@stdlib/array/complex128' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var isComplex128 = require( '@stdlib/assert/is-complex128' );
 var isComplex64 = require( '@stdlib/assert/is-complex64' );
 var isFloat64Array = require( '@stdlib/assert/is-float64array' );
 var isFloat32Array = require( '@stdlib/assert/is-float32array' );
+var isFloat16Array = require( '@stdlib/assert/is-float16array' );
 var isArray = require( '@stdlib/assert/is-array' );
 var isArrayLikeObject = require( '@stdlib/assert/is-array-like-object' );
 var isComplex128Array = require( '@stdlib/assert/is-complex128array' );
@@ -376,6 +378,22 @@ tape( 'if the specified output array length is `0`, the function returns the out
 	t.end();
 });
 
+tape( 'if the specified output array length is `0`, the function returns the output array unchanged (dtype=float16)', function test( t ) {
+	var expected;
+	var actual;
+	var out;
+
+	out = new Float16Array( 0 );
+	actual = linspace( 0, 10, out );
+	expected = new Float16Array( out.length );
+
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual, out, 'returns expected value' );
+	t.strictEqual( actual.length, expected.length, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'if the specified output array length is `0`, the function returns the output array unchanged (dtype=complex128)', function test( t ) {
 	var expected;
 	var actual;
@@ -489,6 +507,22 @@ tape( 'if the specified output array length is `1`, the function returns an arra
 	t.strictEqual( isFloat32Array( actual ), true, 'returns expected value' );
 	t.strictEqual( actual, out, 'returns expected value' );
 	t.deepEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if the specified output array length is `1`, the function returns an array containing a single element (dtype=float16)', function test( t ) {
+	var expected;
+	var actual;
+	var out;
+
+	out = new Float16Array( 1 );
+	actual = linspace( 0, 10, out );
+	expected = new Float16Array( [ 10.0 ] );
+
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual, out, 'returns expected value' );
+	t.strictEqual( actual[ 0 ], expected[ 0 ], 'returns expected value' );
 
 	t.end();
 });
@@ -1630,6 +1664,75 @@ tape( 'the function returns a linearly spaced array (real; dtype=float32)', func
 	out = new Float32Array( 5 );
 	actual = linspace( x2, x1, out );
 	t.strictEqual( isFloat32Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual.length, 5, 'returns expected value' );
+	t.strictEqual( actual, out, 'returns expected value' );
+	t.strictEqual( actual[ 0 ], x2, 'returns expected value' );
+	t.strictEqual( actual[ actual.length-1 ], x1, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a linearly spaced array (real; dtype=float16)', function test( t ) {
+	var expected;
+	var actual;
+	var out;
+	var x1;
+	var x2;
+
+	x1 = -5.0;
+	x2 = 5.0;
+
+	out = new Float16Array( 2 );
+	actual = linspace( x1, x2, out );
+	expected = new Float16Array( [ x1, x2 ] );
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual.length, 2, 'returns expected value' );
+	t.strictEqual( actual, out, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	out = new Float16Array( 2 );
+	actual = linspace( x2, x1, out );
+	expected = new Float16Array( [ x2, x1 ] );
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual.length, 2, 'returns expected value' );
+	t.strictEqual( actual, out, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	out = new Float16Array( 6 );
+	actual = linspace( x1, x2, out );
+	expected = new Float16Array( [ x1, -3.0, -1.0, 1.0, 3.0, x2 ] );
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual.length, 6, 'returns expected value' );
+	t.strictEqual( actual, out, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	out = new Float16Array( 6 );
+	actual = linspace( x2, x1, out );
+	expected = new Float16Array( [ x2, 3.0, 1.0, -1.0, -3.0, x1 ] );
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual.length, 6, 'returns expected value' );
+	t.strictEqual( actual, out, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	out = new Float16Array( 6 );
+	actual = linspace( x2, x2, out );
+	expected = new Float16Array( [ x2, x2, x2, x2, x2, x2 ] );
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual.length, 6, 'returns expected value' );
+	t.strictEqual( actual, out, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	out = new Float16Array( 5 );
+	actual = linspace( x1, x2, out );
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual.length, 5, 'returns expected value' );
+	t.strictEqual( actual, out, 'returns expected value' );
+	t.strictEqual( actual[ 0 ], x1, 'returns expected value' );
+	t.strictEqual( actual[ actual.length-1 ], x2, 'returns expected value' );
+
+	out = new Float16Array( 5 );
+	actual = linspace( x2, x1, out );
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
 	t.strictEqual( actual.length, 5, 'returns expected value' );
 	t.strictEqual( actual, out, 'returns expected value' );
 	t.strictEqual( actual[ 0 ], x2, 'returns expected value' );

--- a/lib/node_modules/@stdlib/array/linspace/test/test.main.js
+++ b/lib/node_modules/@stdlib/array/linspace/test/test.main.js
@@ -1072,7 +1072,6 @@ tape( 'if the specified output array length is `1`, the function returns an arra
 	expected = new Float16Array( [ 10.0 ] );
 
 	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
-	t.strictEqual( actual.length, expected.length, 'returns expected value' );
 	t.deepEqual( actual, expected, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/array/linspace/test/test.main.js
+++ b/lib/node_modules/@stdlib/array/linspace/test/test.main.js
@@ -27,10 +27,12 @@ var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var Float64Array = require( '@stdlib/array/float64' );
 var Float32Array = require( '@stdlib/array/float32' );
+var Float16Array = require( '@stdlib/array/float16' );
 var isComplex128 = require( '@stdlib/assert/is-complex128' );
 var isComplex64 = require( '@stdlib/assert/is-complex64' );
 var isFloat64Array = require( '@stdlib/assert/is-float64array' );
 var isFloat32Array = require( '@stdlib/assert/is-float32array' );
+var isFloat16Array = require( '@stdlib/assert/is-float16array' );
 var isArray = require( '@stdlib/assert/is-array' );
 var isComplex128Array = require( '@stdlib/assert/is-complex128array' );
 var isComplex64Array = require( '@stdlib/assert/is-complex64array' );
@@ -482,6 +484,24 @@ tape( 'if the specified output array length is `0`, the function returns an empt
 	t.end();
 });
 
+tape( 'if the specified output array length is `0`, the function returns an empty array (dtype=float16)', function test( t ) {
+	var expected;
+	var actual;
+	var opts;
+
+	opts = {
+		'dtype': 'float16',
+		'endpoint': true
+	};
+	actual = linspace( 0, 10, 0, opts );
+	expected = new Float16Array( [] );
+
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'if the specified output array length is `0`, the function returns an empty array (dtype=complex128)', function test( t ) {
 	var expected;
 	var actual;
@@ -684,6 +704,23 @@ tape( 'if the specified output array length is `1`, the function returns an arra
 	expected = new Float32Array( [ 10.0 ] );
 
 	t.strictEqual( isFloat32Array( actual ), true, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if the specified output array length is `1`, the function returns an array containing a single element (dtype=float16)', function test( t ) {
+	var expected;
+	var actual;
+	var opts;
+
+	opts = {
+		'dtype': 'float16'
+	};
+	actual = linspace( 0, 10, 1, opts );
+	expected = new Float16Array( [ 10.0 ] );
+
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
 	t.deepEqual( actual, expected, 'returns expected value' );
 
 	t.end();
@@ -1017,6 +1054,25 @@ tape( 'if the specified output array length is `1`, the function returns an arra
 	expected = new Float32Array( [ 10.0 ] );
 
 	t.strictEqual( isFloat32Array( actual ), true, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if the specified output array length is `1`, the function returns an array containing a single element (dtype=float16; endpoint=true)', function test( t ) {
+	var expected;
+	var actual;
+	var opts;
+
+	opts = {
+		'dtype': 'float16',
+		'endpoint': true
+	};
+	actual = linspace( 0, 10, 1, opts );
+	expected = new Float16Array( [ 10.0 ] );
+
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual.length, expected.length, 'returns expected value' );
 	t.deepEqual( actual, expected, 'returns expected value' );
 
 	t.end();
@@ -1361,6 +1417,24 @@ tape( 'if the specified output array length is `1`, the function returns an arra
 	expected = new Float32Array( [ 0.0 ] );
 
 	t.strictEqual( isFloat32Array( actual ), true, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if the specified output array length is `1`, the function returns an array containing a single element (dtype=float16; endpoint=false)', function test( t ) {
+	var expected;
+	var actual;
+	var opts;
+
+	opts = {
+		'dtype': 'float16',
+		'endpoint': false
+	};
+	actual = linspace( 0, 10, 1, opts );
+	expected = new Float16Array( [ 0.0 ] );
+
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
 	t.deepEqual( actual, expected, 'returns expected value' );
 
 	t.end();
@@ -1775,6 +1849,65 @@ tape( 'the function returns a linearly spaced array (real; dtype=float32)', func
 
 	actual = linspace( x2, x1, 5, opts );
 	t.strictEqual( isFloat32Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual.length, 5, 'returns expected value' );
+	t.strictEqual( actual[ 0 ], x2, 'returns expected value' );
+	t.strictEqual( actual[ actual.length-1 ], x1, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a linearly spaced array (real; dtype=float16)', function test( t ) {
+	var expected;
+	var actual;
+	var opts;
+	var x1;
+	var x2;
+
+	x1 = -5.0;
+	x2 = 5.0;
+
+	opts = {
+		'dtype': 'float16'
+	};
+
+	actual = linspace( x1, x2, 2, opts );
+	expected = new Float16Array( [ x1, x2 ] );
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual.length, 2, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	actual = linspace( x2, x1, 2, opts );
+	expected = new Float16Array( [ x2, x1 ] );
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual.length, 2, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	actual = linspace( x1, x2, 6, opts );
+	expected = new Float16Array( [ x1, -3.0, -1.0, 1.0, 3.0, x2 ] );
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual.length, 6, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	actual = linspace( x2, x1, 6, opts );
+	expected = new Float16Array( [ x2, 3.0, 1.0, -1.0, -3.0, x1 ] );
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual.length, 6, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	actual = linspace( x2, x2, 6, opts );
+	expected = new Float16Array( [ x2, x2, x2, x2, x2, x2 ] );
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual.length, 6, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	actual = linspace( x1, x2, 5, opts );
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
+	t.strictEqual( actual.length, 5, 'returns expected value' );
+	t.strictEqual( actual[ 0 ], x1, 'returns expected value' );
+	t.strictEqual( actual[ actual.length-1 ], x2, 'returns expected value' );
+
+	actual = linspace( x2, x1, 5, opts );
+	t.strictEqual( isFloat16Array( actual ), true, 'returns expected value' );
 	t.strictEqual( actual.length, 5, 'returns expected value' );
 	t.strictEqual( actual[ 0 ], x2, 'returns expected value' );
 	t.strictEqual( actual[ actual.length-1 ], x1, 'returns expected value' );


### PR DESCRIPTION
Progresses #13193

## Description

> What is the purpose of this pull request?

This pull request:

-   add float16 dtype support to array/linspace

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #13193

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
