### PR TITLE
feat!: add `start` and `end` parameter support to `blas/ext/base/ndarray/cfill-equal`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/README.md
@@ -55,8 +55,16 @@ var alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
     'dtype': 'complex64'
 });
 
-cfillEqual( [ x, searchElement, alpha ] );
-// x => <ndarray>[ <Complex64>[ 5.0, 5.0 ], <Complex64>[ -2.0, 3.0 ], <Complex64>[ 5.0, 5.0 ], <Complex64>[ 4.0, -6.0 ] ]
+var start = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var end = scalar2ndarray( 2, {
+    'dtype': 'generic'
+});
+
+cfillEqual( [ x, searchElement, alpha, start, end ] );
+// x => <ndarray>[ <Complex64>[ 5.0, 5.0 ], <Complex64>[ -2.0, 3.0 ], <Complex64>[ 0.0, 0.0 ], <Complex64>[ 4.0, -6.0 ] ]
 ```
 
 The function has the following parameters:
@@ -66,6 +74,8 @@ The function has the following parameters:
     -   a one-dimensional input ndarray.
     -   a zero-dimensional ndarray containing the search element.
     -   a zero-dimensional ndarray containing the scalar constant.
+    -   a zero-dimensional ndarray containing the starting index (inclusive).
+    -   a zero-dimensional ndarray containing the ending index (exclusive).
 
 </section>
 
@@ -76,6 +86,7 @@ The function has the following parameters:
 ## Notes
 
 -   The input ndarray is modified **in-place** (i.e., the input ndarray is **mutated**).
+-   If a specified `start` or `end` index is negative, the function resolves the respective index by counting backward from the last element (where `-1` refers to the last element).
 -   When comparing elements, the function checks for equality of real and imaginary components using the strict equality operator `===`. As a consequence, `NaN` components are considered distinct (i.e., as `NaN === NaN` always evaluates to `false`, elements having one or more `NaN` components are never replaced), and `-0` and `+0` are considered the same.
 
 </section>
@@ -114,7 +125,17 @@ var alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
 });
 console.log( 'Alpha:', ndarraylike2scalar( alpha ) );
 
-cfillEqual( [ x, searchElement, alpha ] );
+var start = scalar2ndarray( 5, {
+    'dtype': 'generic'
+});
+console.log( 'Start Index:', ndarraylike2scalar( start ) );
+
+var end = scalar2ndarray( 15, {
+    'dtype': 'generic'
+});
+console.log( 'End Index:', ndarraylike2scalar( end ) );
+
+cfillEqual( [ x, searchElement, alpha, start, end ] );
 console.log( ndarray2array( x ) );
 ```
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/benchmark/benchmark.js
@@ -50,7 +50,9 @@ var options = {
 function createBenchmark( len ) {
 	var searchElement;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 	var i;
 
@@ -76,6 +78,12 @@ function createBenchmark( len ) {
 			'dtype': 'complex64'
 		})
 	];
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( len, {
+		'dtype': 'generic'
+	});
 	return benchmark;
 
 	/**
@@ -90,7 +98,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			out = cfillEqual( [ x, searchElement[ i%2 ], alpha[ i%2 ] ] );
+			out = cfillEqual( [ x, searchElement[ i%2 ], alpha[ i%2 ], start, end ] ); // eslint-disable-line max-len
 			if ( typeof out !== 'object' ) {
 				b.fail( 'should return an ndarray' );
 			}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/docs/repl.txt
@@ -7,6 +7,10 @@
     The input ndarray is modified *in-place* (i.e., the input ndarray is
     *mutated*).
 
+    If a specified `start` or `end` index is negative, the function resolves
+    the respective index by counting backward from the last element (where `-1`
+    refers to the last element).
+
     When comparing elements, the function checks for equality of real and
     imaginary components using the strict equality operator `===`. As a
     consequence, `NaN` components are considered distinct (i.e., as
@@ -22,6 +26,8 @@
         - a one-dimensional input ndarray.
         - a zero-dimensional ndarray containing the search element.
         - a zero-dimensional ndarray containing the scalar constant.
+        - a zero-dimensional ndarray containing the starting index (inclusive).
+        - a zero-dimensional ndarray containing the ending index (exclusive).
 
     Returns
     -------
@@ -35,7 +41,9 @@
     > var v = {{alias:@stdlib/ndarray/from-scalar}}( s, { 'dtype': 'complex64' } );
     > var a = new {{alias:@stdlib/complex/float32/ctor}}( 5.0, 5.0 );
     > var alpha = {{alias:@stdlib/ndarray/from-scalar}}( a, { 'dtype': 'complex64' } );
-    > {{alias}}( [ x, v, alpha ] )
+    > var st = {{alias:@stdlib/ndarray/from-scalar}}( 0, { 'dtype': 'generic' } );
+    > var en = {{alias:@stdlib/ndarray/from-scalar}}( 2, { 'dtype': 'generic' } );
+    > {{alias}}( [ x, v, alpha, st, en ] )
     <ndarray>[ <Complex64>[ 5.0, 5.0 ], <Complex64>[ -2.0, 3.0 ] ]
 
     See Also

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/docs/types/index.d.ts
@@ -33,6 +33,8 @@ import { Complex64 } from '@stdlib/types/complex';
 *     -   a one-dimensional input ndarray.
 *     -   a zero-dimensional ndarray containing the search element.
 *     -   a zero-dimensional ndarray containing the scalar constant.
+*     -   a zero-dimensional ndarray containing the starting index (inclusive).
+*     -   a zero-dimensional ndarray containing the ending index (exclusive).
 *
 * -   When comparing elements, the function checks for equality of real and imaginary components using the strict equality operator `===`. As a consequence, `NaN` components are considered distinct (i.e., as `NaN === NaN` always evaluates to `false`, elements having one or more `NaN` components are never replaced), and `-0` and `+0` are considered the same.
 *
@@ -54,10 +56,18 @@ import { Complex64 } from '@stdlib/types/complex';
 *     'dtype': 'complex64'
 * });
 *
-* var out = cfillEqual( [ x, searchElement, alpha ] );
-* // returns <ndarray>[ <Complex64>[ 5.0, 5.0 ], <Complex64>[ -2.0, 3.0 ], <Complex64>[ 5.0, 5.0 ], <Complex64>[ 4.0, -6.0 ] ]
+* var start = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var end = scalar2ndarray( 2, {
+*     'dtype': 'generic'
+* });
+*
+* var out = cfillEqual( [ x, searchElement, alpha, start, end ] );
+* // returns <ndarray>[ <Complex64>[ 5.0, 5.0 ], <Complex64>[ -2.0, 3.0 ], <Complex64>[ 0.0, 0.0 ], <Complex64>[ 4.0, -6.0 ] ]
 */
-declare function cfillEqual( arrays: [ complex64ndarray, typedndarray<Complex64>, typedndarray<Complex64> ] ): complex64ndarray;
+declare function cfillEqual( arrays: [ complex64ndarray, typedndarray<Complex64>, typedndarray<Complex64>, typedndarray<number>, typedndarray<number> ] ): complex64ndarray;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/docs/types/test.ts
@@ -37,8 +37,14 @@ import cfillEqual = require( './index' );
 	const alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
 		'dtype': 'complex64'
 	});
+	const start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	const end = scalar2ndarray( 10, {
+		'dtype': 'generic'
+	});
 
-	cfillEqual( [ x, searchElement, alpha ] ); // $ExpectType complex64ndarray
+	cfillEqual( [ x, searchElement, alpha, start, end ] ); // $ExpectType complex64ndarray
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
@@ -65,7 +71,13 @@ import cfillEqual = require( './index' );
 	const alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
 		'dtype': 'complex64'
 	});
+	const start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	const end = scalar2ndarray( 10, {
+		'dtype': 'generic'
+	});
 
 	cfillEqual(); // $ExpectError
-	cfillEqual( [ x, searchElement, alpha ], {} ); // $ExpectError
+	cfillEqual( [ x, searchElement, alpha, start, end ], {} ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/examples/index.js
@@ -43,5 +43,15 @@ var alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
 });
 console.log( 'Alpha:', ndarraylike2scalar( alpha ) );
 
-cfillEqual( [ x, searchElement, alpha ] );
+var start = scalar2ndarray( 5, {
+	'dtype': 'generic'
+});
+console.log( 'Start Index:', ndarraylike2scalar( start ) );
+
+var end = scalar2ndarray( 15, {
+	'dtype': 'generic'
+});
+console.log( 'End Index:', ndarraylike2scalar( end ) );
+
+cfillEqual( [ x, searchElement, alpha, start, end ] );
 console.log( ndarray2array( x ) );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/lib/index.js
@@ -39,8 +39,16 @@
 *     'dtype': 'complex64'
 * });
 *
-* var out = cfillEqual( [ x, searchElement, alpha ] );
-* // returns <ndarray>[ <Complex64>[ 5.0, 5.0 ], <Complex64>[ -2.0, 3.0 ], <Complex64>[ 5.0, 5.0 ], <Complex64>[ 4.0, -6.0 ] ]
+* var start = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var end = scalar2ndarray( 2, {
+*     'dtype': 'generic'
+* });
+*
+* var out = cfillEqual( [ x, searchElement, alpha, start, end ] );
+* // returns <ndarray>[ <Complex64>[ 5.0, 5.0 ], <Complex64>[ -2.0, 3.0 ], <Complex64>[ 0.0, 0.0 ], <Complex64>[ 4.0, -6.0 ] ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/lib/main.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
+var clipIndex = require( '@stdlib/ndarray/base/clip-index' );
 var getStride = require( '@stdlib/ndarray/base/stride' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
@@ -40,6 +41,8 @@ var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 *     -   a one-dimensional input ndarray.
 *     -   a zero-dimensional ndarray containing the search element.
 *     -   a zero-dimensional ndarray containing the scalar constant.
+*     -   a zero-dimensional ndarray containing the starting index (inclusive).
+*     -   a zero-dimensional ndarray containing the ending index (exclusive).
 *
 * -   When comparing elements, the function checks for equality of real and imaginary components using the strict equality operator `===`. As a consequence, `NaN` components are considered distinct (i.e., as `NaN === NaN` always evaluates to `false`, elements having one or more `NaN` components are never replaced), and `-0` and `+0` are considered the same.
 *
@@ -61,18 +64,41 @@ var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 *     'dtype': 'complex64'
 * });
 *
-* var out = cfillEqual( [ x, searchElement, alpha ] );
-* // returns <ndarray>[ <Complex64>[ 5.0, 5.0 ], <Complex64>[ -2.0, 3.0 ], <Complex64>[ 5.0, 5.0 ], <Complex64>[ 4.0, -6.0 ] ]
+* var start = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var end = scalar2ndarray( 2, {
+*     'dtype': 'generic'
+* });
+*
+* var out = cfillEqual( [ x, searchElement, alpha, start, end ] );
+* // returns <ndarray>[ <Complex64>[ 5.0, 5.0 ], <Complex64>[ -2.0, 3.0 ], <Complex64>[ 0.0, 0.0 ], <Complex64>[ 4.0, -6.0 ] ]
 */
 function cfillEqual( arrays ) {
 	var searchElement;
+	var stride;
+	var offset;
 	var alpha;
+	var start;
+	var end;
+	var N;
 	var x;
 
 	x = arrays[ 0 ];
 	searchElement = ndarraylike2scalar( arrays[ 1 ] );
 	alpha = ndarraylike2scalar( arrays[ 2 ] );
-	strided( numelDimension( x, 0 ), searchElement, alpha, getData( x ), getStride( x, 0 ), getOffset( x ) ); // eslint-disable-line max-len
+
+	N = numelDimension( x, 0 );
+	start = clipIndex( ndarraylike2scalar( arrays[ 3 ] ), N );
+	end = clipIndex( ndarraylike2scalar( arrays[ 4 ] ), N );
+	if ( start >= end ) {
+		return x;
+	}
+	stride = getStride( x, 0 );
+	offset = getOffset( x ) + ( stride*start );
+
+	strided( end-start, searchElement, alpha, getData( x ), stride, offset );
 	return x;
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/lib/main.js
@@ -26,7 +26,13 @@ var getStride = require( '@stdlib/ndarray/base/stride' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
 var strided = require( '@stdlib/blas/ext/base/cfill-equal' ).ndarray;
+var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
+var clipIndex = require( '@stdlib/ndarray/base/clip-index' );
+var getStride = require( '@stdlib/ndarray/base/stride' );
+var getOffset = require( '@stdlib/ndarray/base/offset' );
+var getData = require( '@stdlib/ndarray/base/data-buffer' );
 var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
+var strided = require( '@stdlib/blas/ext/base/cfill-equal' ).ndarray;
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/lib/main.js
@@ -25,6 +25,7 @@ var clipIndex = require( '@stdlib/ndarray/base/clip-index' );
 var getStride = require( '@stdlib/ndarray/base/stride' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
+var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 var strided = require( '@stdlib/blas/ext/base/cfill-equal' ).ndarray;
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/lib/main.js
@@ -26,13 +26,6 @@ var getStride = require( '@stdlib/ndarray/base/stride' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
 var strided = require( '@stdlib/blas/ext/base/cfill-equal' ).ndarray;
-var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
-var clipIndex = require( '@stdlib/ndarray/base/clip-index' );
-var getStride = require( '@stdlib/ndarray/base/stride' );
-var getOffset = require( '@stdlib/ndarray/base/offset' );
-var getData = require( '@stdlib/ndarray/base/data-buffer' );
-var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
-var strided = require( '@stdlib/blas/ext/base/cfill-equal' ).ndarray;
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill-equal/test/test.js
@@ -60,7 +60,9 @@ tape( 'the function replaces elements equal to a provided search element', funct
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Complex64Array( [ 0.0, 0.0, -2.0, 3.0, 0.0, 0.0, 4.0, -6.0 ] );
@@ -71,8 +73,14 @@ tape( 'the function replaces elements equal to a provided search element', funct
 	alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
 		'dtype': 'complex64'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
 
-	actual = cfillEqual( [ x, searchElement, alpha ] );
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Complex64Array( [ 5.0, 5.0, -2.0, 3.0, 5.0, 5.0, 4.0, -6.0 ] );
@@ -86,7 +94,9 @@ tape( 'the function supports an input ndarray having a non-unit stride', functio
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 3.0, 4.0, 0.0, 0.0 ] );
@@ -97,8 +107,14 @@ tape( 'the function supports an input ndarray having a non-unit stride', functio
 	alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
 		'dtype': 'complex64'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
 
-	actual = cfillEqual( [ x, searchElement, alpha ] );
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Complex64Array( [ 5.0, 5.0, 0.0, 0.0, 3.0, 4.0, 0.0, 0.0 ] );
@@ -112,7 +128,9 @@ tape( 'the function supports an input ndarray having a negative stride', functio
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 3.0, 4.0, 0.0, 0.0 ] );
@@ -123,8 +141,14 @@ tape( 'the function supports an input ndarray having a negative stride', functio
 	alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
 		'dtype': 'complex64'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
 
-	actual = cfillEqual( [ x, searchElement, alpha ] );
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Complex64Array( [ 5.0, 5.0, 0.0, 0.0, 3.0, 4.0, 0.0, 0.0 ] );
@@ -138,7 +162,9 @@ tape( 'the function supports an input ndarray having a non-zero offset', functio
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Complex64Array( [ 0.0, 0.0, -2.0, 3.0, 0.0, 0.0, 4.0, -6.0 ] );
@@ -149,8 +175,281 @@ tape( 'the function supports an input ndarray having a non-zero offset', functio
 	alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
 		'dtype': 'complex64'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
 
-	actual = cfillEqual( [ x, searchElement, alpha ] );
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Complex64Array( [ 0.0, 0.0, -2.0, 3.0, 5.0, 5.0, 4.0, -6.0 ] );
+	t.strictEqual( isSameComplex64Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a nonnegative starting index', function test( t ) {
+	var searchElement;
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	x = vector( xbuf, 4, 1, 0 );
+	searchElement = scalar2ndarray( new Complex64( 0.0, 0.0 ), {
+		'dtype': 'complex64'
+	});
+	alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
+		'dtype': 'complex64'
+	});
+	start = scalar2ndarray( 1, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
+
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Complex64Array( [ 0.0, 0.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0 ] );
+	t.strictEqual( isSameComplex64Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative starting index', function test( t ) {
+	var searchElement;
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	x = vector( xbuf, 4, 1, 0 );
+	searchElement = scalar2ndarray( new Complex64( 0.0, 0.0 ), {
+		'dtype': 'complex64'
+	});
+	alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
+		'dtype': 'complex64'
+	});
+	start = scalar2ndarray( -3, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
+
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Complex64Array( [ 0.0, 0.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0 ] );
+	t.strictEqual( isSameComplex64Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a nonnegative ending index', function test( t ) {
+	var searchElement;
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	x = vector( xbuf, 4, 1, 0 );
+	searchElement = scalar2ndarray( new Complex64( 0.0, 0.0 ), {
+		'dtype': 'complex64'
+	});
+	alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
+		'dtype': 'complex64'
+	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
+
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Complex64Array( [ 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 0.0, 0.0 ] );
+	t.strictEqual( isSameComplex64Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative ending index', function test( t ) {
+	var searchElement;
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	x = vector( xbuf, 4, 1, 0 );
+	searchElement = scalar2ndarray( new Complex64( 0.0, 0.0 ), {
+		'dtype': 'complex64'
+	});
+	alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
+		'dtype': 'complex64'
+	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( -1, {
+		'dtype': 'generic'
+	});
+
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Complex64Array( [ 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 0.0, 0.0 ] );
+	t.strictEqual( isSameComplex64Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function clamps out-of-bounds starting and ending indices', function test( t ) {
+	var searchElement;
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	x = vector( xbuf, 4, 1, 0 );
+	searchElement = scalar2ndarray( new Complex64( 0.0, 0.0 ), {
+		'dtype': 'complex64'
+	});
+	alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
+		'dtype': 'complex64'
+	});
+	start = scalar2ndarray( -10, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 10, {
+		'dtype': 'generic'
+	});
+
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Complex64Array( [ 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0 ] );
+	t.strictEqual( isSameComplex64Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if a resolved starting index is greater than or equal to a resolved ending index, the function returns the input ndarray unchanged', function test( t ) {
+	var searchElement;
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	x = vector( xbuf, 4, 1, 0 );
+	searchElement = scalar2ndarray( new Complex64( 0.0, 0.0 ), {
+		'dtype': 'complex64'
+	});
+	alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
+		'dtype': 'complex64'
+	});
+	expected = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+
+	start = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( isSameComplex64Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	start = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 1, {
+		'dtype': 'generic'
+	});
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( isSameComplex64Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	start = scalar2ndarray( 5, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( isSameComplex64Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( -10, {
+		'dtype': 'generic'
+	});
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( isSameComplex64Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying a fill range for an input ndarray having a non-unit stride', function test( t ) {
+	var searchElement;
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Complex64Array( [ 0.0, 0.0, -2.0, 3.0, 0.0, 0.0, 4.0, -6.0 ] );
+	x = vector( xbuf, 2, 2, 0 );
+	searchElement = scalar2ndarray( new Complex64( 0.0, 0.0 ), {
+		'dtype': 'complex64'
+	});
+	alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
+		'dtype': 'complex64'
+	});
+	start = scalar2ndarray( 1, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
+
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Complex64Array( [ 0.0, 0.0, -2.0, 3.0, 5.0, 5.0, 4.0, -6.0 ] );
@@ -164,7 +463,9 @@ tape( 'if all elements are not equal to a provided search element, the function 
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
@@ -175,8 +476,14 @@ tape( 'if all elements are not equal to a provided search element, the function 
 	alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
 		'dtype': 'complex64'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
 
-	actual = cfillEqual( [ x, searchElement, alpha ] );
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
@@ -190,7 +497,9 @@ tape( 'if provided a search element having `NaN` components, the function return
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Complex64Array( [ NaN, NaN, 1.0, 1.0, NaN, NaN ] );
@@ -201,8 +510,14 @@ tape( 'if provided a search element having `NaN` components, the function return
 	alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
 		'dtype': 'complex64'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
-	actual = cfillEqual( [ x, searchElement, alpha ] );
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Complex64Array( [ NaN, NaN, 1.0, 1.0, NaN, NaN ] );
@@ -216,7 +531,9 @@ tape( 'the function does not replace elements having `NaN` components', function
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Complex64Array( [ NaN, 0.0, 0.0, 0.0, 0.0, NaN ] );
@@ -227,8 +544,14 @@ tape( 'the function does not replace elements having `NaN` components', function
 	alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
 		'dtype': 'complex64'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
-	actual = cfillEqual( [ x, searchElement, alpha ] );
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Complex64Array( [ NaN, 0.0, 5.0, 5.0, 0.0, NaN ] );
@@ -242,7 +565,9 @@ tape( 'the function considers `-0` and `+0` to be the same value', function test
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Complex64Array( [ -0.0, -0.0, 1.0, 1.0, 0.0, -0.0, -0.0, 0.0 ] );
@@ -253,8 +578,14 @@ tape( 'the function considers `-0` and `+0` to be the same value', function test
 	alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
 		'dtype': 'complex64'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
 
-	actual = cfillEqual( [ x, searchElement, alpha ] );
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Complex64Array( [ 5.0, 5.0, 1.0, 1.0, 5.0, 5.0, 5.0, 5.0 ] );
@@ -266,7 +597,7 @@ tape( 'the function considers `-0` and `+0` to be the same value', function test
 		'dtype': 'complex64'
 	});
 
-	actual = cfillEqual( [ x, searchElement, alpha ] );
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Complex64Array( [ 5.0, 5.0, 1.0, 1.0, 5.0, 5.0, 5.0, 5.0 ] );
@@ -280,7 +611,9 @@ tape( 'the function returns the input ndarray unchanged when the input ndarray i
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Complex64Array( [] );
@@ -291,8 +624,14 @@ tape( 'the function returns the input ndarray unchanged when the input ndarray i
 	alpha = scalar2ndarray( new Complex64( 5.0, 5.0 ), {
 		'dtype': 'complex64'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = cfillEqual( [ x, searchElement, alpha ] );
+	actual = cfillEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Complex64Array( [] );


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1246.

## Description

> What is the purpose of this pull request?

This pull request:

-   add `start` and `end` parameter support to `blas/ext/base/ndarray/cfill-equal`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1246.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Primarily written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
