### PR TITLE
test: migrate `stats/base/dists/gumbel/median` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/median/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/median/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var median = require( './../lib' );
 
 
@@ -76,9 +75,7 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', function t
 
 tape( 'the function returns the median of a Gumbel distribution', function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -89,13 +86,7 @@ tape( 'the function returns the median of a Gumbel distribution', function test(
 	for ( i = 0; i < mu.length; i++ ) {
 		y = median( mu[i], beta[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/median/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/median/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -85,9 +84,7 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', opts, func
 
 tape( 'the function returns the median of a Gumbel distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -97,14 +94,8 @@ tape( 'the function returns the median of a Gumbel distribution', opts, function
 	beta = data.beta;
 	for ( i = 0; i < mu.length; i++ ) {
 		y = median( mu[i], beta[i] );
-		if ( expected[i] !== null) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+		if ( expected[i] !== null ) {
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `stats/base/dists/gumbel/median` from relative tolerance (`EPS`-based) assertions to ULP difference assertions via `@stdlib/assert/is-almost-same-value`.
-   replaces the `delta`/`tol` tolerance branch (previously `tol = 2.0 * EPS * abs( expected[ i ] )`) with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' )`, retaining the existing `expected[ i ] !== null` guard.
-   removes the now-unused `abs` and `EPS` requires and the corresponding `delta`/`tol` variable declarations.

**Final ULP constant: `0`**, for both the JavaScript and the native test suites.

The bound was tightened empirically. Starting from a high value and searching downward via a per-case minimum-ULP computation over the full fixture set (`test/fixtures/julia/data.json`, 100 fixture cases), the measured maximum ULP difference is `0` — every fixture value is reproduced bit-for-bit — so `0` is the minimum value at which the suites pass.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   The native add-on was built locally (`make install-node-addons NODE_ADDONS_PATTERN="stats/base/dists/gumbel/median"`) so that `test/test.native.js` actually executed rather than being skipped; the native implementation also matches the fixtures exactly (max ULP difference `0`).
-   The package test suite was run twice at the final ULP value to confirm determinism: 110/110 assertions passing in `test.js` and 110/110 in `test.native.js` on both runs.
-   `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/gumbel/median/.*"` is clean.
-   No files other than the two test files were changed.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This pull request was authored by an automated Claude Code agent running as a scheduled task, following the conventions established in previously merged ULP migration pull requests for this issue.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4tVv8pEgy2wh9DZoqWqFp)_