### PR TITLE
test: migrate `stats/base/dists/uniform/quantile` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/quantile/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/quantile/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -117,8 +116,6 @@ tape( 'if provided `a >= b`, the created function always returns `NaN`', functio
 tape( 'the created function evaluates the quantile for `p` given a small range `b - a`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -132,13 +129,7 @@ tape( 'the created function evaluates the quantile for `p` given a small range `
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( a[i], b[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -146,8 +137,6 @@ tape( 'the created function evaluates the quantile for `p` given a small range `
 tape( 'the created function evaluates the quantile for `p` given a medium range `b - a`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -161,13 +150,7 @@ tape( 'the created function evaluates the quantile for `p` given a medium range 
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( a[i], b[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -175,8 +158,6 @@ tape( 'the created function evaluates the quantile for `p` given a medium range 
 tape( 'the created function evaluates the quantile for `p` given a large range `b - a`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -190,13 +171,7 @@ tape( 'the created function evaluates the quantile for `p` given a large range `
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( a[i], b[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/quantile/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/quantile/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -91,8 +90,6 @@ tape( 'if provided `a >= b`, the function returns `NaN`', opts, function test( t
 
 tape( 'the function evaluates the quantile for `p` given a small range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -105,21 +102,13 @@ tape( 'the function evaluates the quantile for `p` given a small range `b - a`',
 	b = smallRange.b;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the quantile for `p` given a medium range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -132,21 +121,13 @@ tape( 'the function evaluates the quantile for `p` given a medium range `b - a`'
 	b = mediumRange.b;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the quantile for `p` given a large range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -159,13 +140,7 @@ tape( 'the function evaluates the quantile for `p` given a large range `b - a`',
 	b = largeRange.b;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/quantile/test/test.quantile.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/quantile/test/test.quantile.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var quantile = require( './../lib' );
 
 
@@ -82,8 +81,6 @@ tape( 'if provided `a >= b`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function evaluates the quantile for `p` given a small range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -96,21 +93,13 @@ tape( 'the function evaluates the quantile for `p` given a small range `b - a`',
 	b = smallRange.b;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the quantile for `p` given a medium range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -123,21 +112,13 @@ tape( 'the function evaluates the quantile for `p` given a medium range `b - a`'
 	b = mediumRange.b;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the quantile for `p` given a large range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -150,13 +131,7 @@ tape( 'the function evaluates the quantile for `p` given a large range `b - a`',
 	b = largeRange.b;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for `stats/base/dists/uniform/quantile` from relative tolerance (`EPS`/`delta`/`tol`) assertions to ULP difference assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   updates `test/test.quantile.js`, `test/test.factory.js`, and `test/test.native.js`. No other files are changed.

The ULP bound was tightened agentically: starting from a high bound and lowering to the minimum integer which still passes over the full fixture set (`small_range`, `medium_range`, `large_range`; 1000 cases each, 3000 total per file).

Measured minimum ULP bound:

| File | Fixture | ULP |
| ---- | ------- | --- |
| `test/test.quantile.js` | `small_range`, `medium_range`, `large_range` | `0` |
| `test/test.factory.js` | `small_range`, `medium_range`, `large_range` | `0` |
| `test/test.native.js` | `small_range`, `medium_range`, `large_range` | `0` |

Both the JavaScript and C implementations compute `a + ( p * ( b - a ) )`, and every fixture value matches bit-for-bit, so `0` is the tightest possible bound in all three files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Verification: `test/test.js`, `test/test.quantile.js` (3011 assertions), `test/test.factory.js` (3014 assertions), and `test/test.native.js` (3011 assertions) all pass. The native add-on was built locally (`make install-node-addons NODE_ADDONS_PATTERN="stats/base/dists/uniform/quantile"`) so that `test/test.native.js` was actually exercised rather than skipped.
-   The full suite was run twice at the final bound of `0` to confirm determinism (no FMA/architecture-dependent variation).
-   ESLint (tests configuration) is clean for all changed files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This PR was authored by Claude Code as part of an automated, mechanical migration of existing test assertions to ULP-based assertions, following the idiom established in previously merged PRs referencing #11352. The ULP bound was determined empirically by running the fixtures and minimizing the accepted bound.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbeWLyp2YBanmPrDdD2hsX)_