### PR TITLE
test: migrate `stats/base/dists/beta/skewness` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/beta/skewness/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/skewness/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var skewness = require( './../lib' );
 
 
@@ -96,10 +95,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the skewness of a beta distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -108,13 +105,7 @@ tape( 'the function returns the skewness of a beta distribution', function test(
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = skewness( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/skewness/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/skewness/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -105,10 +104,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 
 tape( 'the function returns the skewness of a beta distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -117,13 +114,7 @@ tape( 'the function returns the skewness of a beta distribution', opts, function
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = skewness( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/beta/skewness` from relative tolerance testing to ULP difference testing, per #11352.

Specifically, in both `test/test.js` and `test/test.native.js`, the exact-match/relative-tolerance branch in the fixture loop

```javascript
if ( y === expected[i] ) {
    t.strictEqual( y, expected[i], ... );
} else {
    delta = abs( y - expected[ i ] );
    tol = 1.0 * EPS * abs( expected[ i ] );
    t.ok( delta <= tol, ... );
}
```

is replaced by

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
```

along with adding the `@stdlib/assert/is-almost-same-value` require and removing the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires and the `delta`/`tol` declarations.

### ULP bound

-   **Final ULP constant: `0`** (used in both `test/test.js` and `test/test.native.js`).
-   **Measured minimum: `0`.** Starting from a bound of `64`, the bound was lowered while the suite continued to pass. Over the full Julia fixture set (1000 cases in `test/fixtures/julia/data.json`), the maximum ULP difference between the returned and expected values is `0`, i.e., every returned value is bit-identical to the expected value, so `0` is the tightest possible bound.
-   The suite was run twice at the final bound to confirm determinism (1014/1014 assertions passing on both runs).

This is consistent with the implementation: both the JavaScript and C implementations evaluate the same expression using only correctly rounded IEEE 754 operations (`+`, `-`, `*`, `/`, and `sqrt`), with no FMA-contractible `a*b + c` pattern, so the result is expected to be reproducible across platforms.

Note that `test/test.native.js` is skipped in this environment because the native add-on is not built; the bound there matches the JavaScript bound, as in previously migrated packages.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Only the two test files are modified; no source, documentation, benchmark, or fixture files are touched.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended task. It studied previously merged migrations (e.g., `stats/base/dists/beta/entropy`) to mirror the established idiom, applied the mechanical test refactor, and empirically determined the minimum ULP bound by running the package's test suite.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

* * *

@stdlib-js/reviewers


---
_Generated by [Claude Code](https://claude.ai/code/session_01BJ4HC2kbYmGbhdhkj9d9LT)_