### PR TITLE
test: migrate `math/base/special/atandf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/atandf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/atandf/test/test.js
@@ -22,8 +22,7 @@
 
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var absf = require( '@stdlib/math/base/special/absf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var atandf = require( './../lib' );
 
@@ -50,8 +49,6 @@ tape( 'the function returns `NaN` if provided `NaN`', function test( t ) {
 
 tape( 'the function computes the arctangent in degrees (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -63,21 +60,13 @@ tape( 'the function computes the arctangent in degrees (negative values)', funct
 	for ( i = 0; i < x.length; i++ ) {
 		y = atandf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = absf( y - e );
-			tol = EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent in degrees (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -89,13 +78,7 @@ tape( 'the function computes the arctangent in degrees (positive values)', funct
 	for ( i = 0; i < x.length; i++ ) {
 		y = atandf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = absf( y - e );
-			tol = EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/atandf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/atandf/test/test.native.js
@@ -23,8 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var absf = require( '@stdlib/math/base/special/absf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -59,8 +58,6 @@ tape( 'the function returns `NaN` if provided `NaN`', opts, function test( t ) {
 
 tape( 'the function computes the arctangent in degrees (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -72,21 +69,13 @@ tape( 'the function computes the arctangent in degrees (negative values)', opts,
 	for ( i = 0; i < x.length; i++ ) {
 		y = atandf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = absf( y - e );
-			tol = EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent in degrees (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -98,13 +87,7 @@ tape( 'the function computes the arctangent in degrees (positive values)', opts,
 	for ( i = 0; i < x.length; i++ ) {
 		y = atandf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = absf( y - e );
-			tol = EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for `math/base/special/atandf` from relative tolerance testing (`delta <= EPS * absf( expected )`) to ULP difference testing via `@stdlib/number/float32/base/assert/is-almost-same-value`.
-   updates both `test/test.js` and `test/test.native.js`, removing the `absf` and `@stdlib/constants/float32/eps` imports along with the `delta`/`tol` bookkeeping, and replacing the `t.ok( delta <= tol, ... )` assertions with `t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );`.

The ULP bound was tightened to the measured minimum:

| File | Fixture set | ULP |
| ---- | ----------- | --- |
| `test/test.js` | `julia/negative.json` (2003 values) | `1` |
| `test/test.js` | `julia/positive.json` (2003 values) | `1` |
| `test/test.native.js` | `julia/negative.json` (2003 values) | `1` |
| `test/test.native.js` | `julia/positive.json` (2003 values) | `1` |

`1` is the minimum: at `0` ULP, 970 of the 2003 values in each fixture set fail (for both the JavaScript and the C implementation), and at `1` ULP none fail.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the two test files are modified; no source, fixtures, or documentation were touched.
-   `make test TESTS_FILTER=".*/math/base/special/atandf/.*"` passes: 4009/4009 assertions for `test/test.js` and 4009/4009 for `test/test.native.js`. The native add-on was built locally (`make install-node-addons NODE_ADDONS_PATTERN="atandf"`) so that `test/test.native.js` was actually exercised rather than skipped, and the suite was run twice at the final ULP value to confirm determinism.
-   ESLint is clean against `etc/eslint/.eslintrc.tests.js`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, following the migration pattern established in previously merged conversions (e.g., `math/base/special/logitf`), with the ULP bound measured empirically against the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01PjcKKsBf83rPdZ62AbLwxx)_