### PR TITLE
test: migrate `math/base/special/binet` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/binet/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/binet/test/test.native.js
@@ -25,10 +25,9 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var fibonacci = require( '@stdlib/math/base/special/fibonacci' );
 var negaFibonacci = require( '@stdlib/math/base/special/negafibonacci' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -68,40 +67,24 @@ tape( 'if provided `-infinity`, the function returns `NaN`', opts, function test
 
 tape( 'for nonnegative integers, the function approximates the nth Fibonacci number', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var v;
 	var i;
 	for ( i = 0; i < 79; i++ ) {
 		v = binet( i );
 		expected = fibonacci( i );
-		if ( v === expected ) {
-			t.strictEqual( v, expected, 'returns the '+i+'th Fibonacci number' );
-		} else {
-			delta = abs( v - expected );
-			tol = 13.0 * EPS * abs( expected );
-			t.strictEqual( delta <= tol, true, 'returns approximation. n: '+i+'. expected: '+expected+'. actual: '+v+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( v, expected, 24 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'for nonpositive integers, the function approximates the nth negaFibonacci number', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var v;
 	var i;
 	for ( i = 0; i > -79; i-- ) {
 		v = binet( i );
 		expected = negaFibonacci( i );
-		if ( v === expected ) {
-			t.strictEqual( v, expected, 'returns the '+i+'th negaFibonacci number' );
-		} else {
-			delta = abs( v - expected );
-			tol = 12.0 * EPS * abs( expected );
-			t.strictEqual( delta <= tol, true, 'returns approximation. n: '+i+'. expected: '+expected+'. actual: '+v+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( v, expected, 22 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates `math/base/special/binet` test fixtures from relative-tolerance (`EPS`-scaled `delta`/`tol`) comparisons to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`, per the RFC in #11352.
-   Converts `test/test.native.js`. `test/test.js` was already migrated to `isAlmostSameValue` in a prior PR, so it was left untouched.
-   Final ULP bounds: `24` for the "nonnegative integers / Fibonacci" fixture loop and `22` for the "nonpositive integers / negaFibonacci" fixture loop. These are the exact minimum integer ULP values that still pass across the full fixture set (indices `0` through `±78`), verified both against a manual ULP-distance computation and by incrementing `isAlmostSameValue`'s `maxULP` argument until it first returns `true` for every fixture point. One ULP lower than each bound (`23` and `21`, respectively) produces at least one failure, confirming tightness. The native addon was built locally (`NODE_ADDONS_PATTERN=math/base/special/binet make install-node-addons`) to allow `test/test.native.js` to actually execute (rather than being skipped) while measuring these bounds.
-   Ran the full test suite for the package twice at the final bounds to confirm deterministic results (no FMA/architecture-related flakiness).
-   No other test cases (edge cases for `±Infinity` and `NaN`) were changed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored autonomously by Claude Code as part of a scheduled automation task, including candidate discovery (grepping the repo for the relative-tolerance idiom), the test-file conversion, and ULP-bound measurement. It was opened as a draft for maintainer review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_019qnYgzw2NUZHM8UJNM3G8F)_