### PR TITLE
test: migrate `stats/base/dists/lognormal/entropy` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/entropy/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/entropy/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var entropy = require( './../lib' );
 
 
@@ -76,9 +75,7 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', function 
 
 tape( 'the function returns the differential entropy of a lognormal distribution', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -89,13 +86,7 @@ tape( 'the function returns the differential entropy of a lognormal distribution
 	for ( i = 0; i < mu.length; i++ ) {
 		y = entropy( mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 18.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 21 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/entropy/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/entropy/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -88,9 +87,7 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', opts, fun
 
 tape( 'the function returns the differential entropy of a lognormal distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -100,14 +97,8 @@ tape( 'the function returns the differential entropy of a lognormal distribution
 	sigma = data.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
 		y = entropy( mu[i], sigma[i] );
-		if ( expected[i] !== null) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 18.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+		if ( expected[i] !== null ) {
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 21 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suites for `stats/base/dists/lognormal/entropy` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `delta`/`tol` comparisons in `test/test.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 21 ), true, 'returns expected value' );`, adding the `@stdlib/assert/is-almost-same-value` require and dropping the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**ULP bound: `21` (both `test/test.js` and `test/test.native.js`), the measured minimum over the fixture set.**

The bound was determined empirically rather than assumed. Starting from a high bound and bisecting downward over `isAlmostSameValue` across the full Julia fixture set (100 values), the minimum admissible bound is exactly `21`. The distribution of ULP differences over the fixtures is:

-   `0` ULP (bit-identical to the Julia reference): 29 values
-   `1` ULP: 32 values
-   `2` ULP: 16 values
-   `3` ULP: 6 values
-   `4` ULP: 5 values
-   `5`–`7` ULP: 5 values
-   `11`–`13` ULP: 5 values
-   `19` ULP: 1 value
-   `21` ULP: 1 value

The largest ULP difference is therefore `21`, attained at `mu = -2.2043783383184983`, `sigma = 2.3638997544259355` (returned `0.0748728884657351` vs. expected `0.07487288846573481`). Lowering the bound to `20` was confirmed to fail (1 failing assertion per suite), so the bound cannot be tightened further. The suite was then run twice at the final bound with identical results (110/110 for `test/test.js` and 111/111 for `test/test.native.js` in each run), so the bound is not sensitive to run-to-run variation.

The previous relative tolerance was `18.0 * EPS * abs( expected[ i ] )`. Since `EPS * abs( x )` equals `m` ULP for `abs( x ) = m * 2**e` with `m` in `[1, 2)`, that tolerance corresponds to between `18` and `36` ULP depending on where the expected value falls within its binade; at the worst-case fixture (`m ≈ 1.198`) it corresponds to roughly `21.6` ULP. The new bound of `21` therefore sits just inside the prior accuracy budget rather than loosening it.

To confirm that `21` is also correct for the C implementation, the native addon was compiled locally and `test/test.native.js` was executed against the real addon rather than being skipped: it likewise passes all 111 assertions at `21` ULP, twice, and bisecting the native results independently also yields `21` as the minimum, with the worst case at the same fixture index. In fact, the JavaScript and C implementations agree bit-for-bit across all 100 fixtures, which is expected given that both evaluate `ln( sigma * exp( mu + 0.5 ) * sqrt( 2*pi ) )` using the same stdlib kernels. This matches the sibling conversions in this family (`halfnormal/entropy`, `beta/entropy`, `weibull/entropy`), which likewise use a single bound across both suites.

Only the two test files are modified; no implementation, fixture, or documentation changes are included.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Notes on local verification:

-   `make install-node-modules` initially failed in this environment because the local npm cache held a stale packument for `es-object-atoms`, causing `es-object-atoms@^1.1.2` to resolve as nonexistent. Clearing the npm cache resolved it; no repository files were involved.
-   `make lint-editorconfig-files` (run via the pre-commit hook) could not execute because the `editorconfig-checker` binary download is blocked in this environment. The changed files were instead checked manually for indentation (tabs), trailing whitespace, line endings (LF), and final newline, and match the surrounding files exactly.
-   `make eslint-tests TESTS_FILTER=".*/stats/base/dists/lognormal/entropy/.*"` reports no problems for either file.
-   `make test TESTS_FILTER=".*/stats/base/dists/lognormal/entropy/.*"` passes.
-   The locally compiled native addon and its build artifacts were removed before committing; `git status` confirms that the only changed files are the two test files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. It studied previously merged conversions under #11352 (including the `halfnormal/entropy` sibling) to match the established idiom, applied the migration, measured the minimum ULP bound empirically against the fixtures for both the JavaScript and the locally compiled C implementation, and verified that the tests pass and that the files lint cleanly.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_018cwdBtLXDvMWH6Wk4uErxk)_