### PR TITLE
test: migrate `simulate/iter/bartlett-hann-pulse` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/simulate/iter/bartlett-hann-pulse/test/test.js
+++ b/lib/node_modules/@stdlib/simulate/iter/bartlett-hann-pulse/test/test.js
@@ -22,10 +22,10 @@
 
 var tape = require( 'tape' );
 var proxyquire = require( 'proxyquire' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var iteratorSymbol = require( '@stdlib/symbol/iterator' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var cospi = require( '@stdlib/math/base/special/cospi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var iterBartlettHannPulse = require( './../lib' );
 
 
@@ -160,8 +160,6 @@ tape( 'the function throws an error if provided a pulse duration which is less t
 tape( 'the function returns an iterator protocol-compliant object which generates a "Bartlett-Hann" pulse waveform', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var phi;
 	var tau;
 	var it;
@@ -190,13 +188,7 @@ tape( 'the function returns an iterator protocol-compliant object which generate
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -204,9 +196,7 @@ tape( 'the function returns an iterator protocol-compliant object which generate
 tape( 'the function supports specifying the pulse period', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var phi;
 	var tau;
 	var it;
@@ -238,13 +228,7 @@ tape( 'the function supports specifying the pulse period', function test( t ) {
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -252,9 +236,7 @@ tape( 'the function supports specifying the pulse period', function test( t ) {
 tape( 'the function supports specifying the pulse duration', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var phi;
 	var tau;
 	var it;
@@ -294,13 +276,7 @@ tape( 'the function supports specifying the pulse duration', function test( t ) 
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -308,9 +284,7 @@ tape( 'the function supports specifying the pulse duration', function test( t ) 
 tape( 'the function supports specifying the waveform amplitude', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var phi;
 	var tau;
 	var it;
@@ -351,13 +325,7 @@ tape( 'the function supports specifying the waveform amplitude', function test( 
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -365,9 +333,7 @@ tape( 'the function supports specifying the waveform amplitude', function test( 
 tape( 'the function supports specifying the phase offset (left shift)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var phi;
 	var tau;
 	var it;
@@ -408,13 +374,7 @@ tape( 'the function supports specifying the phase offset (left shift)', function
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -422,9 +382,7 @@ tape( 'the function supports specifying the phase offset (left shift)', function
 tape( 'the function supports specifying the phase offset (left shift; mod)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var phi;
 	var tau;
 	var it;
@@ -468,13 +426,7 @@ tape( 'the function supports specifying the phase offset (left shift; mod)', fun
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -482,9 +434,7 @@ tape( 'the function supports specifying the phase offset (left shift; mod)', fun
 tape( 'the function supports specifying the phase offset (right shift)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var phi;
 	var tau;
 	var it;
@@ -528,13 +478,7 @@ tape( 'the function supports specifying the phase offset (right shift)', functio
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -542,9 +486,7 @@ tape( 'the function supports specifying the phase offset (right shift)', functio
 tape( 'the function supports specifying the phase offset (right shift; mod)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var phi;
 	var tau;
 	var it;
@@ -588,13 +530,7 @@ tape( 'the function supports specifying the phase offset (right shift; mod)', fu
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -602,9 +538,7 @@ tape( 'the function supports specifying the phase offset (right shift; mod)', fu
 tape( 'the function supports limiting the number of iterations', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var tau;
 	var it;
 	var A;
@@ -633,13 +567,7 @@ tape( 'the function supports limiting the number of iterations', function test( 
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	actual = it.next();
 	t.strictEqual( actual.value, void 0, 'returns expected value' );


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for `simulate/iter/bartlett-hann-pulse` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the nine `delta`/`tol` comparison blocks in `test/test.js` with `t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );`, adding the `@stdlib/assert/is-almost-same-value` require and dropping the now unused `@stdlib/constants/float64/eps` require.

Note that the `@stdlib/math/base/special/abs` require is retained, as `abs` remains in use by the `bartlettHann` reference implementation defined within the test file. The package has no `test/test.native.js`, so `test/test.js` is the only test file requiring migration.

**ULP bound: `0`, the measured minimum over the full set of generated values.**

The bound was determined empirically rather than assumed. Instrumenting `@stdlib/number/float64/base/ulp-difference` over every value produced by all nine waveform test cases (the default waveform, the `period`, `duration`, `amplitude`, and four `offset` variants, and the `iter`-limited case; 1604 generated values in total) yields a maximum ULP difference of `0`: every returned value is bit-identical to the reference value computed within the test file. Starting from a high bound and tightening downward therefore terminates at `0`, which is the minimum admissible non-negative bound and cannot be tightened further.

This result is expected rather than incidental. Unlike the `math/base/special` conversions, the expected values here are not external fixtures but are computed in the test file by a `bartlettHann` helper that mirrors the private `bartlettHann` in `lib/main.js` operation for operation, including the shared `cospi` call. Both sides therefore evaluate an identical sequence of IEEE-754 double-precision operations on identical inputs, and agreement is exact regardless of the accuracy of `cospi` itself. The previous `1.0 * EPS * abs( expected[ i ] )` tolerance branch was consequently never exercised; the migration preserves the strictness of the original assertions rather than loosening them.

The suite was run twice at the final bound with identical results (3281/3281 passing in each run), so the bound is not sensitive to run-to-run variation. A bound of `0` is consistent with sibling conversions under #11352 whose values likewise agree exactly (for example, `math/base/special/coversin` and `math/base/special/asecf`).

Only `test/test.js` is modified; no implementation, fixture, or documentation changes are included.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

Yes, one. This package sits outside `math/base/special`, which is the family named in the #11352 tracking issue, although it uses exactly the relative tolerance idiom the RFC targets and other packages outside that family have already been migrated under the same issue. If migrations outside `math/base/special` are not wanted at this time, please close this PR and no further such packages will be proposed.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Notes on local verification:

-   `make install-node-modules` failed in this environment because `es-object-atoms@^1.1.2`, required by `string.prototype.trim@1.2.11`, `string.prototype.trimend@1.0.10`, and `es-abstract-get@1.0.0`, does not resolve against the registry (the highest published version is `1.1.1`). Installing with a temporary `overrides` entry pinning `es-object-atoms` to `1.1.1` succeeded; `package.json` was restored to its committed state before committing and is not part of this diff.
-   `make test TESTS_FILTER=".*/simulate/iter/bartlett-hann-pulse/.*"` passes (3281/3281), run twice.
-   `make lint-javascript-tests TESTS_FILTER=".*/simulate/iter/bartlett-hann-pulse/.*"` reports no problems for either `test/test.js` or `test/test.validate.js`.
-   `make lint-editorconfig-files` could not execute because the `editorconfig-checker` binary download is blocked in this environment. The changed file was instead checked manually for indentation (tabs), trailing whitespace, line endings (LF), character set, and final newline, and matches the surrounding files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. It studied previously merged conversions under #11352 to match the established idiom, applied the migration, measured the minimum ULP bound empirically over every generated value, and verified that the tests pass and that the files lint cleanly.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5Rfq8WubGHGBX5kxLXdjK)_