### PR TITLE
fix: add support for wrapped line syntax highlighting and terminal resizing in the `REPL` output stream

### DIFF
--- a/lib/node_modules/@stdlib/repl/lib/output_stream.js
+++ b/lib/node_modules/@stdlib/repl/lib/output_stream.js
@@ -128,24 +128,6 @@ function OutputStream( repl, autoPage ) {
 inherit( OutputStream, Transform );
 
 /**
-* Defines an accessor for retrieving the number of columns.
-*
-* ## Notes
-*
-* -   A readline interface resolves the terminal width from its output stream in order to determine when a line wraps. As this stream sits between a readline interface and the underlying output stream, we must forward the viewport width; otherwise, a readline interface assumes an infinitely wide terminal and fails to account for wrapped lines when rendering.
-* -   We resolve `undefined` when a viewport width is unavailable (e.g., when not a TTY), as a readline interface only falls back to assuming an infinitely wide terminal for falsy values.
-*
-* @private
-* @name columns
-* @memberof OutputStream.prototype
-* @type {(integer|void)}
-*/
-setNonEnumerableReadOnlyAccessor( OutputStream.prototype, 'columns', function columns() {
-	var w = this._repl.viewportWidth();
-	return ( w > 0 ) ? w : void 0;
-});
-
-/**
 * Implements the `_transform` method.
 *
 * @private
@@ -489,6 +471,23 @@ setNonEnumerableReadOnly( OutputStream.prototype, 'enablePaging', function enabl
 */
 setNonEnumerableReadOnlyAccessor( OutputStream.prototype, 'isPaging', function isPaging() {
 	return this._isPaging;
+});
+
+/**
+* Number of columns (i.e., the viewport width).
+*
+* ## Notes
+*
+* -   A readline interface resolves the terminal width from its output stream in order to determine when a line wraps. As this stream sits between a readline interface and the underlying output stream, we must forward the viewport width; otherwise, a readline interface assumes an infinitely wide terminal and fails to account for wrapped lines when rendering.
+* -   We resolve `undefined` when a viewport width is unavailable (e.g., when not a TTY), as a readline interface only falls back to assuming an infinitely wide terminal for falsy values.
+*
+* @name columns
+* @memberof OutputStream.prototype
+* @type {(integer|void)}
+*/
+setNonEnumerableReadOnlyAccessor( OutputStream.prototype, 'columns', function columns() {
+	var w = this._repl.viewportWidth();
+	return ( w > 0 ) ? w : void 0;
 });
 
 /**

--- a/lib/node_modules/@stdlib/repl/lib/output_stream.js
+++ b/lib/node_modules/@stdlib/repl/lib/output_stream.js
@@ -128,6 +128,24 @@ function OutputStream( repl, autoPage ) {
 inherit( OutputStream, Transform );
 
 /**
+* Defines an accessor for retrieving the number of columns.
+*
+* ## Notes
+*
+* -   A readline interface resolves the terminal width from its output stream in order to determine when a line wraps. As this stream sits between a readline interface and the underlying output stream, we must forward the viewport width; otherwise, a readline interface assumes an infinitely wide terminal and fails to account for wrapped lines when rendering.
+* -   We resolve `undefined` when a viewport width is unavailable (e.g., when not a TTY), as a readline interface only falls back to assuming an infinitely wide terminal for falsy values.
+*
+* @private
+* @name columns
+* @memberof OutputStream.prototype
+* @type {(integer|void)}
+*/
+setNonEnumerableReadOnlyAccessor( OutputStream.prototype, 'columns', function columns() {
+	var w = this._repl.viewportWidth();
+	return ( w > 0 ) ? w : void 0;
+});
+
+/**
 * Implements the `_transform` method.
 *
 * @private
@@ -510,6 +528,8 @@ setNonEnumerableReadOnly( OutputStream.prototype, 'beforeKeypress', function bef
 */
 setNonEnumerableReadOnly( OutputStream.prototype, 'onResize', function onResize() {
 	if ( !this._isPaging ) {
+		// Notify the readline interface in order to allow it to re-render (possibly wrapped) input according to the new viewport width:
+		this.emit( 'resize' );
 		return;
 	}
 	if ( !this._isScrollable( this._indices.length ) ) {

--- a/lib/node_modules/@stdlib/repl/lib/syntax_highlighter.js
+++ b/lib/node_modules/@stdlib/repl/lib/syntax_highlighter.js
@@ -75,6 +75,39 @@ function removeDuplicateTokens( tokens ) {
 	return out;
 }
 
+/**
+* Resolves the display position of a character offset within a (possibly wrapped) input line.
+*
+* ## Notes
+*
+* -   The returned row and column offsets are relative to the beginning of the input line (i.e., relative to the first character of the prompt).
+* -   This mirrors the arithmetic performed by a readline interface when resolving cursor positions, thus ensuring that we remain in agreement with a readline interface when rendering.
+* -   If a viewport width is unknown (e.g., when the output stream is not a TTY), a line is assumed to never wrap.
+*
+* @private
+* @param {NonNegativeInteger} offset - character offset
+* @param {integer} columns - viewport width
+* @returns {Object} display position
+*
+* @example
+* var pos = displayPosition( 45, 40 );
+* // returns { 'cols': 5, 'rows': 1 }
+*/
+function displayPosition( offset, columns ) {
+	var cols;
+	if ( columns <= 0 ) {
+		return {
+			'cols': offset,
+			'rows': 0
+		};
+	}
+	cols = offset % columns;
+	return {
+		'cols': cols,
+		'rows': ( offset-cols ) / columns
+	};
+}
+
 
 // MAIN //
 
@@ -313,6 +346,10 @@ setNonEnumerableReadOnly( SyntaxHighlighter.prototype, 'enable', function enable
 * @returns {void}
 */
 setNonEnumerableReadOnly( SyntaxHighlighter.prototype, 'onKeypress', function onKeypress() {
+	var cursorPos;
+	var promptLen;
+	var columns;
+	var endPos;
 	var tokens;
 
 	if ( !this._enabled ) {
@@ -345,10 +382,33 @@ setNonEnumerableReadOnly( SyntaxHighlighter.prototype, 'onKeypress', function on
 	}
 	// Replace:
 	debug( 'Replacing current line with the highlighted line...' );
-	readline.moveCursor( this._ostream, -1 * this._rli.cursor, 0 );
-	readline.clearLine( this._ostream, 1 );
+
+	// Resolve the viewport width (note: the width is negative when the output stream is not a TTY):
+	columns = this._repl.viewportWidth();
+	promptLen = this._repl.promptLength();
+
+	// Resolve the display positions of the cursor and of the end of the input line in order to support lines which wrap across multiple rows:
+	cursorPos = displayPosition( promptLen+this._rli.cursor, columns );
+	endPos = displayPosition( promptLen+this._line.length, columns );
+
+	// Move the cursor to the row on which the prompt is displayed and to the column immediately following the prompt:
+	readline.moveCursor( this._ostream, 0, -cursorPos.rows );
+	readline.cursorTo( this._ostream, promptLen );
+
+	// Rewrite the line:
 	this._ostream.write( this._highlightedLine );
-	readline.moveCursor( this._ostream, this._rli.cursor - this._line.length, 0 ); // eslint-disable-line max-len
+
+	// If the line ends exactly at the end of a row, force the terminal to allocate the next row:
+	if ( endPos.cols === 0 && endPos.rows > 0 ) {
+		this._ostream.write( ' ' );
+	}
+
+	// Move the cursor back to its original position:
+	readline.cursorTo( this._ostream, cursorPos.cols );
+	if ( cursorPos.rows < endPos.rows ) {
+		readline.moveCursor( this._ostream, 0, cursorPos.rows-endPos.rows );
+	}
+
 	this._multilineHandler.updateLine( this._highlightedLine ); // save displayed line
 });
 

--- a/lib/node_modules/@stdlib/repl/test/integration/test.syntax_highlighting.js
+++ b/lib/node_modules/@stdlib/repl/test/integration/test.syntax_highlighting.js
@@ -128,7 +128,8 @@ function assert( t, fixture, done ) {
 			t.fail( error.message );
 			return;
 		}
-		actual = data[ data.length - 1 ];
+		// NOTE: after rewriting the highlighted line, the syntax highlighter repositions the cursor (to support wrapped lines), so the highlighted line is the penultimate chunk, followed by a trailing cursor-repositioning escape sequence...
+		actual = data[ data.length - 2 ];
 		t.strictEqual( actual, expected, 'returns expected value' );
 		done();
 	}


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown_pkg_readmes status: na
  - task: lint_markdown_docs status: na
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves #14646

## Description

> What is the purpose of this pull request?

This pull request:

-   add support for wrapped line syntax highlighting and terminal resizing in the `REPL` output stream

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
