### PR TITLE
test: migrate `math/base/special/kernel-cos` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/kernel-cos/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-cos/test/test.native.js
@@ -103,7 +103,6 @@ tape( 'the function can be used to compute the cosine for input values outside o
 		case 2:
 			out = -kernelCos( y[ 0 ], y[ 1 ] );
 
-
 			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
 			t.strictEqual( isAlmostSameValue( out, expected[ i ], 1 ), true, 'returns expected value' );
 			break;
@@ -136,7 +135,6 @@ tape( 'the function can be used to compute the cosine for input values outside o
 			break;
 		case 2:
 			out = -kernelCos( y[ 0 ], y[ 1 ] );
-
 
 			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
 			t.strictEqual( isAlmostSameValue( out, expected[ i ], 1 ), true, 'returns expected value' );

--- a/lib/node_modules/@stdlib/math/base/special/kernel-cos/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-cos/test/test.native.js
@@ -102,7 +102,8 @@ tape( 'the function can be used to compute the cosine for input values outside o
 			break;
 		case 2:
 			out = -kernelCos( y[ 0 ], y[ 1 ] );
-			
+
+
 			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
 			t.strictEqual( isAlmostSameValue( out, expected[ i ], 1 ), true, 'returns expected value' );
 			break;
@@ -135,7 +136,8 @@ tape( 'the function can be used to compute the cosine for input values outside o
 			break;
 		case 2:
 			out = -kernelCos( y[ 0 ], y[ 1 ] );
-			
+
+
 			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
 			t.strictEqual( isAlmostSameValue( out, expected[ i ], 1 ), true, 'returns expected value' );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/kernel-cos/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-cos/test/test.native.js
@@ -23,8 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var rempio2 = require( '@stdlib/math/base/special/rempio2' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -84,8 +83,6 @@ tape( 'the function evaluates the cosine for input values on the interval `[-pi/
 tape( 'the function can be used to compute the cosine for input values outside of `[-pi/4, pi/4]` after argument reduction via `rempio2` (positive)', opts, function test( t ) {
 	var expected;
 	var values;
-	var delta;
-	var tol;
 	var out;
 	var x;
 	var y;
@@ -105,15 +102,9 @@ tape( 'the function can be used to compute the cosine for input values outside o
 			break;
 		case 2:
 			out = -kernelCos( y[ 0 ], y[ 1 ] );
-			if ( out === expected[ i ] ) {
-				t.strictEqual( out, expected[ i ], 'returns expected value' );
-			} else {
-				delta = abs( out - expected[ i ] );
-
-				// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-				tol = EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x+'. out: '+out+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-			}
+			
+			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+			t.strictEqual( isAlmostSameValue( out, expected[ i ], 1 ), true, 'returns expected value' );
 			break;
 		default:
 			break;
@@ -125,8 +116,6 @@ tape( 'the function can be used to compute the cosine for input values outside o
 tape( 'the function can be used to compute the cosine for input values outside of `[-pi/4, pi/4]` after argument reduction via `rempio2` (negative)', opts, function test( t ) {
 	var expected;
 	var values;
-	var delta;
-	var tol;
 	var out;
 	var x;
 	var y;
@@ -146,15 +135,9 @@ tape( 'the function can be used to compute the cosine for input values outside o
 			break;
 		case 2:
 			out = -kernelCos( y[ 0 ], y[ 1 ] );
-			if ( out === expected[ i ] ) {
-				t.strictEqual( out, expected[ i ], 'returns expected value' );
-			} else {
-				delta = abs( out - expected[ i ] );
-
-				// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-				tol = EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x+'. out: '+out+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-			}
+			
+			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+			t.strictEqual( isAlmostSameValue( out, expected[ i ], 1 ), true, 'returns expected value' );
 			break;
 		default:
 			break;


### PR DESCRIPTION
Resolves a part of  #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates test/test.native.js of math/base/special/kernel-cos from relative tolerance (EPS-based) assertions to ULP difference assertions via @stdlib/assert/is-almost-same-value.
- replaces the delta/tol tolerance branch with t.strictEqual( isAlmostSameValue( out, expected[ i ], 1 ), true, 'returns expected value' ).
- removes the now-unused abs and EPS requires and the corresponding delta/tol variable declarations.
- retains the existing tolerance distinction between the JavaScript and native implementations, as the native implementation can produce divergent results due to compiler optimizations.

The final ULP value for the native implementation is 1.
## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
