### PR TITLE
feat!: add `fromIndex` support to `blas/ext/base/ndarray/glast-index-equal`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/README.md
@@ -41,12 +41,17 @@ var glastIndexEqual = require( '@stdlib/blas/ext/base/ndarray/glast-index-equal'
 Returns the index of the last element in a one-dimensional ndarray equal to a corresponding element in another one-dimensional ndarray.
 
 ```javascript
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var vector = require( '@stdlib/ndarray/vector/ctor' );
 
 var x = vector( [ 1.0, 2.0, 3.0, 4.0 ], 'generic' );
 var y = vector( [ 0.0, 0.0, 3.0, 0.0 ], 'generic' );
 
-var idx = glastIndexEqual( [ x, y ] );
+var fromIndex = scalar2ndarray( 3, {
+    'dtype': 'generic'
+});
+
+var idx = glastIndexEqual( [ x, y, fromIndex ] );
 // returns 2
 ```
 
@@ -56,16 +61,22 @@ The function has the following parameters:
 
     -   first one-dimensional input ndarray.
     -   second one-dimensional input ndarray.
+    -   a zero-dimensional ndarray containing the index from which to begin searching.
 
 If the function is unable to find matching elements, the function returns `-1`.
 
 ```javascript
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var vector = require( '@stdlib/ndarray/vector/ctor' );
 
 var x = vector( [ 1.0, 2.0, 3.0, 4.0 ], 'generic' );
 var y = vector( [ 5.0, 6.0, 7.0, 8.0 ], 'generic' );
 
-var idx = glastIndexEqual( [ x, y ] );
+var fromIndex = scalar2ndarray( 3, {
+    'dtype': 'generic'
+});
+
+var idx = glastIndexEqual( [ x, y, fromIndex ] );
 // returns -1
 ```
 
@@ -77,6 +88,7 @@ var idx = glastIndexEqual( [ x, y ] );
 
 ## Notes
 
+-   If a specified starting search index is negative, the function resolves the starting search index by counting backward from the last element (where `-1` refers to the last element).
 -   When comparing elements, the function checks for equality using the strict equality operator `===`. As a consequence, `NaN` values are considered distinct, and `-0` and `+0` are considered the same.
 
 </section>
@@ -91,6 +103,7 @@ var idx = glastIndexEqual( [ x, y ] );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/discrete-uniform' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var glastIndexEqual = require( '@stdlib/blas/ext/base/ndarray/glast-index-equal' );
 
@@ -103,7 +116,11 @@ console.log( ndarray2array( x ) );
 var y = discreteUniform( [ 10 ], 0, 10, opts );
 console.log( ndarray2array( y ) );
 
-var idx = glastIndexEqual( [ x, y ] );
+var fromIndex = scalar2ndarray( 9, {
+    'dtype': 'generic'
+});
+
+var idx = glastIndexEqual( [ x, y, fromIndex ] );
 console.log( idx );
 ```
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/benchmark/benchmark.js
@@ -23,9 +23,9 @@
 var bench = require( '@stdlib/bench' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var pow = require( '@stdlib/math/base/special/pow' );
-var vector = require( '@stdlib/ndarray/vector/ctor' );
-var ones = require( '@stdlib/array/ones' );
-var zeros = require( '@stdlib/array/zeros' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+var ones = require( '@stdlib/ndarray/ones' );
+var zeros = require( '@stdlib/ndarray/zeros' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var glastIndexEqual = require( './../lib' );
@@ -48,8 +48,15 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = vector( ones( len, options.dtype ), options.dtype );
-	var y = vector( zeros( len, options.dtype ), options.dtype );
+	var fromIndex;
+	var x;
+	var y;
+
+	x = ones( [ len ], options );
+	y = zeros( [ len ], options );
+	fromIndex = scalar2ndarray( len - 1, {
+		'dtype': 'generic'
+	});
 	return benchmark;
 
 	/**
@@ -64,7 +71,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			out = glastIndexEqual( [ x, y ] );
+			out = glastIndexEqual( [ x, y, fromIndex ] );
 			if ( out !== out ) {
 				b.fail( 'should return an integer' );
 			}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/docs/repl.txt
@@ -3,6 +3,10 @@
     Returns the index of the last element in a one-dimensional ndarray equal to
     a corresponding element in another one-dimensional ndarray.
 
+    If a specified starting search index is negative, the function resolves the
+    starting search index by counting backward from the last element (where `-1`
+    refers to the last element).
+
     When comparing elements, the function checks for equality using the strict
     equality operator `===`. As a consequence, `NaN` values are considered
     distinct, and `-0` and `+0` are considered the same.
@@ -14,6 +18,8 @@
 
         - first one-dimensional input ndarray.
         - second one-dimensional input ndarray.
+        - a zero-dimensional ndarray containing the index from which to begin
+        searching.
 
     Returns
     -------
@@ -24,7 +30,8 @@
     --------
     > var x = {{alias:@stdlib/ndarray/vector/ctor}}( [ 1.0, 2.0, 3.0, 4.0 ], 'generic' );
     > var y = {{alias:@stdlib/ndarray/vector/ctor}}( [ 0.0, 0.0, 3.0, 0.0 ], 'generic' );
-    > {{alias}}( [ x, y ] )
+    > var i = {{alias:@stdlib/ndarray/from-scalar}}( 3, { 'dtype': 'generic' } );
+    > {{alias}}( [ x, y, i ] )
     2
 
     See Also

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/docs/types/index.d.ts
@@ -31,6 +31,7 @@ import { typedndarray } from '@stdlib/types/ndarray';
 *
 *     -   first one-dimensional input ndarray.
 *     -   second one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * -   When comparing elements, the function checks for equality using the strict equality operator `===`. As a consequence, `NaN` values are considered distinct, and `-0` and `+0` are considered the same.
 *
@@ -38,15 +39,20 @@ import { typedndarray } from '@stdlib/types/ndarray';
 * @returns index
 *
 * @example
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var vector = require( '@stdlib/ndarray/vector/ctor' );
 *
 * var x = vector( [ 1.0, 2.0, 3.0, 4.0 ], 'generic' );
 * var y = vector( [ 0.0, 0.0, 3.0, 0.0 ], 'generic' );
 *
-* var idx = glastIndexEqual( [ x, y ] );
+* var fromIndex = scalar2ndarray( 3, {
+*     'dtype': 'generic'
+* });
+*
+* var idx = glastIndexEqual( [ x, y, fromIndex ] );
 * // returns 2
 */
-declare function glastIndexEqual( arrays: [ typedndarray<unknown>, typedndarray<unknown> ] ): number;
+declare function glastIndexEqual( arrays: [ typedndarray<unknown>, typedndarray<unknown>, typedndarray<number> ] ): number;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/docs/types/test.ts
@@ -19,6 +19,7 @@
 /* eslint-disable space-in-parens */
 
 import zeros = require( '@stdlib/ndarray/zeros' );
+import scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 import glastIndexEqual = require( './index' );
 
 
@@ -32,8 +33,11 @@ import glastIndexEqual = require( './index' );
 	const y = zeros( [ 10 ], {
 		'dtype': 'generic'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	glastIndexEqual( [ x, y ] ); // $ExpectType number
+	glastIndexEqual( [ x, y, fromIndex ] ); // $ExpectType number
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
@@ -57,7 +61,10 @@ import glastIndexEqual = require( './index' );
 	const y = zeros( [ 10 ], {
 		'dtype': 'generic'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	glastIndexEqual(); // $ExpectError
-	glastIndexEqual( [ x, y ], {} ); // $ExpectError
+	glastIndexEqual( [ x, y, fromIndex ], {} ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/discrete-uniform' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var glastIndexEqual = require( './../lib' );
 
@@ -31,5 +32,9 @@ console.log( ndarray2array( x ) );
 var y = discreteUniform( [ 10 ], 0, 10, opts );
 console.log( ndarray2array( y ) );
 
-var idx = glastIndexEqual( [ x, y ] );
+var fromIndex = scalar2ndarray( 9, {
+	'dtype': 'generic'
+});
+
+var idx = glastIndexEqual( [ x, y, fromIndex ] );
 console.log( idx );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/lib/index.js
@@ -24,13 +24,18 @@
 * @module @stdlib/blas/ext/base/ndarray/glast-index-equal
 *
 * @example
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var vector = require( '@stdlib/ndarray/vector/ctor' );
 * var glastIndexEqual = require( '@stdlib/blas/ext/base/ndarray/glast-index-equal' );
 *
 * var x = vector( [ 1.0, 2.0, 3.0, 4.0 ], 'generic' );
 * var y = vector( [ 0.0, 0.0, 3.0, 0.0 ], 'generic' );
 *
-* var idx = glastIndexEqual( [ x, y ] );
+* var fromIndex = scalar2ndarray( 3, {
+*     'dtype': 'generic'
+* });
+*
+* var idx = glastIndexEqual( [ x, y, fromIndex ] );
 * // returns 2
 */
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/lib/main.js
@@ -20,7 +20,9 @@
 
 // MODULES //
 
+var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
+var clipUpperIndex = require( '@stdlib/ndarray/base/clip-upper-index' );
 var getStride = require( '@stdlib/ndarray/base/stride' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
@@ -38,6 +40,7 @@ var strided = require( '@stdlib/blas/ext/base/glast-index-equal' ).ndarray;
 *
 *     -   first one-dimensional input ndarray.
 *     -   second one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * -   When comparing elements, the function checks for equality using the strict equality operator `===`. As a consequence, `NaN` values are considered distinct, and `-0` and `+0` are considered the same.
 *
@@ -45,18 +48,35 @@ var strided = require( '@stdlib/blas/ext/base/glast-index-equal' ).ndarray;
 * @returns {integer} index
 *
 * @example
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var vector = require( '@stdlib/ndarray/vector/ctor' );
 *
 * var x = vector( [ 1.0, 2.0, 3.0, 4.0 ], 'generic' );
 * var y = vector( [ 0.0, 0.0, 3.0, 0.0 ], 'generic' );
 *
-* var idx = glastIndexEqual( [ x, y ] );
+* var fromIndex = scalar2ndarray( 3, {
+*     'dtype': 'generic'
+* });
+*
+* var idx = glastIndexEqual( [ x, y, fromIndex ] );
 * // returns 2
 */
 function glastIndexEqual( arrays ) {
-	var x = arrays[ 0 ];
-	var y = arrays[ 1 ];
-	return strided( numelDimension( x, 0 ), getData( x ), getStride( x, 0 ), getOffset( x ), getData( y ), getStride( y, 0 ), getOffset( y ) ); // eslint-disable-line max-len
+	var fromIndex;
+	var N;
+	var x;
+	var y;
+
+	x = arrays[ 0 ];
+	y = arrays[ 1 ];
+	fromIndex = ndarraylike2scalar( arrays[ 2 ] );
+
+	N = numelDimension( x, 0 );
+	fromIndex = clipUpperIndex( fromIndex, ( fromIndex < 0 ) ? N : N-1 );
+	if ( fromIndex < 0 ) {
+		return -1;
+	}
+	return strided( fromIndex+1, getData( x ), getStride( x, 0 ), getOffset( x ), getData( y ), getStride( y, 0 ), getOffset( y ) ); // eslint-disable-line max-len
 }
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-equal/test/test.js
@@ -22,6 +22,7 @@
 
 var tape = require( 'tape' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var glastIndexEqual = require( './../lib' );
 
 
@@ -51,55 +52,97 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function returns the index of the last element in a one-dimensional ndarray equal to a corresponding element in another one-dimensional ndarray', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
 
+	fromIndex = scalar2ndarray( 5, {
+		'dtype': 'generic'
+	});
+
 	x = vector( [ 1.0, 1.0, 2.0, 2.0, 3.0, 3.0 ], 6, 1, 0 );
 	y = vector( [ 1.0, 0.0, 2.0, 0.0, 3.0, 0.0 ], 6, 1, 0 );
 
-	actual = glastIndexEqual( [ x, y ] );
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, 4, 'returns expected value' );
 
 	x = vector( [ 1.0, 2.0, 3.0, 4.0 ], 4, 1, 0 );
 	y = vector( [ 0.0, 0.0, 3.0, 0.0 ], 4, 1, 0 );
 
-	actual = glastIndexEqual( [ x, y ] );
+	fromIndex = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, 2, 'returns expected value' );
 
 	x = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], 6, 1, 0 );
 	y = vector( [ 0.0, 0.0, 0.0, 0.0, 0.0, 6.0 ], 6, 1, 0 );
 
-	actual = glastIndexEqual( [ x, y ] );
+	fromIndex = scalar2ndarray( 5, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, 5, 'returns expected value' );
 
 	x = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], 6, 1, 0 );
 	y = vector( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ], 6, 1, 0 );
 
-	actual = glastIndexEqual( [ x, y ] );
+	fromIndex = scalar2ndarray( 5, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `-1` if unable to find matching elements', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
 
+	fromIndex = scalar2ndarray( 5, {
+		'dtype': 'generic'
+	});
+
 	x = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], 6, 1, 0 );
 	y = vector( [ 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ], 6, 1, 0 );
 
-	actual = glastIndexEqual( [ x, y ] );
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, -1, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `-1` if provided an empty input ndarray', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+	var y;
+
+	x = vector( [], 0, 1, 0 );
+	y = vector( [], 0, 1, 0 );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having non-unit strides', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
+
+	fromIndex = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
 	x = [
 		1.0,  // 0
@@ -122,16 +165,21 @@ tape( 'the function supports one-dimensional ndarrays having non-unit strides', 
 		8.0
 	];
 
-	actual = glastIndexEqual( [ vector( x, 4, 2, 0 ), vector( y, 4, 2, 0 ) ] );
+	actual = glastIndexEqual( [ vector( x, 4, 2, 0 ), vector( y, 4, 2, 0 ), fromIndex ] );
 
 	t.strictEqual( actual, 3, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having negative strides', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
+
+	fromIndex = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
 	x = [
 		1.0,  // 3
@@ -154,16 +202,21 @@ tape( 'the function supports one-dimensional ndarrays having negative strides', 
 		8.0
 	];
 
-	actual = glastIndexEqual( [ vector( x, 4, -2, 6 ), vector( y, 4, -2, 6 ) ] );
+	actual = glastIndexEqual( [ vector( x, 4, -2, 6 ), vector( y, 4, -2, 6 ), fromIndex ] );
 
 	t.strictEqual( actual, 2, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having non-zero offsets', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 	var y;
+
+	fromIndex = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
 	x = [
 		0.0,
@@ -186,8 +239,118 @@ tape( 'the function supports one-dimensional ndarrays having non-zero offsets', 
 		4.0   // 3
 	];
 
-	actual = glastIndexEqual( [ vector( x, 4, 2, 1 ), vector( y, 4, 2, 1 ) ] );
+	actual = glastIndexEqual( [ vector( x, 4, 2, 1 ), vector( y, 4, 2, 1 ), fromIndex ] );
 	t.strictEqual( actual, 3, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a nonnegative starting search index', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+	var y;
+
+	x = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], 6, 1, 0 );
+	y = vector( [ 1.0, 2.0, 0.0, 4.0, 0.0, 6.0 ], 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( 5, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 1, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative starting search index', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+	var y;
+
+	x = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], 6, 1, 0 );
+	y = vector( [ 1.0, 2.0, 0.0, 4.0, 0.0, 6.0 ], 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( -1, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -2, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -3, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -5, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 1, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -6, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 0, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -7, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, -1, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function clamps a starting search index which is greater than or equal to the number of elements in the input ndarray', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+	var y;
+
+	x = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], 6, 1, 0 );
+	y = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( 6, {
+		'dtype': 'generic'
+	});
+
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 7, {
+		'dtype': 'generic'
+	});
+
+	actual = glastIndexEqual( [ x, y, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1190.

## Description

> What is the purpose of this pull request?

This pull request:

-   add `fromIndex` support to `blas/ext/base/ndarray/glast-index-equal`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1190.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Primarily written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
