### PR TITLE
test: migrate `stats/base/dists/frechet/mean` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/mean/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mean = require( './../lib' );
 
 
@@ -97,8 +96,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', function test
 tape( 'the function returns the expected value of a Fréchet distribution', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var y;
 	var i;
@@ -109,13 +106,7 @@ tape( 'the function returns the expected value of a Fréchet distribution', func
 	for ( i = 0; i < alpha.length; i++ ) {
 		y = mean( alpha[i], s[i], 0.0 );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'alpha:'+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. s: '+s[i]+'. m: 0. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/mean/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -112,8 +111,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', opts, functio
 tape( 'the function returns the expected value of a Fréchet distribution', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var y;
 	var i;
@@ -124,13 +121,7 @@ tape( 'the function returns the expected value of a Fréchet distribution', opts
 	for ( i = 0; i < alpha.length; i++ ) {
 		y = mean( alpha[i], s[i], 0.0 );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'alpha:'+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. s: '+s[i]+'. m: 0. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/frechet/mean` from relative-tolerance assertions (`delta <= tol`, with `delta = abs( y - expected[ i ] )` and `tol = 2.0 * EPS * abs( expected[ i ] )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the same migration to both `test/test.js` and `test/test.native.js`.
-   preserves all existing test cases and structure, including the non-tolerance assertions (`NaN` parameters, nonpositive `alpha`, and nonpositive `s`) and the `expected[ i ] !== null` fixture guard.

The ULP bound used is:

| Test file            | Fixture block                                    | ULP |
| -------------------- | ------------------------------------------------ | :-: |
| `test/test.js`        | `fixtures/julia/data.json` (81 non-`null` cases) |  3  |
| `test/test.native.js` | `fixtures/julia/data.json` (81 non-`null` cases) |  3  |

`3` is the measured minimum: starting from `N = 64` and tightening, `N = 3` passes over the full fixture set while `N = 2` fails (one fixture entry, `alpha = 3.988247436421993`, `s = 2.814258823431831`, differs from the Julia expected value by exactly 3 ULP). The suite was run twice at the final `N` to confirm deterministic passing (96 assertions, all passing on both runs).

Because the native add-on is not built in this environment, `test/test.native.js` is skipped locally and its bound could not be measured by running that file directly. Instead, the C implementation was compiled standalone against its resolved C dependency closure (`math/base/special/gamma`, `math/base/assert/is-nan`, `constants/float64/pinf`) and evaluated over all 100 fixture inputs: its results are bit-for-bit identical to the JavaScript implementation for every input, so the same bound of `3` applies to both files.

Linting was checked before and after the change and is unchanged (0 errors; the same 2 pre-existing `@cspell/spellchecker` warnings for "Fréchet" in the test descriptions, which this PR does not touch). The only files changed are the two test files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code: the assistant mechanically converted the tolerance-based assertions to `isAlmostSameValue`, agentically searched for the minimum ULP bound, verified that the C implementation matches the JavaScript implementation bit-for-bit over the fixture set, confirmed determinism across two full runs, and ran the local lint and test suites before submitting.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_014VYisWJoAMK8fVxSCKwkg6)_