### PR TITLE
test: migrate `stats/base/dists/laplace/logpdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/logpdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/logpdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -141,8 +140,6 @@ tape( 'if provided a nonpositive `b`, the created function always returns `NaN`'
 tape( 'the created function evaluates the logpdf for `x` given positive `mu`', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var i;
@@ -157,13 +154,7 @@ tape( 'the created function evaluates the logpdf for `x` given positive `mu`', f
 		logpdf = factory( mu[i], b[i] );
 		y = logpdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -172,8 +163,6 @@ tape( 'the created function evaluates the logpdf for `x` given positive `mu`', f
 tape( 'the created function evaluates the logpdf for `x` given negative `mu`', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var i;
@@ -188,13 +177,7 @@ tape( 'the created function evaluates the logpdf for `x` given negative `mu`', f
 		logpdf = factory( mu[i], b[i] );
 		y = logpdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -203,8 +186,6 @@ tape( 'the created function evaluates the logpdf for `x` given negative `mu`', f
 tape( 'the created function evaluates the logpdf for `x` given large variance (large `b`)', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var i;
@@ -219,13 +200,7 @@ tape( 'the created function evaluates the logpdf for `x` given large variance (l
 		logpdf = factory( mu[i], b[i] );
 		y = logpdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/logpdf/test/test.logpdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/logpdf/test/test.logpdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logpdf = require( './../lib' );
 
 
@@ -98,8 +97,6 @@ tape( 'if provided a nonpositive `b`, the function returns `NaN`', function test
 
 tape( 'the function evaluates the logpdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var b;
@@ -113,13 +110,7 @@ tape( 'the function evaluates the logpdf for `x` given positive `mu`', function 
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -127,8 +118,6 @@ tape( 'the function evaluates the logpdf for `x` given positive `mu`', function 
 
 tape( 'the function evaluates the logpdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var b;
@@ -142,13 +131,7 @@ tape( 'the function evaluates the logpdf for `x` given negative `mu`', function 
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -156,8 +139,6 @@ tape( 'the function evaluates the logpdf for `x` given negative `mu`', function 
 
 tape( 'the function evaluates the logpdf for `x` given large variance (large `b` )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var b;
@@ -171,13 +152,7 @@ tape( 'the function evaluates the logpdf for `x` given large variance (large `b`
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/logpdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/logpdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -107,8 +106,6 @@ tape( 'if provided a nonpositive `b`, the function returns `NaN`', opts, functio
 
 tape( 'the function evaluates the logpdf for `x` given positive `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var b;
@@ -122,13 +119,7 @@ tape( 'the function evaluates the logpdf for `x` given positive `mu`', opts, fun
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -136,8 +127,6 @@ tape( 'the function evaluates the logpdf for `x` given positive `mu`', opts, fun
 
 tape( 'the function evaluates the logpdf for `x` given negative `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var b;
@@ -151,13 +140,7 @@ tape( 'the function evaluates the logpdf for `x` given negative `mu`', opts, fun
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -165,8 +148,6 @@ tape( 'the function evaluates the logpdf for `x` given negative `mu`', opts, fun
 
 tape( 'the function evaluates the logpdf for `x` given large variance (large `b` )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var b;
@@ -180,13 +161,7 @@ tape( 'the function evaluates the logpdf for `x` given large variance (large `b`
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.logpdf.js`, `test/test.factory.js`, and `test/test.native.js` of `stats/base/dists/laplace/logpdf` from relative tolerance (`EPS`-based) assertions to ULP difference assertions via `@stdlib/assert/is-almost-same-value`.
-   replaces the `delta`/`tol` tolerance branch (previously `tol = 1.0 * EPS * abs( expected[ i ] )`) with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' )`, retaining the existing `expected[ i ] !== null` guard.
-   removes the now-unused `abs` and `EPS` requires and the corresponding `delta`/`tol` variable declarations.

**Final ULP constant: `0`**, for all three test suites (main, factory, and native).

The bound was tightened empirically. Starting from a high value and searching downward via a per-case minimum-ULP computation over the full fixture set (`positive_mean.json`, `negative_mean.json`, and `large_variance.json`; 3000 fixture cases in total), the measured maximum ULP difference is `0` — every fixture value is reproduced bit-for-bit — so `0` is the minimum value at which the suites pass.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   The native add-on was built locally (`make install-node-addons NODE_ADDONS_PATTERN="stats/base/dists/laplace/logpdf"`) so that `test/test.native.js` actually executed rather than being skipped; the native implementation also matches the fixtures exactly (max ULP difference `0`).
-   The package test suite was run twice at the final ULP value to confirm determinism: 3015/3015 assertions passing in `test.logpdf.js`, 3018/3018 in `test.factory.js`, and 3015/3015 in `test.native.js` on both runs.
-   `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/laplace/logpdf/.*"` is clean.
-   No files other than the three test files were changed.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This pull request was authored by an automated Claude Code agent running as a scheduled task, following the conventions established in previously merged ULP migration pull requests for this issue.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAE53LahjWYTege9U8NEuE)_