### PR TITLE
build: avoid false positives in ESLint rule `jsdoc-doctest-decimal-point`

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/lib/float_array_types.json
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/lib/float_array_types.json
@@ -1,0 +1,5 @@
+[
+  "Float64Array",
+  "Float32Array",
+  "Float16Array"
+]

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/lib/integer_array_types.json
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/lib/integer_array_types.json
@@ -1,0 +1,9 @@
+[
+  "Int8Array",
+  "Uint8Array",
+  "Uint8ClampedArray",
+  "Int16Array",
+  "Uint16Array",
+  "Int32Array",
+  "Uint32Array"
+]

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/lib/main.js
@@ -24,6 +24,7 @@ var parseJS = require( 'acorn' ).parse;
 var parseJSDoc = require( 'doctrine' ).parse;
 var contains = require( '@stdlib/assert/contains' );
 var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var isArray = require( '@stdlib/assert/is-array' );
 var isEmptyArray = require( '@stdlib/assert/is-empty-array' );
 var isObject = require( '@stdlib/assert/is-object' );
@@ -171,7 +172,7 @@ function findReturnStatements( node, out ) {
 		}
 		return out;
 	}
-	if ( !isObject( node ) || typeof node.type !== 'string' ) {
+	if ( !isObject( node ) || !isString( node.type ) ) {
 		return out;
 	}
 	if (
@@ -191,7 +192,7 @@ function findReturnStatements( node, out ) {
 			continue;
 		}
 		v = node[ keys[ i ] ];
-		if ( isArray( v ) || ( isObject( v ) && typeof v.type === 'string' ) ) {
+		if ( isArray( v ) || ( isObject( v ) && isString( v.type ) ) ) {
 			findReturnStatements( v, out );
 		}
 	}
@@ -235,10 +236,11 @@ function checkReturnedElements( node, tags ) {
 		returns = findReturnStatements( fnode.body, [] );
 	} else {
 		// Handle arrow functions having concise (expression) bodies by treating the body as the sole returned expression:
-		returns = [];
-		returns.push({
-			'argument': fnode.body
-		});
+		returns = [
+			{
+				'argument': fnode.body
+			}
+		];
 	}
 	if ( returns.length === 0 ) {
 		return null;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/lib/main.js
@@ -41,7 +41,7 @@ var FLOAT_ARRAY_TYPES = require( './float_array_types.json' );
 
 var RE_TRAILING_COMMENT = /; (\/\/|=>)[^\n]*\n/g;
 var RE_ANNOTATION = /(?:returns|=>|throws) {0,1}([\s\S]*?)(?:\n\n|$)/;
-var RE_NUMBER = /^[0-9e+-.]+$/;
+var RE_NUMBER = /^[~0-9e+-.]+$/;
 var RE_DECIMAL = /([~+-]*[0-9]+)(?:.0)?(e[+-]?[0-9]+)?/;
 var RE_MUTATION = /^ *[a-zA-Z_$][\w$]*(?:\.[\w$]+|\[[^\]]*\])* *=>/;
 var DOPTS = {
@@ -231,7 +231,15 @@ function checkReturnedElements( node, tags ) {
 	if ( isNull( fnode ) || !fnode.body ) {
 		return null;
 	}
-	returns = findReturnStatements( fnode.body, [] );
+	if ( fnode.body.type === 'BlockStatement' ) {
+		returns = findReturnStatements( fnode.body, [] );
+	} else {
+		// Handle arrow functions having concise (expression) bodies by treating the body as the sole returned expression:
+		returns = [];
+		returns.push({
+			'argument': fnode.body
+		});
+	}
 	if ( returns.length === 0 ) {
 		return null;
 	}

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/lib/main.js
@@ -23,13 +23,18 @@
 var parseJS = require( 'acorn' ).parse;
 var parseJSDoc = require( 'doctrine' ).parse;
 var contains = require( '@stdlib/assert/contains' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isArray = require( '@stdlib/assert/is-array' );
 var isEmptyArray = require( '@stdlib/assert/is-empty-array' );
 var isObject = require( '@stdlib/assert/is-object' );
 var isNull = require( '@stdlib/assert/is-null' );
 var replace = require( '@stdlib/string/replace' );
+var objectKeys = require( '@stdlib/utils/keys' );
 var findJSDoc = require( '@stdlib/_tools/eslint/utils/find-jsdoc' );
 var INTEGER_TYPES = require( './integer_types.json' );
 var FLOAT_TYPES = require( './float_types.json' );
+var INTEGER_ARRAY_TYPES = require( './integer_array_types.json' );
+var FLOAT_ARRAY_TYPES = require( './float_array_types.json' );
 
 
 // VARIABLES //
@@ -38,10 +43,11 @@ var RE_TRAILING_COMMENT = /; (\/\/|=>)[^\n]*\n/g;
 var RE_ANNOTATION = /(?:returns|=>|throws) {0,1}([\s\S]*?)(?:\n\n|$)/;
 var RE_NUMBER = /^[0-9e+-.]+$/;
 var RE_DECIMAL = /([~+-]*[0-9]+)(?:.0)?(e[+-]?[0-9]+)?/;
+var RE_MUTATION = /^ *[a-zA-Z_$][\w$]*(?:\.[\w$]+|\[[^\]]*\])* *=>/;
 var DOPTS = {
 	'sloppy': true,
 	'unwrap': true,
-	'tags': [ 'example', 'returns' ]
+	'tags': [ 'example', 'returns', 'param' ]
 };
 var rule;
 
@@ -81,6 +87,177 @@ function checkType( type ) {
 }
 
 /**
+* Checks the element type of a typed array type for whether annotations for element values should include a decimal point.
+*
+* @private
+* @param {string} type - type name
+* @returns {(boolean|null)} for typed arrays, a boolean indicating whether annotations for element values should include a decimal point, `null` otherwise
+*/
+function checkArrayType( type ) {
+	if ( contains( FLOAT_ARRAY_TYPES, type ) ) {
+		return true;
+	}
+	if ( contains( INTEGER_ARRAY_TYPES, type ) ) {
+		return false;
+	}
+	return null;
+}
+
+/**
+* Resolves the function AST node associated with a documented node.
+*
+* @private
+* @param {ASTNode} node - documented node
+* @returns {(ASTNode|null)} function AST node or null
+*/
+function functionNode( node ) {
+	var decls;
+	var expr;
+	var i;
+	if (
+		node.type === 'FunctionDeclaration' ||
+		node.type === 'FunctionExpression' ||
+		node.type === 'ArrowFunctionExpression'
+	) {
+		return node;
+	}
+	if ( node.type === 'VariableDeclaration' ) {
+		decls = node.declarations;
+		for ( i = 0; i < decls.length; i++ ) {
+			if (
+				decls[ i ].init &&
+				(
+					decls[ i ].init.type === 'FunctionExpression' ||
+					decls[ i ].init.type === 'ArrowFunctionExpression'
+				)
+			) {
+				return decls[ i ].init;
+			}
+		}
+		return null;
+	}
+	if ( node.type === 'ExpressionStatement' ) {
+		expr = node.expression;
+		if (
+			expr &&
+			expr.type === 'AssignmentExpression' &&
+			expr.right &&
+			(
+				expr.right.type === 'FunctionExpression' ||
+				expr.right.type === 'ArrowFunctionExpression'
+			)
+		) {
+			return expr.right;
+		}
+	}
+	return null;
+}
+
+/**
+* Collects the return statements of a function body without descending into nested functions.
+*
+* @private
+* @param {(ASTNode|Array)} node - AST node (or node list) to examine
+* @param {Array} out - output array
+* @returns {Array} output array
+*/
+function findReturnStatements( node, out ) {
+	var keys;
+	var v;
+	var i;
+	if ( isArray( node ) ) {
+		for ( i = 0; i < node.length; i++ ) {
+			findReturnStatements( node[ i ], out );
+		}
+		return out;
+	}
+	if ( !isObject( node ) || typeof node.type !== 'string' ) {
+		return out;
+	}
+	if (
+		node.type === 'FunctionDeclaration' ||
+		node.type === 'FunctionExpression' ||
+		node.type === 'ArrowFunctionExpression'
+	) {
+		return out;
+	}
+	if ( node.type === 'ReturnStatement' ) {
+		out.push( node );
+		return out;
+	}
+	keys = objectKeys( node );
+	for ( i = 0; i < keys.length; i++ ) {
+		if ( keys[ i ] === 'parent' ) {
+			continue;
+		}
+		v = node[ keys[ i ] ];
+		if ( isArray( v ) || ( isObject( v ) && typeof v.type === 'string' ) ) {
+			findReturnStatements( v, out );
+		}
+	}
+	return out;
+}
+
+/**
+* Checks whether a documented function only ever returns elements of typed array parameters and, if so, whether annotations for returned values should include a decimal point.
+*
+* @private
+* @param {ASTNode} node - documented node
+* @param {Array} tags - JSDoc tags
+* @returns {(boolean|null)} for typed array element accessors, a boolean indicating whether annotations for returned values should include a decimal point, `null` otherwise
+*/
+function checkReturnedElements( node, tags ) {
+	var returns;
+	var params;
+	var fnode;
+	var flg;
+	var arg;
+	var tag;
+	var f;
+	var i;
+
+	// Resolve the documented parameters which are typed arrays...
+	params = {};
+	for ( i = 0; i < tags.length; i++ ) {
+		tag = tags[ i ];
+		if ( tag.title === 'param' && tag.type && tag.type.name && tag.name ) {
+			f = checkArrayType( tag.type.name );
+			if ( !isNull( f ) ) {
+				params[ tag.name ] = f;
+			}
+		}
+	}
+	fnode = functionNode( node );
+	if ( isNull( fnode ) || !fnode.body ) {
+		return null;
+	}
+	returns = findReturnStatements( fnode.body, [] );
+	if ( returns.length === 0 ) {
+		return null;
+	}
+	// Check whether every return statement returns an element of a typed array parameter...
+	flg = null;
+	for ( i = 0; i < returns.length; i++ ) {
+		arg = returns[ i ].argument;
+		if (
+			!arg ||
+			arg.type !== 'MemberExpression' ||
+			!arg.computed ||
+			arg.object.type !== 'Identifier' ||
+			!hasOwnProp( params, arg.object.name )
+		) {
+			return null;
+		}
+		f = params[ arg.object.name ];
+		if ( !isNull( flg ) && f !== flg ) {
+			return null;
+		}
+		flg = f;
+	}
+	return flg;
+}
+
+/**
 * Checks whether a comment is a return annotation and, if so, whether it only includes decimal points for real-valued return values.
 *
 * @private
@@ -95,11 +272,19 @@ function checkComment( comment, rType, flg ) {
 	var val;
 
 	str = comment.value;
+	if ( RE_MUTATION.test( str ) ) {
+		// Annotations describing mutated values (e.g., `// D => [ 3.0 ]`) do not describe a function's return value:
+		return null;
+	}
 	matches = str.match( RE_ANNOTATION );
 	if ( matches ) {
 		val = matches[ 1 ];
+		if ( !RE_NUMBER.test( val ) ) {
+			// Annotation values which are not scalar numeric values (e.g., arrays, strings, objects, etc) do not have the documented return type:
+			return null;
+		}
 		if ( flg ) {
-			if ( RE_NUMBER.test( val ) && !contains( val, '.' ) ) {
+			if ( !contains( val, '.' ) ) {
 				return '`//'+str+'` should be `//'+createReplacement( str, flg )+'` (return annotations for values of type `'+rType+'` must always include a decimal point)';
 			}
 		}
@@ -146,6 +331,7 @@ function main( context ) {
 		var jsdoc;
 		var descr;
 		var rType;
+		var elems;
 		var tags;
 		var ast;
 		var msg;
@@ -160,18 +346,31 @@ function main( context ) {
 			if ( isEmptyArray( tags ) ) {
 				return;
 			}
-			if ( tags[ 0 ].title === 'returns' && tags[ 0 ].type ) {
-				rType = tags[ 0 ].type.name;
-				flg = checkType( rType );
-				if ( isNull( flg ) ) {
-					return;
+			rType = null;
+			for ( i = 0; i < tags.length; i++ ) {
+				if ( tags[ i ].title === 'returns' && tags[ i ].type ) {
+					rType = tags[ i ].type.name;
+					break;
 				}
-			} else {
+			}
+			if ( isNull( rType ) ) {
 				// Return early for functions that do not have a return value...
 				return;
 			}
-			for ( i = 1; i < tags.length; i++ ) {
+			flg = checkType( rType );
+			if ( isNull( flg ) ) {
+				return;
+			}
+			// Handle functions which return elements of typed array parameters (e.g., a function documented as returning a `number` may return integer-valued elements of a `Uint8Array`, in which case annotation values are ambiguous and should not be validated)...
+			elems = checkReturnedElements( node, tags );
+			if ( !isNull( elems ) && elems !== flg ) {
+				return;
+			}
+			for ( i = 0; i < tags.length; i++ ) {
 				tag = tags[ i ];
+				if ( tag.title !== 'example' ) {
+					continue;
+				}
 				comments = [];
 				descr = tag.description;
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/test/fixtures/invalid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/test/fixtures/invalid.js
@@ -280,6 +280,37 @@ test = {
 };
 invalid.push( test );
 
+test = {
+	'code': [
+		'/**',
+		'* Returns an element from a `Float64Array`.',
+		'*',
+		'* @private',
+		'* @param {Float64Array} arr - input array',
+		'* @param {NonNegativeInteger} idx - element index',
+		'* @returns {number} element value',
+		'*',
+		'* @example',
+		'* var Float64Array = require( \'@stdlib/array/float64\' );',
+		'*',
+		'* var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0 ] );',
+		'*',
+		'* var v = getFloat64( arr, 2 );',
+		'* // returns 3',
+		'*/',
+		'function getFloat64( arr, idx ) {',
+		'  return arr[ idx ];',
+		'}'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': '`// returns 3` should be `// returns 3.0` (return annotations for values of type `number` must always include a decimal point)',
+			'type': null
+		}
+	]
+};
+invalid.push( test );
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/test/fixtures/invalid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/test/fixtures/invalid.js
@@ -311,6 +311,31 @@ test = {
 };
 invalid.push( test );
 
+test = {
+	'code': [
+		'/**',
+		'* Returns the number of elements.',
+		'*',
+		'* @param {Collection} x - input collection',
+		'* @returns {integer} number of elements',
+		'*',
+		'* @example',
+		'* var n = numel( [ 1, 2, 3 ] );',
+		'* // returns ~3.0',
+		'*/',
+		'function numel( x ) {',
+		'  return x.length;',
+		'}'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': '`// returns ~3.0` should be `// returns ~3` (return annotations for values of type `integer` must NOT include a decimal point)',
+			'type': null
+		}
+	]
+};
+invalid.push( test );
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/test/fixtures/valid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/test/fixtures/valid.js
@@ -247,6 +247,138 @@ test = {
 };
 valid.push( test );
 
+test = {
+	'code': [
+		'/**',
+		'* Sorts a double-precision floating-point strided array.',
+		'*',
+		'* @param {string} sortOrder - sort direction',
+		'* @param {NonNegativeInteger} N - number of elements to sort',
+		'* @param {Float64Array} D - array to sort in-place',
+		'* @returns {integer} status code',
+		'*',
+		'* @example',
+		'* var Float64Array = require( \'@stdlib/array/float64\' );',
+		'*',
+		'* var D = new Float64Array( [ 5.0, 7.0, 9.0, 3.0, 11.0 ] );',
+		'*',
+		'* dlasrt( \'increasing\', 5, D );',
+		'* // D => <Float64Array>[ 3.0, 5.0, 7.0, 9.0, 11.0 ]',
+		'*/',
+		'function dlasrt( sortOrder, N, D ) {',
+		'  return base( sortOrder[ 0 ], N, D, 1, 0, stack, 1, 0 );',
+		'}'
+	].join( '\n' )
+};
+valid.push( test );
+
+test = {
+	'code': [
+		'/**',
+		'* Sorts a double-precision floating-point strided array.',
+		'*',
+		'* @param {string} sortOrder - sort direction',
+		'* @param {NonNegativeInteger} N - number of elements to sort',
+		'* @param {Float64Array} D - array to sort in-place',
+		'* @returns {integer} status code',
+		'*',
+		'* @example',
+		'* var Float64Array = require( \'@stdlib/array/float64\' );',
+		'*',
+		'* var D = new Float64Array( [ 5.0, 7.0, 9.0, 3.0, 11.0 ] );',
+		'*',
+		'* dlasrt( \'increasing\', 5, D );',
+		'* // D => [ 3.0, 5.0, 7.0, 9.0, 11.0 ]',
+		'*/',
+		'function dlasrt( sortOrder, N, D ) {',
+		'  return base( sortOrder[ 0 ], N, D, 1, 0, stack, 1, 0 );',
+		'}'
+	].join( '\n' )
+};
+valid.push( test );
+
+test = {
+	'code': [
+		'/**',
+		'* Returns an element from a `Uint8Array`.',
+		'*',
+		'* @private',
+		'* @param {Uint8Array} arr - input array',
+		'* @param {NonNegativeInteger} idx - element index',
+		'* @returns {number} element value',
+		'*',
+		'* @example',
+		'* var Uint8Array = require( \'@stdlib/array/uint8\' );',
+		'*',
+		'* var arr = new Uint8Array( [ 1, 2, 3, 4 ] );',
+		'*',
+		'* var v = getUint8( arr, 2 );',
+		'* // returns 3',
+		'*/',
+		'function getUint8( arr, idx ) {',
+		'  return arr[ idx ];',
+		'}'
+	].join( '\n' )
+};
+valid.push( test );
+
+test = {
+	'code': [
+		'/**',
+		'* Returns an element from a `Float64Array`.',
+		'*',
+		'* @private',
+		'* @param {Float64Array} arr - input array',
+		'* @param {NonNegativeInteger} idx - element index',
+		'* @returns {integer} element value',
+		'*',
+		'* @example',
+		'* var Float64Array = require( \'@stdlib/array/float64\' );',
+		'*',
+		'* var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0 ] );',
+		'*',
+		'* var v = getFloat64( arr, 2 );',
+		'* // returns 3.0',
+		'*/',
+		'function getFloat64( arr, idx ) {',
+		'  return arr[ idx ];',
+		'}'
+	].join( '\n' )
+};
+valid.push( test );
+
+test = {
+	'code': [
+		'/**',
+		'* Copies elements to an output array.',
+		'*',
+		'* @param {Float64Array} x - input array',
+		'* @param {Float64Array} y - output array',
+		'* @returns {NonNegativeInteger} number of copied elements',
+		'*',
+		'* @example',
+		'* var Float64Array = require( \'@stdlib/array/float64\' );',
+		'*',
+		'* var x = new Float64Array( [ 1.0, 2.0, 3.0 ] );',
+		'* var y = new Float64Array( x.length );',
+		'*',
+		'* var n = copy( x, y );',
+		'* // returns 3',
+		'*',
+		'* console.log( y );',
+		'* // => <Float64Array>[ 1.0, 2.0, 3.0 ]',
+		'*/',
+		'function copy( x, y ) {',
+		'  var i;',
+		'  for ( i = 0; i < x.length; i++ ) {',
+		'    y[ i ] = x[ i ];',
+		'  }',
+		'  return x.length;',
+		'}'
+	].join( '\n' )
+};
+valid.push( test );
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/test/fixtures/valid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest-decimal-point/test/fixtures/valid.js
@@ -379,6 +379,32 @@ test = {
 };
 valid.push( test );
 
+test = {
+	'code': [
+		'/**',
+		'* Returns an element from a `Uint8Array`.',
+		'*',
+		'* @private',
+		'* @param {Uint8Array} arr - input array',
+		'* @param {NonNegativeInteger} idx - element index',
+		'* @returns {number} element value',
+		'*',
+		'* @example',
+		'* var Uint8Array = require( \'@stdlib/array/uint8\' );',
+		'*',
+		'* var arr = new Uint8Array( [ 1, 2, 3, 4 ] );',
+		'*',
+		'* var v = getUint8( arr, 2 );',
+		'* // returns 3',
+		'*/',
+		'var getUint8 = ( arr, idx ) => arr[ idx ];'
+	].join( '\n' ),
+	'parserOptions': {
+		'ecmaVersion': 2018
+	}
+};
+valid.push( test );
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/array/base/getter/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/getter/lib/main.js
@@ -114,7 +114,7 @@ function getFloat16( arr, idx ) {
 * var v = getInt32( arr, 2 );
 * // returns 3
 */
-function getInt32( arr, idx ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+function getInt32( arr, idx ) {
 	return arr[ idx ];
 }
 
@@ -134,7 +134,7 @@ function getInt32( arr, idx ) { // eslint-disable-line stdlib/jsdoc-doctest-deci
 * var v = getInt16( arr, 2 );
 * // returns 3
 */
-function getInt16( arr, idx ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+function getInt16( arr, idx ) {
 	return arr[ idx ];
 }
 
@@ -154,7 +154,7 @@ function getInt16( arr, idx ) { // eslint-disable-line stdlib/jsdoc-doctest-deci
 * var v = getInt8( arr, 2 );
 * // returns 3
 */
-function getInt8( arr, idx ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+function getInt8( arr, idx ) {
 	return arr[ idx ];
 }
 
@@ -174,7 +174,7 @@ function getInt8( arr, idx ) { // eslint-disable-line stdlib/jsdoc-doctest-decim
 * var v = getUint32( arr, 2 );
 * // returns 3
 */
-function getUint32( arr, idx ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+function getUint32( arr, idx ) {
 	return arr[ idx ];
 }
 
@@ -194,7 +194,7 @@ function getUint32( arr, idx ) { // eslint-disable-line stdlib/jsdoc-doctest-dec
 * var v = getUint16( arr, 2 );
 * // returns 3
 */
-function getUint16( arr, idx ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+function getUint16( arr, idx ) {
 	return arr[ idx ];
 }
 
@@ -214,7 +214,7 @@ function getUint16( arr, idx ) { // eslint-disable-line stdlib/jsdoc-doctest-dec
 * var v = getUint8( arr, 2 );
 * // returns 3
 */
-function getUint8( arr, idx ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+function getUint8( arr, idx ) {
 	return arr[ idx ];
 }
 
@@ -234,7 +234,7 @@ function getUint8( arr, idx ) { // eslint-disable-line stdlib/jsdoc-doctest-deci
 * var v = getUint8c( arr, 2 );
 * // returns 3
 */
-function getUint8c( arr, idx ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+function getUint8c( arr, idx ) {
 	return arr[ idx ];
 }
 

--- a/lib/node_modules/@stdlib/blas/base/wasm/ccopy/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/ccopy/lib/module.js
@@ -186,7 +186,7 @@ inherits( Module, WasmModule );
 * console.log( reinterpretComplex64( view, 0 ) );
 * // => <Float32Array>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ]
 */
-setReadOnly( Module.prototype, 'main', function ccopy( N, xptr, strideX, yptr, strideY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function ccopy( N, xptr, strideX, yptr, strideY ) {
 	this._instance.exports.c_ccopy( N, xptr, strideX, yptr, strideY );
 	return yptr;
 });
@@ -263,7 +263,7 @@ setReadOnly( Module.prototype, 'main', function ccopy( N, xptr, strideX, yptr, s
 * console.log( reinterpretComplex64( view, 0 ) );
 * // => <Float32Array>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function ccopy( N, xptr, strideX, offsetX, yptr, strideY, offsetY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function ccopy( N, xptr, strideX, offsetX, yptr, strideY, offsetY ) {
 	this._instance.exports.c_ccopy_ndarray( N, xptr, strideX, offsetX, yptr, strideY, offsetY ); // eslint-disable-line max-len
 	return yptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/cscal/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/cscal/lib/module.js
@@ -187,7 +187,7 @@ inherits( Module, WasmModule );
 * console.log( reinterpretComplex64( view, 0 ) );
 * // => <Float32Array>[ -2.0, 6.0, -2.0, 14.0, -2.0, 22.0, -2.0, 30.0, -2.0, 38.0 ]
 */
-setReadOnly( Module.prototype, 'main', function cscal( N, aptr, xptr, strideX ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function cscal( N, aptr, xptr, strideX ) {
 	this._instance.exports.c_cscal( N, aptr, xptr, strideX );
 	return xptr;
 });
@@ -263,7 +263,7 @@ setReadOnly( Module.prototype, 'main', function cscal( N, aptr, xptr, strideX ) 
 * console.log( reinterpretComplex64( view, 0 ) );
 * // => <Float32Array>[ -2.0, 6.0, -2.0, 14.0, -2.0, 22.0, -2.0, 30.0, -2.0, 38.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function cscal( N, aptr, xptr, strideX, offsetX ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function cscal( N, aptr, xptr, strideX, offsetX ) {
 	this._instance.exports.c_cscal_ndarray( N, aptr, xptr, strideX, offsetX );
 	return xptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/csrot/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/csrot/lib/module.js
@@ -196,7 +196,7 @@ inherits( Module, WasmModule );
 * console.log( reinterpretComplex64( viewX, 0 ) );
 * // => <Float32Array>[ ~1.4, ~2.2, 3.0, ~3.8, ~4.6, ~5.4, ~6.2, 7.0, ~7.8, ~8.6 ]
 */
-setReadOnly( Module.prototype, 'main', function csrot( N, cxptr, strideX, cyptr, strideY, c, s ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function csrot( N, cxptr, strideX, cyptr, strideY, c, s ) {
 	this._instance.exports.c_csrot( N, cxptr, strideX, cyptr, strideY, c, s );
 	return cyptr;
 });
@@ -279,7 +279,7 @@ setReadOnly( Module.prototype, 'main', function csrot( N, cxptr, strideX, cyptr,
 * console.log( reinterpretComplex64( viewX, 0 ) );
 * // => <Float32Array>[ ~1.4, ~2.2, 3.0, ~3.8, ~4.6, ~5.4, ~6.2, 7.0, ~7.8, ~8.6 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function csrot( N, cxptr, strideX, offsetX, cyptr, strideY, offsetY, c, s ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function csrot( N, cxptr, strideX, offsetX, cyptr, strideY, offsetY, c, s ) {
 	this._instance.exports.c_csrot_ndarray( N, cxptr, strideX, offsetX, cyptr, strideY, offsetY, c, s ); // eslint-disable-line max-len
 	return cyptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/cswap/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/cswap/lib/module.js
@@ -192,7 +192,7 @@ inherits( Module, WasmModule );
 * console.log( reinterpretComplex64( viewY, 0 ) );
 * // => <Float32Array>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ]
 */
-setReadOnly( Module.prototype, 'main', function cswap( N, xptr, strideX, yptr, strideY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function cswap( N, xptr, strideX, yptr, strideY ) {
 	this._instance.exports.c_cswap( N, xptr, strideX, yptr, strideY );
 	return yptr;
 });
@@ -272,7 +272,7 @@ setReadOnly( Module.prototype, 'main', function cswap( N, xptr, strideX, yptr, s
 * console.log( reinterpretComplex64( viewY, 0 ) );
 * // => <Float32Array>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function cswap( N, xptr, strideX, offsetX, yptr, strideY, offsetY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function cswap( N, xptr, strideX, offsetX, yptr, strideY, offsetY ) {
 	this._instance.exports.c_cswap_ndarray( N, xptr, strideX, offsetX, yptr, strideY, offsetY ); // eslint-disable-line max-len
 	return yptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/daxpy/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/daxpy/lib/module.js
@@ -167,7 +167,7 @@ inherits( Module, WasmModule );
 * daxpy.read( yptr, view );
 * // view => <Float64Array>[ 6.0, 11.0, 16.0, 21.0, 26.0 ]
 */
-setReadOnly( Module.prototype, 'main', function daxpy( N, alpha, xptr, strideX, yptr, strideY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function daxpy( N, alpha, xptr, strideX, yptr, strideY ) {
 	this._instance.exports.c_daxpy( N, alpha, xptr, strideX, yptr, strideY );
 	return yptr;
 });
@@ -235,7 +235,7 @@ setReadOnly( Module.prototype, 'main', function daxpy( N, alpha, xptr, strideX, 
 * daxpy.read( yptr, view );
 * // view => <Float64Array>[ 6.0, 11.0, 16.0, 21.0, 26.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function daxpy( N, alpha, xptr, strideX, offsetX, yptr, strideY, offsetY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function daxpy( N, alpha, xptr, strideX, offsetX, yptr, strideY, offsetY ) {
 	this._instance.exports.c_daxpy_ndarray( N, alpha, xptr, strideX, offsetX, yptr, strideY, offsetY ); // eslint-disable-line max-len
 	return yptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/dcopy/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/dcopy/lib/module.js
@@ -166,7 +166,7 @@ inherits( Module, WasmModule );
 * dcopy.read( yptr, view );
 * // view => <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0 ]
 */
-setReadOnly( Module.prototype, 'main', function dcopy( N, xptr, strideX, yptr, strideY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function dcopy( N, xptr, strideX, yptr, strideY ) {
 	this._instance.exports.c_dcopy( N, xptr, strideX, yptr, strideY );
 	return yptr;
 });
@@ -233,7 +233,7 @@ setReadOnly( Module.prototype, 'main', function dcopy( N, xptr, strideX, yptr, s
 * dcopy.read( yptr, view );
 * // view => <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function dcopy( N, xptr, strideX, offsetX, yptr, strideY, offsetY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function dcopy( N, xptr, strideX, offsetX, yptr, strideY, offsetY ) {
 	this._instance.exports.c_dcopy_ndarray( N, xptr, strideX, offsetX, yptr, strideY, offsetY ); // eslint-disable-line max-len
 	return yptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/drot/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/drot/lib/module.js
@@ -176,7 +176,7 @@ inherits( Module, WasmModule );
 * drot.read( yptr, viewY );
 * // viewY => <Float64Array>[ -1.0, -2.0, -3.0, -4.0, -5.0 ]
 */
-setReadOnly( Module.prototype, 'main', function drot( N, xptr, strideX, yptr, strideY, c, s ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function drot( N, xptr, strideX, yptr, strideY, c, s ) {
 	this._instance.exports.c_drot( N, xptr, strideX, yptr, strideY, c, s );
 	return yptr;
 });
@@ -249,7 +249,7 @@ setReadOnly( Module.prototype, 'main', function drot( N, xptr, strideX, yptr, st
 * drot.read( yptr, viewY );
 * // viewY => <Float64Array>[ -1.0, -2.0, -3.0, -4.0, -5.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function drot( N, xptr, strideX, offsetX, yptr, strideY, offsetY, c, s ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function drot( N, xptr, strideX, offsetX, yptr, strideY, offsetY, c, s ) {
 	this._instance.exports.c_drot_ndarray( N, xptr, strideX, offsetX, yptr, strideY, offsetY, c, s ); // eslint-disable-line max-len
 	return yptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/drotm/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/drotm/lib/module.js
@@ -179,7 +179,7 @@ inherits( Module, WasmModule );
 * drotm.read( yptr, viewY );
 * // viewY => <Float64Array>[ 0.0, -1.0, -2.0, -3.0, -4.0 ]
 */
-setReadOnly( Module.prototype, 'main', function drotm( N, xptr, strideX, yptr, strideY, pptr ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function drotm( N, xptr, strideX, yptr, strideY, pptr ) {
 	this._instance.exports.c_drotm( N, xptr, strideX, yptr, strideY, pptr );
 	return yptr;
 });
@@ -253,7 +253,7 @@ setReadOnly( Module.prototype, 'main', function drotm( N, xptr, strideX, yptr, s
 * drotm.read( yptr, viewY );
 * // viewY => <Float64Array>[ 0.0, -1.0, -2.0, -3.0, -4.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function drotm( N, xptr, strideX, offsetX, yptr, strideY, offsetY, pptr ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function drotm( N, xptr, strideX, offsetX, yptr, strideY, offsetY, pptr ) {
 	this._instance.exports.c_drotm_ndarray( N, xptr, strideX, offsetX, yptr, strideY, offsetY, pptr ); // eslint-disable-line max-len
 	return yptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/dscal/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/dscal/lib/module.js
@@ -159,7 +159,7 @@ inherits( Module, WasmModule );
 * dscal.read( xptr, view );
 * // view => <Float64Array>[ 5.0, 10.0, 15.0, 20.0, 25.0 ]
 */
-setReadOnly( Module.prototype, 'main', function dscal( N, alpha, xptr, strideX ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function dscal( N, alpha, xptr, strideX ) {
 	this._instance.exports.c_dscal( N, alpha, xptr, strideX );
 	return xptr;
 });
@@ -221,7 +221,7 @@ setReadOnly( Module.prototype, 'main', function dscal( N, alpha, xptr, strideX )
 * dscal.read( xptr, view );
 * // view => <Float64Array>[ 5.0, 10.0, 15.0, 20.0, 25.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function dscal( N, alpha, xptr, strideX, offsetX ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function dscal( N, alpha, xptr, strideX, offsetX ) {
 	this._instance.exports.c_dscal_ndarray( N, alpha, xptr, strideX, offsetX );
 	return xptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/dswap/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/dswap/lib/module.js
@@ -174,7 +174,7 @@ inherits( Module, WasmModule );
 * dswap.read( yptr, viewY );
 * // viewY => <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0 ]
 */
-setReadOnly( Module.prototype, 'main', function dswap( N, xptr, strideX, yptr, strideY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function dswap( N, xptr, strideX, yptr, strideY ) {
 	this._instance.exports.c_dswap( N, xptr, strideX, yptr, strideY );
 	return yptr;
 });
@@ -245,7 +245,7 @@ setReadOnly( Module.prototype, 'main', function dswap( N, xptr, strideX, yptr, s
 * dswap.read( yptr, viewY );
 * // viewY => <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function dswap( N, xptr, strideX, offsetX, yptr, strideY, offsetY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function dswap( N, xptr, strideX, offsetX, yptr, strideY, offsetY ) {
 	this._instance.exports.c_dswap_ndarray( N, xptr, strideX, offsetX, yptr, strideY, offsetY ); // eslint-disable-line max-len
 	return yptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/saxpy/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/saxpy/lib/module.js
@@ -167,7 +167,7 @@ inherits( Module, WasmModule );
 * saxpy.read( yptr, view );
 * // view => <Float32Array>[ 6.0, 11.0, 16.0, 21.0, 26.0 ]
 */
-setReadOnly( Module.prototype, 'main', function saxpy( N, alpha, xptr, strideX, yptr, strideY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function saxpy( N, alpha, xptr, strideX, yptr, strideY ) {
 	this._instance.exports.c_saxpy( N, alpha, xptr, strideX, yptr, strideY );
 	return yptr;
 });
@@ -235,7 +235,7 @@ setReadOnly( Module.prototype, 'main', function saxpy( N, alpha, xptr, strideX, 
 * saxpy.read( yptr, view );
 * // view => <Float32Array>[ 6.0, 11.0, 16.0, 21.0, 26.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function saxpy( N, alpha, xptr, strideX, offsetX, yptr, strideY, offsetY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function saxpy( N, alpha, xptr, strideX, offsetX, yptr, strideY, offsetY ) {
 	this._instance.exports.c_saxpy_ndarray( N, alpha, xptr, strideX, offsetX, yptr, strideY, offsetY ); // eslint-disable-line max-len
 	return yptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/scopy/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/scopy/lib/module.js
@@ -166,7 +166,7 @@ inherits( Module, WasmModule );
 * scopy.read( yptr, view );
 * // view => <Float32Array>[ 1.0, 2.0, 3.0, 4.0, 5.0 ]
 */
-setReadOnly( Module.prototype, 'main', function scopy( N, xptr, strideX, yptr, strideY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function scopy( N, xptr, strideX, yptr, strideY ) {
 	this._instance.exports.c_scopy( N, xptr, strideX, yptr, strideY );
 	return yptr;
 });
@@ -233,7 +233,7 @@ setReadOnly( Module.prototype, 'main', function scopy( N, xptr, strideX, yptr, s
 * scopy.read( yptr, view );
 * // view => <Float32Array>[ 1.0, 2.0, 3.0, 4.0, 5.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function scopy( N, xptr, strideX, offsetX, yptr, strideY, offsetY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function scopy( N, xptr, strideX, offsetX, yptr, strideY, offsetY ) {
 	this._instance.exports.c_scopy_ndarray( N, xptr, strideX, offsetX, yptr, strideY, offsetY ); // eslint-disable-line max-len
 	return yptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/srot/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/srot/lib/module.js
@@ -176,7 +176,7 @@ inherits( Module, WasmModule );
 * srot.read( yptr, viewY );
 * // viewY => <Float32Array>[ -1.0, -2.0, -3.0, -4.0, -5.0 ]
 */
-setReadOnly( Module.prototype, 'main', function srot( N, xptr, strideX, yptr, strideY, c, s ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function srot( N, xptr, strideX, yptr, strideY, c, s ) {
 	this._instance.exports.c_srot( N, xptr, strideX, yptr, strideY, c, s );
 	return yptr;
 });
@@ -249,7 +249,7 @@ setReadOnly( Module.prototype, 'main', function srot( N, xptr, strideX, yptr, st
 * srot.read( yptr, viewY );
 * // viewY => <Float32Array>[ -1.0, -2.0, -3.0, -4.0, -5.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function srot( N, xptr, strideX, offsetX, yptr, strideY, offsetY, c, s ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function srot( N, xptr, strideX, offsetX, yptr, strideY, offsetY, c, s ) {
 	this._instance.exports.c_srot_ndarray( N, xptr, strideX, offsetX, yptr, strideY, offsetY, c, s ); // eslint-disable-line max-len
 	return yptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/srotm/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/srotm/lib/module.js
@@ -179,7 +179,7 @@ inherits( Module, WasmModule );
 * srotm.read( yptr, viewY );
 * // viewY => <Float32Array>[ 0.0, -1.0, -2.0, -3.0, -4.0 ]
 */
-setReadOnly( Module.prototype, 'main', function srotm( N, xptr, strideX, yptr, strideY, pptr ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function srotm( N, xptr, strideX, yptr, strideY, pptr ) {
 	this._instance.exports.c_srotm( N, xptr, strideX, yptr, strideY, pptr );
 	return yptr;
 });
@@ -253,7 +253,7 @@ setReadOnly( Module.prototype, 'main', function srotm( N, xptr, strideX, yptr, s
 * srotm.read( yptr, viewY );
 * // viewY => <Float32Array>[ 0.0, -1.0, -2.0, -3.0, -4.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function srotm( N, xptr, strideX, offsetX, yptr, strideY, offsetY, pptr ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function srotm( N, xptr, strideX, offsetX, yptr, strideY, offsetY, pptr ) {
 	this._instance.exports.c_srotm_ndarray( N, xptr, strideX, offsetX, yptr, strideY, offsetY, pptr ); // eslint-disable-line max-len
 	return yptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/sscal/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/sscal/lib/module.js
@@ -161,7 +161,7 @@ inherits( Module, WasmModule );
 * sscal.read( xptr, view );
 * // view => <Float32Array>[ 5.0, 10.0, 15.0, 20.0, 25.0 ]
 */
-setReadOnly( Module.prototype, 'main', function sscal( N, alpha, xptr, strideX ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function sscal( N, alpha, xptr, strideX ) {
 	this._instance.exports.c_sscal( N, alpha, xptr, strideX );
 	return xptr;
 });
@@ -224,7 +224,7 @@ setReadOnly( Module.prototype, 'main', function sscal( N, alpha, xptr, strideX )
 * sscal.read( xptr, view );
 * // view => <Float32Array>[ 5.0, 10.0, 15.0, 20.0, 25.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function sscal( N, alpha, xptr, strideX, offsetX ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function sscal( N, alpha, xptr, strideX, offsetX ) {
 	this._instance.exports.c_sscal_ndarray( N, alpha, xptr, strideX, offsetX );
 	return xptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/sswap/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/sswap/lib/module.js
@@ -174,7 +174,7 @@ inherits( Module, WasmModule );
 * sswap.read( yptr, viewY );
 * // viewY => <Float32Array>[ 1.0, 2.0, 3.0, 4.0, 5.0 ]
 */
-setReadOnly( Module.prototype, 'main', function sswap( N, xptr, strideX, yptr, strideY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function sswap( N, xptr, strideX, yptr, strideY ) {
 	this._instance.exports.c_sswap( N, xptr, strideX, yptr, strideY );
 	return yptr;
 });
@@ -245,7 +245,7 @@ setReadOnly( Module.prototype, 'main', function sswap( N, xptr, strideX, yptr, s
 * sswap.read( yptr, viewY );
 * // viewY => <Float32Array>[ 1.0, 2.0, 3.0, 4.0, 5.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function sswap( N, xptr, strideX, offsetX, yptr, strideY, offsetY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function sswap( N, xptr, strideX, offsetX, yptr, strideY, offsetY ) {
 	this._instance.exports.c_sswap_ndarray( N, xptr, strideX, offsetX, yptr, strideY, offsetY ); // eslint-disable-line max-len
 	return yptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/zcopy/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zcopy/lib/module.js
@@ -186,7 +186,7 @@ inherits( Module, WasmModule );
 * console.log( reinterpretComplex128( view, 0 ) );
 * // => <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ]
 */
-setReadOnly( Module.prototype, 'main', function zcopy( N, xptr, strideX, yptr, strideY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function zcopy( N, xptr, strideX, yptr, strideY ) {
 	this._instance.exports.c_zcopy( N, xptr, strideX, yptr, strideY );
 	return yptr;
 });
@@ -263,7 +263,7 @@ setReadOnly( Module.prototype, 'main', function zcopy( N, xptr, strideX, yptr, s
 * console.log( reinterpretComplex128( view, 0 ) );
 * // => <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function zcopy( N, xptr, strideX, offsetX, yptr, strideY, offsetY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function zcopy( N, xptr, strideX, offsetX, yptr, strideY, offsetY ) {
 	this._instance.exports.c_zcopy_ndarray( N, xptr, strideX, offsetX, yptr, strideY, offsetY ); // eslint-disable-line max-len
 	return yptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/zdrot/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zdrot/lib/module.js
@@ -196,7 +196,7 @@ inherits( Module, WasmModule );
 * console.log( reinterpretComplex128( viewX, 0 ) );
 * // => <Float64Array>[ ~1.4, ~2.2, 3.0, ~3.8, ~4.6, ~5.4, ~6.2, 7.0, ~7.8, ~8.6 ]
 */
-setReadOnly( Module.prototype, 'main', function zdrot( N, zxptr, strideX, zyptr, strideY, c, s ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function zdrot( N, zxptr, strideX, zyptr, strideY, c, s ) {
 	this._instance.exports.c_zdrot( N, zxptr, strideX, zyptr, strideY, c, s );
 	return zyptr;
 });
@@ -279,7 +279,7 @@ setReadOnly( Module.prototype, 'main', function zdrot( N, zxptr, strideX, zyptr,
 * console.log( reinterpretComplex128( viewX, 0 ) );
 * // => <Float64Array>[ ~1.4, ~2.2, 3.0, ~3.8, ~4.6, ~5.4, ~6.2, 7.0, ~7.8, ~8.6 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function zdrot( N, zxptr, strideX, offsetX, zyptr, strideY, offsetY, c, s ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function zdrot( N, zxptr, strideX, offsetX, zyptr, strideY, offsetY, c, s ) {
 	this._instance.exports.c_zdrot_ndarray( N, zxptr, strideX, offsetX, zyptr, strideY, offsetY, c, s ); // eslint-disable-line max-len
 	return zyptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/zscal/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zscal/lib/module.js
@@ -187,7 +187,7 @@ inherits( Module, WasmModule );
 * console.log( reinterpretComplex128( view, 0 ) );
 * // => <Float64Array>[ -2.0, 6.0, -2.0, 14.0, -2.0, 22.0, -2.0, 30.0, -2.0, 38.0 ]
 */
-setReadOnly( Module.prototype, 'main', function zscal( N, aptr, xptr, strideX ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function zscal( N, aptr, xptr, strideX ) {
 	this._instance.exports.c_zscal( N, aptr, xptr, strideX );
 	return xptr;
 });
@@ -263,7 +263,7 @@ setReadOnly( Module.prototype, 'main', function zscal( N, aptr, xptr, strideX ) 
 * console.log( reinterpretComplex128( view, 0 ) );
 * // => <Float64Array>[ -2.0, 6.0, -2.0, 14.0, -2.0, 22.0, -2.0, 30.0, -2.0, 38.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function zscal( N, aptr, xptr, strideX, offsetX ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function zscal( N, aptr, xptr, strideX, offsetX ) {
 	this._instance.exports.c_zscal_ndarray( N, aptr, xptr, strideX, offsetX );
 	return xptr;
 });

--- a/lib/node_modules/@stdlib/blas/base/wasm/zswap/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zswap/lib/module.js
@@ -192,7 +192,7 @@ inherits( Module, WasmModule );
 * console.log( reinterpretComplex128( viewY, 0 ) );
 * // => <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ]
 */
-setReadOnly( Module.prototype, 'main', function zswap( N, xptr, strideX, yptr, strideY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'main', function zswap( N, xptr, strideX, yptr, strideY ) {
 	this._instance.exports.c_zswap( N, xptr, strideX, yptr, strideY );
 	return yptr;
 });
@@ -272,7 +272,7 @@ setReadOnly( Module.prototype, 'main', function zswap( N, xptr, strideX, yptr, s
 * console.log( reinterpretComplex128( viewY, 0 ) );
 * // => <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ]
 */
-setReadOnly( Module.prototype, 'ndarray', function zswap( N, xptr, strideX, offsetX, yptr, strideY, offsetY ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+setReadOnly( Module.prototype, 'ndarray', function zswap( N, xptr, strideX, offsetX, yptr, strideY, offsetY ) {
 	this._instance.exports.c_zswap_ndarray( N, xptr, strideX, offsetX, yptr, strideY, offsetY ); // eslint-disable-line max-len
 	return yptr;
 });

--- a/lib/node_modules/@stdlib/lapack/base/dgttrf/lib/base.js
+++ b/lib/node_modules/@stdlib/lapack/base/dgttrf/lib/base.js
@@ -72,7 +72,7 @@ var abs = require( '@stdlib/math/base/special/abs' );
 * // DU2 => <Float64Array>[ 0.0 ]
 * // IPIV => <Int32Array>[ 0, 1, 2 ]
 */
-function dgttrf( N, DL, strideDL, offsetDL, D, strideD, offsetD, DU, strideDU, offsetDU, DU2, strideDU2, offsetDU2, IPIV, strideIPIV, offsetIPIV ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point, max-len, max-params
+function dgttrf( N, DL, strideDL, offsetDL, D, strideD, offsetD, DU, strideDU, offsetDU, DU2, strideDU2, offsetDU2, IPIV, strideIPIV, offsetIPIV ) { // eslint-disable-line max-len, max-params
 	var fact;
 	var temp;
 	var idu2;

--- a/lib/node_modules/@stdlib/lapack/base/dgttrf/lib/dgttrf.js
+++ b/lib/node_modules/@stdlib/lapack/base/dgttrf/lib/dgttrf.js
@@ -63,7 +63,7 @@ var base = require( './base.js' );
 * // DU2 => <Float64Array>[ 0.0 ]
 * // IPIV => <Int32Array>[ 0, 1, 2 ]
 */
-function dgttrf( N, DL, D, DU, DU2, IPIV ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point
+function dgttrf( N, DL, D, DU, DU2, IPIV ) {
 	if ( N < 0 ) {
 		throw new RangeError( format( 'invalid argument. First argument must be a nonnegative integer. Value: `%d`.', N ) );
 	}

--- a/lib/node_modules/@stdlib/lapack/base/dgttrf/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/dgttrf/lib/ndarray.js
@@ -72,7 +72,7 @@ var base = require( './base.js' );
 * // DU2 => <Float64Array>[ 0.0 ]
 * // IPIV => <Int32Array>[ 0, 1, 2 ]
 */
-function dgttrf( N, DL, strideDL, offsetDL, D, strideD, offsetD, DU, strideDU, offsetDU, DU2, strideDU2, offsetDU2, IPIV, strideIPIV, offsetIPIV ) { // eslint-disable-line stdlib/jsdoc-doctest-decimal-point, max-len, max-params
+function dgttrf( N, DL, strideDL, offsetDL, D, strideD, offsetD, DU, strideDU, offsetDU, DU2, strideDU2, offsetDU2, IPIV, strideIPIV, offsetIPIV ) { // eslint-disable-line max-len, max-params
 	if ( N < 0 ) {
 		throw new RangeError( format( 'invalid argument. First argument must be a nonnegative integer. Value: `%d`.', N ) );
 	}


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/todo/issues/1517 and https://github.com/stdlib-js/metr-issue-tracker/issues/1237.

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes false positives in the `jsdoc-doctest-decimal-point` ESLint rule, which applied a documented function's `@returns` type to **every** annotation in every `@example`:

    -   **Mutation annotations**: for a function documented as `@returns {integer}` (e.g., a LAPACK status code) which mutates a `Float64Array` argument, annotations such as `// D => <Float64Array>[ 3.0, 5.0 ]` were incorrectly flagged for containing decimal points (see, e.g., the incorrect diagnostic surfaced in the review of #12354). Annotations of the form `// <identifier> => ...` describe mutated values, not return values, and are now skipped.
    -   **Non-scalar annotation values**: annotation values which are not scalar numeric values (e.g., printed arrays such as `// => <Float32Array>[ 1.0, 2.0 ]`) do not have the documented return type and are no longer validated against it (previously only enforced in the "must include a decimal point" branch, but not in the "must NOT include a decimal point" branch).
    -   **Typed array element accessors**: for a function documented as `@returns {number}` which returns elements of an integer typed array parameter (e.g., `function getUint8( arr, idx ) { return arr[ idx ]; }` with `@param {Uint8Array} arr`), annotations such as `// returns 3` were incorrectly required to include a decimal point (see stdlib-js/todo#1517). The rule now resolves `@param` types and, when a function only ever returns elements of typed array parameters whose element type conflicts with the documented return type, skips validation, as the correct annotation format cannot be inferred from the return type alone. When the element type *matches* the documented return type, validation still applies.

-   adds test fixtures covering each of the above scenarios.
-   removes `eslint-disable` directives which are no longer needed under the fixed rule (in `array/base/getter`, the `blas/base/wasm/*` packages, and `lapack/base/dgttrf`); the directives in `utils/type-max` and `utils/type-min` remain, as those functions return integer-valued constants and are not covered by the accessor heuristic.

To validate beyond the unit tests, the previous and fixed rule were run over 5,538 source files across the `array`, `blas`, `lapack`, `number`, and `strided` namespaces: the previous rule reported 76 diagnostics (all false positives, each suppressed via an `eslint-disable` directive), while the fixed rule reports 0, with no new diagnostics introduced.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   stdlib-js/todo#1517
-   https://github.com/stdlib-js/metr-issue-tracker/issues/1237

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code under my direction, with the approach and validation reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md