### PR TITLE
feat!: add `fromIndex` support to `blas/ext/base/ndarray/glast-index-of-falsy`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/README.md
@@ -41,26 +41,39 @@ var glastIndexOfFalsy = require( '@stdlib/blas/ext/base/ndarray/glast-index-of-f
 Returns the index of the last falsy element in a one-dimensional ndarray.
 
 ```javascript
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var vector = require( '@stdlib/ndarray/vector/ctor' );
 
 var x = vector( [ 0.0, 3.0, 0.0, 2.0 ], 'generic' );
 
-var idx = glastIndexOfFalsy( [ x ] );
+var fromIndex = scalar2ndarray( 3, {
+    'dtype': 'generic'
+});
+
+var idx = glastIndexOfFalsy( [ x, fromIndex ] );
 // returns 2
 ```
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing a one-dimensional input ndarray.
+-   **arrays**: array-like object containing the following ndarrays:
+
+    -   a one-dimensional input ndarray.
+    -   a zero-dimensional ndarray containing the index from which to begin searching.
 
 If the function is unable to find a falsy element, the function returns `-1`.
 
 ```javascript
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var vector = require( '@stdlib/ndarray/vector/ctor' );
 
 var x = vector( [ 1.0, 2.0, 3.0, 4.0 ], 'generic' );
 
-var idx = glastIndexOfFalsy( [ x ] );
+var fromIndex = scalar2ndarray( 3, {
+    'dtype': 'generic'
+});
+
+var idx = glastIndexOfFalsy( [ x, fromIndex ] );
 // returns -1
 ```
 
@@ -73,6 +86,7 @@ var idx = glastIndexOfFalsy( [ x ] );
 ## Notes
 
 -   The function treats `NaN` values as falsy.
+-   If a specified starting search index is negative, the function resolves the starting search index by counting backward from the last element (where `-1` refers to the last element).
 
 </section>
 
@@ -86,6 +100,7 @@ var idx = glastIndexOfFalsy( [ x ] );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/discrete-uniform' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var glastIndexOfFalsy = require( '@stdlib/blas/ext/base/ndarray/glast-index-of-falsy' );
 
@@ -96,7 +111,11 @@ var opts = {
 var x = discreteUniform( [ 10 ], 0, 5, opts );
 console.log( ndarray2array( x ) );
 
-var idx = glastIndexOfFalsy( [ x ] );
+var fromIndex = scalar2ndarray( 9, {
+    'dtype': 'generic'
+});
+
+var idx = glastIndexOfFalsy( [ x, fromIndex ] );
 console.log( idx );
 ```
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var ones = require( '@stdlib/ndarray/ones' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
@@ -46,7 +47,13 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = ones( [ len ], options );
+	var fromIndex;
+	var x;
+
+	x = ones( [ len ], options );
+	fromIndex = scalar2ndarray( len - 1, {
+		'dtype': 'generic'
+	});
 	return benchmark;
 
 	/**
@@ -61,7 +68,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			out = glastIndexOfFalsy( [ x ] );
+			out = glastIndexOfFalsy( [ x, fromIndex ] );
 			if ( out !== out ) {
 				b.fail( 'should return an integer' );
 			}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/docs/repl.txt
@@ -2,6 +2,10 @@
 {{alias}}( arrays )
     Returns the index of the last falsy element in a one-dimensional ndarray.
 
+    If a specified starting search index is negative, the function resolves the
+    starting search index by counting backward from the last element (where `-1`
+    refers to the last element).
+
     If unable to find a falsy element, the function returns `-1`.
 
     Parameters
@@ -10,6 +14,8 @@
         Array-like object containing the following ndarrays:
 
         - a one-dimensional input ndarray.
+        - a zero-dimensional ndarray containing the index from which to begin
+        searching.
 
     Returns
     -------
@@ -19,7 +25,8 @@
     Examples
     --------
     > var x = {{alias:@stdlib/ndarray/vector/ctor}}( [ 0.0, 2.0, 0.0 ], 'generic' );
-    > {{alias}}( [ x ] )
+    > var i = {{alias:@stdlib/ndarray/from-scalar}}( 2, { 'dtype': 'generic' } );
+    > {{alias}}( [ x, i ] )
     2
 
     See Also

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/docs/types/index.d.ts
@@ -30,19 +30,25 @@ import { typedndarray } from '@stdlib/types/ndarray';
 * -   The function expects the following ndarrays:
 *
 *     -   a one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * @param arrays - array-like object containing ndarrays
 * @returns index
 *
 * @example
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var vector = require( '@stdlib/ndarray/vector/ctor' );
 *
 * var x = vector( [ 0.0, 3.0, 0.0, 2.0 ], 'generic' );
 *
-* var v = glastIndexOfFalsy( [ x ] );
+* var fromIndex = scalar2ndarray( 3, {
+*     'dtype': 'generic'
+* });
+*
+* var v = glastIndexOfFalsy( [ x, fromIndex ] );
 * // returns 2
 */
-declare function glastIndexOfFalsy( arrays: [ typedndarray<unknown> ] ): number;
+declare function glastIndexOfFalsy( arrays: [ typedndarray<unknown>, typedndarray<number> ] ): number;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/docs/types/test.ts
@@ -19,6 +19,7 @@
 /* eslint-disable space-in-parens */
 
 import zeros = require( '@stdlib/ndarray/zeros' );
+import scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 import glastIndexOfFalsy = require( './index' );
 
 
@@ -29,8 +30,11 @@ import glastIndexOfFalsy = require( './index' );
 	const x = zeros( [ 10 ], {
 		'dtype': 'generic'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	glastIndexOfFalsy( [ x ] ); // $ExpectType number
+	glastIndexOfFalsy( [ x, fromIndex ] ); // $ExpectType number
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
@@ -51,7 +55,10 @@ import glastIndexOfFalsy = require( './index' );
 	const x = zeros( [ 10 ], {
 		'dtype': 'generic'
 	});
+	const fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
 	glastIndexOfFalsy(); // $ExpectError
-	glastIndexOfFalsy( [ x ], {} ); // $ExpectError
+	glastIndexOfFalsy( [ x, fromIndex ], {} ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/discrete-uniform' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var glastIndexOfFalsy = require( './../lib' );
 
@@ -29,5 +30,9 @@ var opts = {
 var x = discreteUniform( [ 10 ], 0, 5, opts );
 console.log( ndarray2array( x ) );
 
-var idx = glastIndexOfFalsy( [ x ] );
+var fromIndex = scalar2ndarray( 9, {
+	'dtype': 'generic'
+});
+
+var idx = glastIndexOfFalsy( [ x, fromIndex ] );
 console.log( idx );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/lib/index.js
@@ -24,12 +24,17 @@
 * @module @stdlib/blas/ext/base/ndarray/glast-index-of-falsy
 *
 * @example
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var vector = require( '@stdlib/ndarray/vector/ctor' );
 * var glastIndexOfFalsy = require( '@stdlib/blas/ext/base/ndarray/glast-index-of-falsy' );
 *
 * var x = vector( [ 0.0, 3.0, 0.0, 2.0 ], 'generic' );
 *
-* var v = glastIndexOfFalsy( [ x ] );
+* var fromIndex = scalar2ndarray( 3, {
+*     'dtype': 'generic'
+* });
+*
+* var v = glastIndexOfFalsy( [ x, fromIndex ] );
 * // returns 2
 */
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/lib/main.js
@@ -20,7 +20,9 @@
 
 // MODULES //
 
+var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
+var clipUpperIndex = require( '@stdlib/ndarray/base/clip-upper-index' );
 var getStride = require( '@stdlib/ndarray/base/stride' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
@@ -37,21 +39,38 @@ var strided = require( '@stdlib/blas/ext/base/glast-index-of-falsy' ).ndarray;
 * -   The function expects the following ndarrays:
 *
 *     -   a one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the index from which to begin searching.
 *
 * @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
 * @returns {integer} index
 *
 * @example
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var vector = require( '@stdlib/ndarray/vector/ctor' );
 *
 * var x = vector( [ 0.0, 3.0, 0.0, 2.0 ], 'generic' );
 *
-* var v = glastIndexOfFalsy( [ x ] );
+* var fromIndex = scalar2ndarray( 3, {
+*     'dtype': 'generic'
+* });
+*
+* var v = glastIndexOfFalsy( [ x, fromIndex ] );
 * // returns 2
 */
 function glastIndexOfFalsy( arrays ) {
-	var x = arrays[ 0 ];
-	return strided( numelDimension( x, 0 ), getData( x ), getStride( x, 0 ), getOffset( x ) ); // eslint-disable-line max-len
+	var fromIndex;
+	var N;
+	var x;
+
+	x = arrays[ 0 ];
+	fromIndex = ndarraylike2scalar( arrays[ 1 ] );
+
+	N = numelDimension( x, 0 );
+	fromIndex = clipUpperIndex( fromIndex, ( fromIndex < 0 ) ? N : N-1 );
+	if ( fromIndex < 0 ) {
+		return -1;
+	}
+	return strided( fromIndex+1, getData( x ), getStride( x, 0 ), getOffset( x ) ); // eslint-disable-line max-len
 }
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glast-index-of-falsy/test/test.js
@@ -22,6 +22,7 @@
 
 var tape = require( 'tape' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var glastIndexOfFalsy = require( './../lib' );
 
 
@@ -56,49 +57,77 @@ tape( 'the function has an arity of 1', function test( t ) {
 });
 
 tape( 'the function returns the index of the last falsy element in a one-dimensional ndarray', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
+	fromIndex = scalar2ndarray( 5, {
+		'dtype': 'generic'
+	});
+
 	x = vector( [ 0.0, 3.0, 0.0, 2.0, 4.0, 1.0 ], 6, 1, 0 );
-	actual = glastIndexOfFalsy( [ x ] );
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, 2, 'returns expected value' );
 
 	x = vector( [ 0.0, 1.0, 2.0, 3.0 ], 4, 1, 0 );
-	actual = glastIndexOfFalsy( [ x ] );
+
+	fromIndex = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, 0, 'returns expected value' );
 
 	x = vector( [ 1.0, 2.0, 3.0, NaN ], 4, 1, 0 );
-	actual = glastIndexOfFalsy( [ x ] );
+
+	fromIndex = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, 3, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `-1` if unable to find a falsy element', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
+	fromIndex = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
+
 	x = vector( [ 1.0, 2.0, 3.0, 4.0 ], 4, 1, 0 );
-	actual = glastIndexOfFalsy( [ x ] );
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'if provided an empty vector, the function returns `-1`', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
 
 	x = vector( [], 0, 1, 0 );
-	actual = glastIndexOfFalsy( [ x ] );
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having non-unit strides', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
+
+	fromIndex = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
 	x = [
 		1.0,  // 0
@@ -111,15 +140,20 @@ tape( 'the function supports one-dimensional ndarrays having non-unit strides', 
 		2.0
 	];
 
-	actual = glastIndexOfFalsy( [ vector( x, 4, 2, 0 ) ] );
+	actual = glastIndexOfFalsy( [ vector( x, 4, 2, 0 ), fromIndex ] );
 	t.strictEqual( actual, 3, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having negative strides', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
+
+	fromIndex = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
 	x = [
 		0.0,  // 3
@@ -132,15 +166,20 @@ tape( 'the function supports one-dimensional ndarrays having negative strides', 
 		2.0
 	];
 
-	actual = glastIndexOfFalsy( [ vector( x, 4, -2, 6 ) ] );
+	actual = glastIndexOfFalsy( [ vector( x, 4, -2, 6 ), fromIndex ] );
 	t.strictEqual( actual, 3, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function supports one-dimensional ndarrays having non-zero offsets', function test( t ) {
+	var fromIndex;
 	var actual;
 	var x;
+
+	fromIndex = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
 	x = [
 		2.0,
@@ -153,8 +192,112 @@ tape( 'the function supports one-dimensional ndarrays having non-zero offsets', 
 		4.0   // 3
 	];
 
-	actual = glastIndexOfFalsy( [ vector( x, 4, 2, 1 ) ] );
+	actual = glastIndexOfFalsy( [ vector( x, 4, 2, 1 ), fromIndex ] );
 	t.strictEqual( actual, 2, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a nonnegative starting search index', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+
+	x = vector( [ 0.0, 0.0, 1.0, 0.0, 1.0, 0.0 ], 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( 5, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 1, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative starting search index', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+
+	x = vector( [ 0.0, 0.0, 1.0, 0.0, 1.0, 0.0 ], 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( -1, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -2, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -3, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 3, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -5, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 1, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -6, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 0, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( -7, {
+		'dtype': 'generic'
+	});
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, -1, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function clamps a starting search index which is greater than or equal to the number of elements in the input ndarray', function test( t ) {
+	var fromIndex;
+	var actual;
+	var x;
+
+	x = vector( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ], 6, 1, 0 );
+
+	fromIndex = scalar2ndarray( 6, {
+		'dtype': 'generic'
+	});
+
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
+
+	fromIndex = scalar2ndarray( 7, {
+		'dtype': 'generic'
+	});
+
+	actual = glastIndexOfFalsy( [ x, fromIndex ] );
+	t.strictEqual( actual, 5, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1191.

## Description

> What is the purpose of this pull request?

This pull request:

-   add `fromIndex` support to `blas/ext/base/ndarray/glast-index-of-falsy`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1191.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Primarily written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
