### PR TITLE
feat: add C implementation for `stats/base/dists/betaprime/cdf`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/README.md
@@ -154,6 +154,106 @@ logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, F(x;α,β): %0.4f', x, alpha, beta,
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text.  Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/stats/base/dists/betaprime/cdf.h"
+```
+
+#### stdlib_base_dists_betaprime_cdf( x, alpha, beta )
+
+Evaluates the [cumulative distribution function][cdf] (CDF) for a [beta prime][betaprime-distribution] distribution with parameters `alpha` (first shape parameter) and `beta` (second shape parameter).
+
+```c
+double y = stdlib_base_dists_betaprime_cdf( 0.5, 1.0, 1.0 );
+// returns ~0.333
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] double` input value.
+-   **alpha**: `[in] double` first shape parameter.
+-   **beta**: `[in] double` second shape parameter.
+
+```c
+double stdlib_base_dists_betaprime_cdf( const double x, const double alpha, const double beta );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section`
+element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/stats/base/dists/betaprime/cdf.h"
+#include "stdlib/constants/float64/eps.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_uniform( const double min, const double max ) {
+    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+    return min + ( v*(max-min) );
+}
+
+int main( void ) {
+    double alpha;
+    double beta;
+    double x;
+    double y;
+    int i;
+
+    for ( i = 0; i < 10; i++ ) {
+        x = random_uniform( 0.0, 1.0 );
+        alpha = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 5.0 );
+        beta = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 5.0 );
+        y = stdlib_base_dists_betaprime_cdf( x, alpha, beta );
+        printf( "x: %lf, α: %lf, β: %lf, F(x;α,β): %lf\n", x, alpha, beta, y );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/benchmark/benchmark.native.js
@@ -1,0 +1,71 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var cdf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( cdf instanceof Error )
+};
+
+
+// MAIN //
+
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
+	var alpha;
+	var beta;
+	var opts;
+	var x;
+	var y;
+	var i;
+
+	opts = {
+		'dtype': 'float64'
+	};
+	alpha = uniform( 100, EPS, 100.0, opts );
+	beta = uniform( 100, EPS, 100.0, opts );
+	x = uniform( 100, EPS, 2.0, opts );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = cdf( x[ i % x.length ], alpha[ i % alpha.length ], beta[ i % beta.length ] );
+		if ( isnan( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/benchmark/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/benchmark/c/benchmark.c
@@ -1,0 +1,143 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/betaprime/cdf.h"
+#include "stdlib/constants/float64/eps.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "betaprime-cdf"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [min,max).
+*
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
+*/
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*(max-min) );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	double alpha[ 100 ];
+	double beta[ 100 ];
+	double x[ 100 ];
+	double y;
+	double t;
+	int i;
+
+	for ( i = 0; i < 100; i++ ) {
+		alpha[ i ] = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 100.0 );
+		beta[ i ] = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 100.0 );
+		x[ i ] = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 2.0 );
+	}
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		y = stdlib_base_dists_betaprime_cdf( x[ i % 100 ], alpha[ i % 100 ], beta[ i % 100 ] );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/examples/c/example.c
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/betaprime/cdf.h"
+#include "stdlib/constants/float64/eps.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*(max-min) );
+}
+
+int main( void ) {
+	double alpha;
+	double beta;
+	double x;
+	double y;
+	int i;
+
+	for ( i = 0; i < 10; i++ ) {
+		x = random_uniform( 0.0, 1.0 );
+		alpha = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 5.0 );
+		beta = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 5.0 );
+		y = stdlib_base_dists_betaprime_cdf( x, alpha, beta );
+		printf( "x: %lf, α: %lf, β: %lf, F(x;α,β): %lf\n", x, alpha, beta, y );
+	}
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/include/stdlib/stats/base/dists/betaprime/cdf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/include/stdlib/stats/base/dists/betaprime/cdf.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_STATS_BASE_DISTS_BETAPRIME_CDF_H
+#define STDLIB_STATS_BASE_DISTS_BETAPRIME_CDF_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a ternary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Evaluates the cumulative distribution function (CDF) for a beta prime distribution with first shape parameter `alpha` and second shape parameter `beta`.
+*/
+double stdlib_base_dists_betaprime_cdf( const double x, const double alpha, const double beta );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_STATS_BASE_DISTS_BETAPRIME_CDF_H

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/lib/native.js
@@ -1,0 +1,84 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Evaluates the cumulative distribution function (CDF) for a beta prime distribution with first shape parameter `alpha` and second shape parameter `beta` at a value `x`.
+*
+* @private
+* @param {number} x - input value
+* @param {PositiveNumber} alpha - first shape parameter
+* @param {PositiveNumber} beta - second shape parameter
+* @returns {Probability} evaluated CDF
+*
+* @example
+* var y = cdf( 0.5, 1.0, 1.0 );
+* // returns ~0.333
+*
+* @example
+* var y = cdf( 0.5, 2.0, 4.0 );
+* // returns ~0.539
+*
+* @example
+* var y = cdf( 0.2, 2.0, 2.0 );
+* // returns ~0.074
+*
+* @example
+* var y = cdf( 0.8, 4.0, 4.0 );
+* // returns ~0.38
+*
+* @example
+* var y = cdf( -0.5, 4.0, 2.0 );
+* // returns 0.0
+*
+* @example
+* var y = cdf( 2.0, -1.0, 0.5 );
+* // returns NaN
+*
+* @example
+* var y = cdf( 2.0, 0.5, -1.0 );
+* // returns NaN
+*
+* @example
+* var y = cdf( NaN, 1.0, 1.0 );
+* // returns NaN
+*
+* @example
+* var y = cdf( 0.0, NaN, 1.0 );
+* // returns NaN
+*
+* @example
+* var y = cdf( 0.0, 1.0, NaN );
+* // returns NaN
+*/
+function cdf( x, alpha, beta ) {
+	return addon( x, alpha, beta );
+}
+
+
+// EXPORTS //
+
+module.exports = cdf;

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/manifest.json
@@ -1,0 +1,84 @@
+{
+  "options": {
+    "task": "build",
+    "wasm": false
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/ternary",
+        "@stdlib/stats/base/dists/beta/cdf",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/pinf"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/stats/base/dists/beta/cdf",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/eps"
+      ]
+    },
+    {
+      "task": "examples",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/stats/base/dists/beta/cdf",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/eps"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/package.json
@@ -14,11 +14,14 @@
     }
   ],
   "main": "./lib",
+  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
+    "include": "./include",
     "lib": "./lib",
+    "src": "./src",
     "test": "./test"
   },
   "types": "./docs/types",

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/src/addon.c
@@ -1,0 +1,22 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/betaprime/cdf.h"
+#include "stdlib/math/base/napi/ternary.h"
+
+STDLIB_MATH_BASE_NAPI_MODULE_DDD_D( stdlib_base_dists_betaprime_cdf )

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/src/main.c
@@ -1,0 +1,53 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/betaprime/cdf.h"
+#include "stdlib/stats/base/dists/beta/cdf.h"
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/constants/float64/pinf.h"
+
+/*
+* Evaluates the cumulative distribution function (CDF) for a beta prime distribution with first shape parameter `alpha` and second shape parameter `beta`.
+*
+* @param x        input value
+* @param alpha    first shape parameter
+* @param beta     second shape parameter
+* @return         evaluated CDF
+*
+* @example
+* double y = stdlib_base_dists_betaprime_cdf( 0.5, 1.0, 1.0 );
+* // returns ~0.333
+*/
+double stdlib_base_dists_betaprime_cdf( const double x, const double alpha, const double beta ) {
+	if (
+		stdlib_base_is_nan( x ) ||
+		stdlib_base_is_nan( alpha ) ||
+		stdlib_base_is_nan( beta ) ||
+		alpha <= 0.0 ||
+		beta <= 0.0
+	) {
+		return 0.0 / 0.0; // NaN
+	}
+	if ( x <= 0.0 ) {
+		return 0.0;
+	}
+	if ( x == STDLIB_CONSTANT_FLOAT64_PINF ) {
+		return 1.0;
+	}
+	return stdlib_base_dists_beta_cdf( x / ( 1.0 + x ), alpha, beta );
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/test/test.native.js
@@ -1,0 +1,196 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+
+
+// VARIABLES //
+
+var cdf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( cdf instanceof Error )
+};
+
+
+// FIXTURES //
+
+var largeAlpha = require( './fixtures/julia/large_alpha.json' );
+var largeBeta = require( './fixtures/julia/large_beta.json' );
+var bothLarge = require( './fixtures/julia/both_large.json' );
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof cdf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'if provided `NaN` for any parameter, the function returns `NaN`', opts, function test( t ) {
+	var y = cdf( NaN, 1.0, 1.0 );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+	y = cdf( 0.0, NaN, 1.0 );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+	y = cdf( 0.0, 1.0, NaN );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided a number less than or equal to zero for `x` and a finite `alpha` and `beta`, the function returns `0`', opts, function test( t ) {
+	var y = cdf( NINF, 0.5, 1.0 );
+	t.strictEqual( y, 0.0, 'returns expected value' );
+
+	y = cdf( -100.0, 0.5, 1.0 );
+	t.strictEqual( y, 0.0, 'returns expected value' );
+
+	y = cdf( -1.0, 0.5, 1.0 );
+	t.strictEqual( y, 0.0, 'returns expected value' );
+
+	y = cdf( 0.0, 0.5, 1.0 );
+	t.strictEqual( y, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided `+Infinity` for `x` and a finite `alpha` and `beta`, the function returns `1`', opts, function test( t ) {
+	var y = cdf( PINF, 0.5, 1.0 );
+	t.strictEqual( y, 1.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided a nonpositive `alpha`, the function returns `NaN`', opts, function test( t ) {
+	var y;
+
+	y = cdf( 2.0, 0.0, 2.0 );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+
+	y = cdf( 2.0, -1.0, 2.0 );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+
+	y = cdf( 0.0, -1.0, 2.0 );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+
+	y = cdf( 2.0, NINF, 1.0 );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+
+	y = cdf( 2.0, NINF, PINF );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+
+	y = cdf( 2.0, NINF, NINF );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+
+	y = cdf( 2.0, NINF, NaN );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided a nonpositive `beta`, the function returns `NaN`', opts, function test( t ) {
+	var y;
+
+	y = cdf( 2.0, 2.0, 0.0 );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+
+	y = cdf( 2.0, 2.0, -1.0 );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+
+	y = cdf( 0.0, 2.0, NINF );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+
+	y = cdf( 2.0, 1.0, NINF );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+
+	y = cdf( 2.0, PINF, NINF );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+
+	y = cdf( 2.0, NINF, NINF );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+
+	y = cdf( 2.0, NaN, NINF );
+	t.strictEqual( isnan( y ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function evaluates the cdf for `x` given large `alpha` and `beta`', opts, function test( t ) {
+	var expected;
+	var alpha;
+	var beta;
+	var i;
+	var x;
+	var y;
+
+	expected = bothLarge.expected;
+	x = bothLarge.x;
+	alpha = bothLarge.alpha;
+	beta = bothLarge.beta;
+	for ( i = 0; i < x.length; i++ ) {
+		y = cdf( x[i], alpha[i], beta[i] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 256 ), true, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function evaluates the cdf for `x` given large `alpha`', opts, function test( t ) {
+	var expected;
+	var alpha;
+	var beta;
+	var i;
+	var x;
+	var y;
+
+	expected = largeAlpha.expected;
+	x = largeAlpha.x;
+	alpha = largeAlpha.alpha;
+	beta = largeAlpha.beta;
+	for ( i = 0; i < x.length; i++ ) {
+		y = cdf( x[i], alpha[i], beta[i] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 128 ), true, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function evaluates the cdf for `x` given large `beta`', opts, function test( t ) {
+	var expected;
+	var alpha;
+	var beta;
+	var i;
+	var x;
+	var y;
+
+	expected = largeBeta.expected;
+	x = largeBeta.x;
+	alpha = largeBeta.alpha;
+	beta = largeBeta.beta;
+	for ( i = 0; i < x.length; i++ ) {
+		y = cdf( x[i], alpha[i], beta[i] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 64 ), true, 'returns expected value' );
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves #3437.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds a C implementation and Node-API native addon for `@stdlib/stats/base/dists/betaprime/cdf`, including C headers, GYP/Makefile build configurations, JavaScript/C benchmarks and examples, native unit tests, and README documentation updates. The implementation applies the transformation `x/(1+x)` before delegating to `@stdlib/stats/base/dists/beta/cdf`, mirroring the JavaScript implementation.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #3355
-   https://github.com/stdlib-js/metr-issue-tracker/issues/1225

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, using the existing `stats/base/dists/betaprime/pdf` C implementation as a template; the changes were reviewed and validated (native addon built, all native tests passing) before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

