### PR TITLE
test: migrate `stats/base/dists/halfnormal/entropy` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/entropy/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/entropy/test/test.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var entropy = require( './../lib' );
 
 
@@ -65,8 +64,6 @@ tape( 'if not provided a positive number, the function returns `NaN`', function 
 tape( 'the function returns the differential entropy of a half-normal distribution', function test( t ) {
 	var expected;
 	var sigma;
-	var delta;
-	var tol;
 	var i;
 	var y;
 
@@ -74,13 +71,7 @@ tape( 'the function returns the differential entropy of a half-normal distributi
 	sigma = data.sigma;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( sigma[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/entropy/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/entropy/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -74,8 +73,6 @@ tape( 'if not provided a positive number, the function returns `NaN`', opts, fun
 tape( 'the function returns the differential entropy of a half-normal distribution', opts, function test( t ) {
 	var expected;
 	var sigma;
-	var delta;
-	var tol;
 	var i;
 	var y;
 
@@ -83,13 +80,7 @@ tape( 'the function returns the differential entropy of a half-normal distributi
 	sigma = data.sigma;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( sigma[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suites for `stats/base/dists/halfnormal/entropy` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `delta`/`tol` comparisons in `test/test.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );`, adding the `@stdlib/assert/is-almost-same-value` require and dropping the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**ULP bound: `2` (both `test/test.js` and `test/test.native.js`), the measured minimum over the fixture set.**

The bound was determined empirically rather than assumed. Starting from a high bound and bisecting downward over `isAlmostSameValue` across the full SciPy fixture set (1000 values), the minimum admissible bound is exactly `2`. The distribution of ULP differences over the fixtures is:

-   `0` ULP (bit-identical to the SciPy reference): 961 values
-   `1` ULP: 36 values
-   `2` ULP: 3 values

The largest ULP difference is therefore `2`, attained at `sigma = 3.3000421880500923` (returned `1.9197266052930475` vs. expected `1.919726605293048`). Lowering the bound to `1` was confirmed to fail (3 failing assertions out of 1006 per suite), so the bound cannot be tightened further. The suite was then run twice at the final bound with identical results (1006/1006 passing per suite in each run), so the bound is not sensitive to run-to-run variation.

The previous relative tolerance was `1.5 * EPS * abs( expected[ i ] )`, which corresponds to roughly 1.5–3 ULP depending on where the expected value falls within its binade, so `2` sits within the prior accuracy budget rather than loosening it.

To confirm that `2` is also correct for the C implementation, the native addon was compiled locally and `test/test.native.js` was executed against the real addon rather than being skipped: it likewise passes all 1006 assertions at `2` ULP, twice, and bisecting the native results independently also yields `2` as the minimum, with the worst case at the same fixture index. This matches the sibling conversions in this family (`beta/entropy`, `binomial/entropy`, `logistic/entropy`), which likewise use a single bound across both suites.

Only the two test files are modified; no implementation, fixture, or documentation changes are included.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Notes on local verification:

-   `make install-node-modules` initially failed in this environment because the local npm cache held a stale packument for `es-object-atoms`, causing `es-object-atoms@^1.1.2` to resolve as nonexistent. Clearing the npm cache resolved it; no repository files were involved.
-   `make lint-editorconfig-files` (run via the pre-commit hook) could not execute because the `editorconfig-checker` binary download is blocked in this environment. The changed files were instead checked manually for indentation (tabs), trailing whitespace, line endings (LF), and final newline, and match the surrounding files exactly.
-   `eslint --config etc/eslint/.eslintrc.tests.js` reports no problems for either file.
-   `make test TESTS_FILTER=".*/stats/base/dists/halfnormal/entropy/.*"` passes (1006/1006).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. It studied previously merged conversions under #11352 (including the `beta/entropy` and `binomial/entropy` siblings) to match the established idiom, applied the migration, measured the minimum ULP bound empirically against the fixtures for both the JavaScript and the locally compiled C implementation, and verified that the tests pass and that the files lint cleanly.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4GUMyAhwgRJV5kSqKH9y9)_