### PR TITLE
test: migrate `stats/base/dists/logistic/cdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/cdf/test/test.cdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( './../lib' );
 
 
@@ -107,8 +106,6 @@ tape( 'if provided `sigma` equals `0`, the function evaluates a degenerate distr
 
 tape( 'the function evaluates the cdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -121,21 +118,13 @@ tape( 'the function evaluates the cdf for `x` given positive `mu`', function tes
 	s = positiveMean.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], s[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -148,21 +137,13 @@ tape( 'the function evaluates the cdf for `x` given negative `mu`', function tes
 	s = negativeMean.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], s[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given large variance ( = large `s` )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -175,13 +156,7 @@ tape( 'the function evaluates the cdf for `x` given large variance ( = large `s`
 	s = largeVariance.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], s[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/cdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -150,9 +149,7 @@ tape( 'if `sigma` equals `0`, the created function evaluates a degenerate distri
 
 tape( 'the created function evaluates the cdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -166,22 +163,14 @@ tape( 'the created function evaluates the cdf for `x` given positive `mu`', func
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( mu[i], s[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -195,22 +184,14 @@ tape( 'the created function evaluates the cdf for `x` given negative `mu`', func
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( mu[i], s[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given large variance ( = large `s`)', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -224,13 +205,7 @@ tape( 'the created function evaluates the cdf for `x` given large variance ( = l
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( mu[i], s[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/cdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -116,8 +115,6 @@ tape( 'if provided `sigma` equals `0`, the function evaluates a degenerate distr
 
 tape( 'the function evaluates the cdf for `x` given positive `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -130,21 +127,13 @@ tape( 'the function evaluates the cdf for `x` given positive `mu`', opts, functi
 	s = positiveMean.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], s[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given negative `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -157,21 +146,13 @@ tape( 'the function evaluates the cdf for `x` given negative `mu`', opts, functi
 	s = negativeMean.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], s[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given large variance ( = large `s` )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -184,13 +165,7 @@ tape( 'the function evaluates the cdf for `x` given large variance ( = large `s`
 	s = largeVariance.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], s[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/logistic/cdf` from relative tolerance testing to ULP difference testing, per #11352.

Changes are confined to the package's test files (`test/test.cdf.js`, `test/test.factory.js`, `test/test.native.js`):

-   adds the `@stdlib/assert/is-almost-same-value` require and removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.
-   removes the `delta`/`tol` declarations and the `if ( y === expected[i] ) { ... } else { ... }` tolerance branch.
-   replaces each fixture-loop assertion with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );`.

No implementation, fixture, or documentation files are touched, and no test cases were added, removed, or otherwise altered.

### ULP bound

**All nine converted assertion loops use an ULP value of `0`**, which is the tightest bound possible.

The bound was measured rather than guessed: computing `@stdlib/number/float64/base/ulp-difference` between each computed value and its expected fixture value across the full fixture set (`positive_mean.json`, `negative_mean.json`, `large_variance.json`; 1000 values each, 3000 total) yields a **maximum observed ULP difference of `0`** for the main export, for the function returned by `factory`, and for the native C implementation. In other words, every fixture value is reproduced exactly.

Verification:

-   `test/test.cdf.js` — 3016 assertions, all passing.
-   `test/test.factory.js` — 3019 assertions, all passing.
-   `test/test.native.js` — 3016 assertions, all passing. The native add-on was built locally so that these tests actually executed rather than being skipped.
-   The full suite was run twice at the final ULP value with identical results, to confirm the bound is not sensitive to FMA/architecture-dependent rounding.
-   ESLint (`etc/eslint/.eslintrc.tests.js`) reports no problems for the three changed files.

This mirrors the bound used by the already-merged sibling packages `stats/base/dists/weibull/cdf` (#14281) and `stats/base/dists/normal/cdf` (#14274).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Opened as a draft.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an unattended scheduled task. It studied the previously merged ULP migrations (in particular the sibling packages `stats/base/dists/weibull/cdf` and `stats/base/dists/normal/cdf`) to match the established idiom, applied the mechanical test conversion, and empirically measured the minimum ULP bound and ran the test suite to verify it.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_013LWUd3exr9mXw1egAc6XQF)_