### PR TITLE
build: migrate Markdown code-block linting to ESLint flat config

### DIFF
--- a/etc/eslint/eslint.flat.config.markdown.js
+++ b/etc/eslint/eslint.flat.config.markdown.js
@@ -1,0 +1,108 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var defaults = require( './../../eslint.flat.config.js' );
+
+
+// MAIN //
+
+/**
+* ESLint flat configuration for linting Markdown code blocks.
+*/
+var config = [];
+
+// Include the default configuration:
+config = config.concat( defaults );
+
+// Append configuration specific to Markdown code blocks:
+config.push({
+	'rules': {
+		// Allow variables to be declared as needed:
+		'vars-on-top': 'off',
+
+		// Allow using synchronous methods:
+		'n/no-sync': 'off',
+
+		// Allow using `console`:
+		'no-console': 'off',
+
+		// Do not require `use strict` pragma:
+		'strict': 'off',
+
+		// Do not require an end-of-line character in code blocks:
+		'eol-last': 'off',
+
+		// Require `4` space indentation:
+		'indent': [ 'error', 4, {
+			'SwitchCase': 0,
+			'VariableDeclarator': 1,
+			'outerIIFEBody': 1,
+			'MemberExpression': 1,
+			'FunctionDeclaration': {
+				'body': 1,
+				'parameters': 'off'
+			},
+			'FunctionExpression': {
+				'body': 1,
+				'parameters': 'off'
+			},
+			'CallExpression': {
+				'arguments': 'off'
+			},
+			'ArrayExpression': 1,
+			'ObjectExpression': 1,
+			'flatTernaryExpressions': true
+		}],
+
+		// Never allow tabs:
+		'no-tabs': 'error',
+
+		// Do not require JSDoc comments:
+		'jsdoc/require-jsdoc': 'off',
+
+		// Do not require `@private` annotations:
+		'stdlib/jsdoc-private-annotation': 'off',
+
+		// Do not lint return annotation values in JSDoc comments (FIXME: remove this once we can reliably lint Markdown code blocks):
+		'stdlib/jsdoc-return-annotations-values': 'off',
+
+		// Do not enforce disallowing empty lines between module-level require statements:
+		'stdlib/no-empty-lines-between-requires': 'off',
+
+		// Allow requiring the package as a whole even though only a single property is used:
+		'stdlib/no-single-property-require': 'off',
+
+		// Allow use of undeclared variables, as variables may be defined in previous code blocks or be implied:
+		'no-undef': 'off',
+
+		// Allow unused variables, as variables may be illustrative or used in subsequent code blocks:
+		'no-unused-vars': 'off',
+
+		// Allow unpublished packages to be required in example code:
+		'n/no-unpublished-require': 'off'
+	}
+});
+
+
+// EXPORTS //
+
+module.exports = config;

--- a/etc/eslint/eslint.flat.config.markdown.js
+++ b/etc/eslint/eslint.flat.config.markdown.js
@@ -20,7 +20,15 @@
 
 // MODULES //
 
+var assign = require( './../../lib/node_modules/@stdlib/object/assign' );
 var defaults = require( './../../eslint.flat.config.js' );
+
+
+// VARIABLES //
+
+var config;
+var entry;
+var i;
 
 
 // MAIN //
@@ -28,13 +36,29 @@ var defaults = require( './../../eslint.flat.config.js' );
 /**
 * ESLint flat configuration for linting Markdown code blocks.
 */
-var config = [];
+config = [
+	// Allow linting code blocks belonging to files residing under `node_modules` directories (e.g., package files residing under `lib/node_modules`), which ESLint unconditionally ignores by default:
+	{
+		'ignores': [ '!**/node_modules/' ]
+	}
+];
 
-// Include the default configuration:
-config = config.concat( defaults );
+// Include the default configuration, ensuring that Markdown files are matched, as code blocks are linted using the path of the containing Markdown file:
+for ( i = 0; i < defaults.length; i++ ) {
+	entry = defaults[ i ];
+	if ( entry.files && entry.files.indexOf( '**/*.js' ) !== -1 ) {
+		entry = assign( {}, entry );
+		entry.files = entry.files.concat( [ '**/*.md' ] );
+	}
+	config.push( entry );
+}
 
 // Append configuration specific to Markdown code blocks:
 config.push({
+	'linterOptions': {
+		// Do not flag unused disable directives, as the remark plugin unconditionally injects a `stdlib/require-order` disable directive when prepending the main `require` statement to subsequent code blocks:
+		'reportUnusedDisableDirectives': 'off'
+	},
 	'rules': {
 		// Allow variables to be declared as needed:
 		'vars-on-top': 'off',

--- a/etc/remark/plugins/eslint/index.js
+++ b/etc/remark/plugins/eslint/index.js
@@ -33,8 +33,7 @@ var opts = {
 	'config': config,
 	'rules': {
 		'stdlib/doctest': 'error' // enable otherwise disabled lint rule
-	},
-	'ignore': false
+	}
 };
 
 

--- a/etc/remark/plugins/eslint/index.js
+++ b/etc/remark/plugins/eslint/index.js
@@ -27,15 +27,14 @@ var join = require( 'path' ).join;
 // VARIABLES //
 
 var etc = resolve( __dirname, '..', '..', '..' );
-var config = join( etc, 'eslint', '.eslintrc.markdown.js' );
+var config = join( etc, 'eslint', 'eslint.flat.config.markdown.js' );
 var eslint = resolve( etc, '..', 'lib', 'node_modules', '@stdlib', '_tools', 'remark', 'plugins', 'remark-lint-eslint' );
 var opts = {
 	'config': config,
 	'rules': {
 		'stdlib/doctest': 'error' // enable otherwise disabled lint rule
 	},
-	'ignore': false,
-	'useEslintrc': false
+	'ignore': false
 };
 
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/doctest/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/doctest/lib/main.js
@@ -25,6 +25,7 @@ var proc = require( 'process' );
 var join = require( 'path' ).join;
 var format = require( 'util' ).format;
 var dirname = require( 'path' ).dirname;
+var extname = require( 'path' ).extname;
 var logger = require( 'debug' );
 var rootDir = require( '@stdlib/_tools/utils/root-dir' );
 var Buffer = require( '@stdlib/buffer/ctor' );
@@ -162,6 +163,15 @@ function main( context ) {
 		'clearInterval': clearInterval,
 		'window': windowShim,
 		'Buffer': Buffer,
+
+		// Share the host realm's error constructors, as required modules are loaded in the host realm, meaning that, without sharing, `instanceof` checks on host-created errors would always fail within the sandbox:
+		'Error': Error,
+		'EvalError': EvalError,
+		'RangeError': RangeError,
+		'ReferenceError': ReferenceError,
+		'SyntaxError': SyntaxError,
+		'TypeError': TypeError,
+		'URIError': URIError,
 		'__dirname': dir,
 		'__filename': filename,
 		'console': {
@@ -327,7 +337,7 @@ function main( context ) {
 			};
 
 			// Do not report errors in `Markdown` fenced code blocks due to modules failing to load as implementations may not be available yet (readme-driven development):
-			if ( filename === '<text>' && contains( err.message, 'Cannot find module' ) ) {
+			if ( ( filename === '<text>' || extname( filename ) === '.md' ) && contains( err.message, 'Cannot find module' ) ) {
 				return;
 			}
 			report( loc, 'Encountered an error while running code: '+err.message );

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/doctest/lib/scope_defaults.json
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/doctest/lib/scope_defaults.json
@@ -9,6 +9,13 @@
   "clearInterval",
   "window",
   "Buffer",
+  "Error",
+  "EvalError",
+  "RangeError",
+  "ReferenceError",
+  "SyntaxError",
+  "TypeError",
+  "URIError",
   "__dirname",
   "__filename",
   "console"

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/require-file-extensions/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/require-file-extensions/lib/main.js
@@ -27,6 +27,7 @@ var hasOwnProp = require( '@stdlib/assert/has-own-property' );
 var isString = require( '@stdlib/assert/is-string' );
 var contains = require( '@stdlib/assert/contains' );
 var dirname = require( '@stdlib/utils/dirname' );
+var extname = require( '@stdlib/utils/extname' );
 var DELIMITER = require( '@stdlib/constants/path/delimiter' );
 var ENV = require( '@stdlib/process/env' );
 
@@ -139,7 +140,7 @@ function main( context ) {
 						return;
 					}
 					// Ignore error for internal requires in fenced code blocks of Markdown files as the package's implementation may not yet be available...
-					if ( filename === '<text>' && startsWith( requirePath, '@stdlib' ) ) {
+					if ( ( filename === '<text>' || extname( filename ) === '.md' ) && startsWith( requirePath, '@stdlib' ) ) {
 						return;
 					}
 					return report( node, 'cannot resolve module: "'+requirePath+'"' );

--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-eslint/README.md
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-eslint/README.md
@@ -196,9 +196,11 @@ var vfile = linter( '```javascript\nvar beep = \'boop\';\n```' );
 
 ## Examples
 
-<!-- eslint-disable no-sync -->
+<!-- Skip linting and running this code block, as executing it (via the `stdlib/doctest` rule or the example runner) would run the linter within the linter and deadlock. -->
 
-<!-- eslint no-undef: "error" -->
+<!-- run-disable -->
+
+<!-- eslint-skip -->
 
 ```javascript
 var join = require( 'path' ).join;

--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-eslint/README.md
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-eslint/README.md
@@ -60,7 +60,7 @@ var vfile = linter( '```javascript\nvar beep = \'boop\';\n```' );
 
 The function recognizes the following `options`:
 
--   **config**: path to an [ESLint][eslint] configuration file. A configuration path is resolved relative to the current working directory of the calling process.
+-   **config**: path to an [ESLint][eslint] "flat" configuration file. A configuration path is resolved relative to the current working directory of the calling process.
 
 To specify configuration `options`, set the respective properties.
 
@@ -71,7 +71,7 @@ var remark = require( 'remark' );
 
 // Define options:
 var opts = {
-    'config': '/path/to/.eslintrc'
+    'config': '/path/to/eslint.config.js'
 };
 
 // Create a plugin:
@@ -208,7 +208,7 @@ var readFileSync = require( '@stdlib/fs/read-file' ).sync;
 var factory = require( '@stdlib/_tools/remark/plugins/remark-lint-eslint' ).factory;
 
 // Define path to an ESLint config file:
-var config = resolve( __dirname, '..', '..', '..', '..', '..', '..', '..', 'etc', 'eslint', '.eslintrc.markdown.js' );
+var config = resolve( __dirname, '..', '..', '..', '..', '..', '..', '..', 'etc', 'eslint', 'eslint.flat.config.markdown.js' );
 
 // Load a Markdown file:
 var fpath = join( __dirname, 'examples', 'fixtures', 'file.md' );
@@ -220,10 +220,10 @@ var opts = {
 };
 
 // Create a plugin:
-var plugin = factory( opts );
+var lint = factory( opts );
 
 // Lint code blocks:
-var out = remark().use( plugin ).processSync( file.toString() );
+var out = remark().use( lint ).processSync( file.toString() );
 
 console.log( out );
 ```

--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-eslint/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-eslint/examples/index.js
@@ -25,7 +25,7 @@ var readFileSync = require( '@stdlib/fs/read-file' ).sync;
 var factory = require( './../lib' ).factory;
 
 // Define path to an ESLint config file:
-var config = resolve( __dirname, '..', '..', '..', '..', '..', '..', '..', '..', 'etc', 'eslint', '.eslintrc.markdown.js' );
+var config = resolve( __dirname, '..', '..', '..', '..', '..', '..', '..', '..', 'etc', 'eslint', 'eslint.flat.config.markdown.js' );
 
 // Load a Markdown file:
 var fpath = join( __dirname, 'fixtures', 'file.md' );

--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-eslint/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-eslint/examples/index.js
@@ -16,6 +16,10 @@
 * limitations under the License.
 */
 
+/* eslint stdlib/doctest: "off" */
+
+// Note: executing this example via the `stdlib/doctest` rule would run the linter within the linter and deadlock; hence, the rule is disabled for this file.
+
 'use strict';
 
 var join = require( 'path' ).join;

--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-eslint/lib/factory.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-eslint/lib/factory.js
@@ -33,6 +33,14 @@ var format = require( '@stdlib/string/format' );
 var transformHTML = require( './transform_html.js' );
 
 
+// VARIABLES //
+
+// Resolve an ESLint class supporting "flat" configuration (note: in ESLint v9+, the default `ESLint` class supports "flat" configuration; in ESLint v8, a separate class must be explicitly loaded):
+if ( parseInt( ESLint.version, 10 ) < 9 ) {
+	ESLint = require( 'eslint/use-at-your-own-risk' ).FlatESLint; // eslint-disable-line stdlib/require-file-extensions, stdlib/require-order
+}
+
+
 // MAIN //
 
 /**
@@ -69,9 +77,6 @@ function factory( options ) {
 		}
 		if ( hasOwnProp( options, 'ignore' ) ) {
 			opts.ignore = options.ignore;
-		}
-		if ( hasOwnProp( options, 'useEslintrc' ) ) {
-			opts.useEslintrc = options.useEslintrc;
 		}
 		// TODO: add support for other ESLint options
 	}

--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-eslint/lib/factory.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-eslint/lib/factory.js
@@ -94,6 +94,14 @@ function factory( options ) {
 	*/
 	function lint( tree, file ) {
 		var FIRST;
+		var fpath;
+
+		// Resolve the path of the file being linted, which allows linting code blocks in the context of the containing file (e.g., resolving relative require paths and providing meaningful `__filename` and `__dirname` values when evaluating doctests):
+		if ( file.path ) {
+			fpath = resolve( cwd(), file.path );
+		} else {
+			fpath = null;
+		}
 		visit( tree, 'code', onNode );
 
 		/**
@@ -157,7 +165,13 @@ function factory( options ) {
 				code = comments.join( '\n' );
 
 				// Lint the code block...
-				awaitSync( eslint.lintText( code ).then( onLint ) );
+				if ( fpath ) {
+					awaitSync( eslint.lintText( code, {
+						'filePath': fpath
+					}).then( onLint ) );
+				} else {
+					awaitSync( eslint.lintText( code ).then( onLint ) );
+				}
 			}
 
 			/**


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1223.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates Markdown code-block linting to ESLint "flat" configuration, unblocking the ESLint v9 upgrade (#10972). Works on both v8 (via `FlatESLint`) and v9 (default `ESLint` class); the removed `useEslintrc` option is no longer used.
-   adds `etc/eslint/eslint.flat.config.markdown.js`, which extends the root flat config with the Markdown rule overrides from `.eslintrc.markdown.js` (the legacy file is left in place until nothing depends on it).
-   lints code blocks in the context of the containing Markdown file (via `lintText()`'s `filePath`), with companion updates so readme-driven development leniency and doctest evaluation continue to work under `.md` file paths.
-   annotates this package's self-referential README/example code (which runs the linter within the linter and deadlocks when executed by the `stdlib/doctest` rule or the example runner) so it is neither executed nor doctested; both remain runnable standalone.

Verified byte-identical lint output between the legacy and new configurations on fixtures with deliberate errors (including doctests and inline `<!-- eslint ... -->` comments), and that errors in READMEs under `lib/node_modules` are still detected (flat-config ESLint ignores `node_modules` by default; an unignore pattern in the config handles this). Implementation notes and pitfalls (e.g., `ignore: false` disabling unignore patterns) are documented in the config and commit messages.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   https://github.com/stdlib-js/metr-issue-tracker/issues/1223

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

#10972 has been rebased on top of this PR and should land after it.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, including root-cause investigation, implementation, and verification, under human direction and review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
