### PR TITLE
test: migrate `stats/incr/mpe` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/mpe/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/mpe/test/test.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var incrmpe = require( './../lib' );
 
 
@@ -48,11 +47,9 @@ tape( 'the initial accumulated value is `null`', function test( t ) {
 tape( 'the accumulator function incrementally computes the mean percentage error', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
 	var acc;
 	var sum;
-	var tol;
 	var N;
 	var x;
 	var y;
@@ -77,13 +74,7 @@ tape( 'the accumulator function incrementally computes the mean percentage error
 		sum += ( y-x ) / y;
 		expected = 100.0 * ( sum/(i+1) );
 		actual = acc( x, y );
-		if ( actual === expected ) {
-			t.strictEqual( actual, expected, 'returns expected value' );
-		} else {
-			delta = abs( expected - actual );
-			tol = 10.0 * EPS * abs( expected );
-			t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+actual+'. Expected: '+expected+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual, expected, 11 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -91,10 +82,8 @@ tape( 'the accumulator function incrementally computes the mean percentage error
 tape( 'if not provided an input value, the accumulator function returns the current mean percentage error', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
 	var acc;
-	var tol;
 	var i;
 
 	data = [
@@ -108,8 +97,6 @@ tape( 'if not provided an input value, the accumulator function returns the curr
 	}
 	actual = acc();
 	expected = 100.0 / 3.0 * ((1.0/3.0) + (2.0/5.0) + (9.0/10.0));
-	delta = abs( expected - actual );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+actual+'. Expected: '+expected+'. Delta: '+delta+'. Tol: '+tol+'.' );
+	t.strictEqual( isAlmostSameValue( actual, expected, 1 ), true, 'returns expected value' );
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/incr/mpe` from relative tolerance (`EPS`-scaled) assertions to ULP-based assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].

Details:

-   `test/test.js` is the only test file in the package containing computed-tolerance assertions; no `test.native.js` exists.
-   Replaced the `abs`/`EPS` `delta <= tol` comparisons (and the associated `delta`/`tol` locals and requires) with `t.strictEqual( isAlmostSameValue( actual, expected, N ), true, 'returns expected value' );`.
-   ULP bounds were tightened to the **measured minimum** by starting from `N = 64` and lowering `N` until the smallest integer which still passes across every fixture value:
    -   `the accumulator function incrementally computes the mean percentage error`: **11 ULP** (passes at `11`, fails at `10`; previous tolerance was `10.0 * EPS`).
    -   `if not provided an input value, the accumulator function returns the current mean percentage error`: **1 ULP** (passes at `1`, fails at `0`; previous tolerance was `1.0 * EPS`).
-   The suite was run twice at the final bounds to confirm determinism: 11/11 passing on both runs.
-   `make lint-javascript-tests TESTS_FILTER=".*/stats/incr/mpe/.*"` is clean, and the only changed file is `lib/node_modules/@stdlib/stats/incr/mpe/test/test.js`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, which studied prior ULP migrations in this repository, applied the same idiom here, and empirically searched for the minimum passing ULP bounds.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAEKccdwzVuZVKVEgVir2Q)_