### PR TITLE
feat!: add `start` and `end` parameter support to `blas/ext/base/ndarray/gfill-nan`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/README.md
@@ -50,8 +50,16 @@ var alpha = scalar2ndarray( 0.0, {
     'dtype': 'generic'
 });
 
-gfillNaN( [ x, alpha ] );
-// x => <ndarray>[ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ]
+var start = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var end = scalar2ndarray( 2, {
+    'dtype': 'generic'
+});
+
+gfillNaN( [ x, alpha, start, end ] );
+// x => <ndarray>[ 0.0, -2.0, 3.0, NaN, 4.0, -6.0 ]
 ```
 
 The function has the following parameters:
@@ -60,6 +68,8 @@ The function has the following parameters:
 
     -   a one-dimensional input ndarray.
     -   a zero-dimensional ndarray containing the scalar constant.
+    -   a zero-dimensional ndarray containing the starting index (inclusive).
+    -   a zero-dimensional ndarray containing the ending index (exclusive).
 
 </section>
 
@@ -70,6 +80,7 @@ The function has the following parameters:
 ## Notes
 
 -   The input ndarray is modified **in-place** (i.e., the input ndarray is **mutated**).
+-   If a specified `start` or `end` index is negative, the function resolves the respective index by counting backward from the last element (where `-1` refers to the last element).
 
 </section>
 
@@ -92,13 +103,19 @@ var opts = {
     'dtype': 'generic'
 };
 
-var x = nans( [ 10 ], opts );
+var x = nans( [ 20 ], opts );
 console.log( ndarray2array( x ) );
 
 var alpha = scalar2ndarray( 5, opts );
 console.log( 'Alpha: %d', ndarraylike2scalar( alpha ) );
 
-gfillNaN( [ x, alpha ] );
+var start = scalar2ndarray( 5, opts );
+console.log( 'Start Index: %d', ndarraylike2scalar( start ) );
+
+var end = scalar2ndarray( 15, opts );
+console.log( 'End Index: %d', ndarraylike2scalar( end ) );
+
+gfillNaN( [ x, alpha, start, end ] );
 console.log( ndarray2array( x ) );
 ```
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/benchmark/benchmark.js
@@ -63,10 +63,14 @@ function clbk( value, indices ) {
 */
 function createBenchmark( len ) {
 	var alpha;
+	var start;
+	var end;
 	var x;
 
 	x = fillBy( zeros( [ len ], options ), clbk );
 	alpha = scalar2ndarray( 0.0, options );
+	start = scalar2ndarray( 0, options );
+	end = scalar2ndarray( len, options );
 	return benchmark;
 
 	/**
@@ -81,7 +85,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			out = gfillNaN( [ x, alpha ] );
+			out = gfillNaN( [ x, alpha, start, end ] );
 			if ( typeof out !== 'object' ) {
 				b.fail( 'should return an ndarray' );
 			}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/docs/repl.txt
@@ -6,6 +6,10 @@
     The input ndarray is modified *in-place* (i.e., the input ndarray is
     *mutated*).
 
+    If a specified `start` or `end` index is negative, the function resolves
+    the respective index by counting backward from the last element (where `-1`
+    refers to the last element).
+
     Parameters
     ----------
     arrays: ArrayLikeObject<ndarray>
@@ -13,6 +17,8 @@
 
         - a one-dimensional input ndarray.
         - a zero-dimensional ndarray containing the scalar constant.
+        - a zero-dimensional ndarray containing the starting index (inclusive).
+        - a zero-dimensional ndarray containing the ending index (exclusive).
 
     Returns
     -------
@@ -25,8 +31,10 @@
     > var x = {{alias:@stdlib/ndarray/vector/ctor}}( buf, 'generic' );
     > var opts = { 'dtype': 'generic' };
     > var alpha = {{alias:@stdlib/ndarray/from-scalar}}( 0.0, opts );
-    > {{alias}}( [ x, alpha ] )
-    <ndarray>[ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ]
+    > var st = {{alias:@stdlib/ndarray/from-scalar}}( 0, opts );
+    > var en = {{alias:@stdlib/ndarray/from-scalar}}( 2, opts );
+    > {{alias}}( [ x, alpha, st, en ] )
+    <ndarray>[ 0.0, -2.0, 3.0, NaN, 4.0, -6.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/docs/types/index.d.ts
@@ -31,6 +31,8 @@ import { typedndarray } from '@stdlib/types/ndarray';
 *
 *     -   a one-dimensional input ndarray.
 *     -   a zero-dimensional ndarray containing the scalar constant.
+*     -   a zero-dimensional ndarray containing the starting index (inclusive).
+*     -   a zero-dimensional ndarray containing the ending index (exclusive).
 *
 * @param arrays - array-like object containing ndarrays
 * @returns input ndarray
@@ -45,10 +47,18 @@ import { typedndarray } from '@stdlib/types/ndarray';
 *     'dtype': 'generic'
 * });
 *
-* var out = gfillNaN( [ x, alpha ] );
-* // returns <ndarray>[ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ]
+* var start = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var end = scalar2ndarray( 2, {
+*     'dtype': 'generic'
+* });
+*
+* var out = gfillNaN( [ x, alpha, start, end ] );
+* // returns <ndarray>[ 0.0, -2.0, 3.0, NaN, 4.0, -6.0 ]
 */
-declare function gfillNaN<T = unknown, U = unknown, V extends typedndarray<T | U> = typedndarray<T | U>>( arrays: [ V, typedndarray<U> ] ): V;
+declare function gfillNaN<T = unknown, U = unknown, V extends typedndarray<T | U> = typedndarray<T | U>>( arrays: [ V, typedndarray<U>, typedndarray<number>, typedndarray<number> ] ): V;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/docs/types/test.ts
@@ -33,8 +33,14 @@ import gfillNaN = require( './index' );
 	const alpha = scalar2ndarray( 0.0, {
 		'dtype': 'generic'
 	});
+	const start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	const end = scalar2ndarray( 10, {
+		'dtype': 'generic'
+	});
 
-	gfillNaN( [ x, alpha ] ); // $ExpectType genericndarray<number>
+	gfillNaN( [ x, alpha, start, end ] ); // $ExpectType genericndarray<number>
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
@@ -58,7 +64,13 @@ import gfillNaN = require( './index' );
 	const alpha = scalar2ndarray( 0.0, {
 		'dtype': 'generic'
 	});
+	const start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	const end = scalar2ndarray( 10, {
+		'dtype': 'generic'
+	});
 
 	gfillNaN(); // $ExpectError
-	gfillNaN( [ x, alpha ], {} ); // $ExpectError
+	gfillNaN( [ x, alpha, start, end ], {} ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/examples/index.js
@@ -28,11 +28,17 @@ var opts = {
 	'dtype': 'generic'
 };
 
-var x = nans( [ 10 ], opts );
+var x = nans( [ 20 ], opts );
 console.log( ndarray2array( x ) );
 
 var alpha = scalar2ndarray( 5, opts );
 console.log( 'Alpha: %d', ndarraylike2scalar( alpha ) );
 
-gfillNaN( [ x, alpha ] );
+var start = scalar2ndarray( 5, opts );
+console.log( 'Start Index: %d', ndarraylike2scalar( start ) );
+
+var end = scalar2ndarray( 15, opts );
+console.log( 'End Index: %d', ndarraylike2scalar( end ) );
+
+gfillNaN( [ x, alpha, start, end ] );
 console.log( ndarray2array( x ) );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/lib/index.js
@@ -34,8 +34,16 @@
 *     'dtype': 'generic'
 * });
 *
-* var out = gfillNaN( [ x, alpha ] );
-* // returns <ndarray>[ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ]
+* var start = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var end = scalar2ndarray( 2, {
+*     'dtype': 'generic'
+* });
+*
+* var out = gfillNaN( [ x, alpha, start, end ] );
+* // returns <ndarray>[ 0.0, -2.0, 3.0, NaN, 4.0, -6.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/lib/main.js
@@ -21,11 +21,12 @@
 // MODULES //
 
 var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
+var clipIndex = require( '@stdlib/ndarray/base/clip-index' );
 var getStride = require( '@stdlib/ndarray/base/stride' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
-var strided = require( '@stdlib/blas/ext/base/gfill-nan' ).ndarray;
 var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
+var strided = require( '@stdlib/blas/ext/base/gfill-nan' ).ndarray;
 
 
 // MAIN //
@@ -39,6 +40,8 @@ var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 *
 *     -   a one-dimensional input ndarray.
 *     -   a zero-dimensional ndarray containing the scalar constant.
+*     -   a zero-dimensional ndarray containing the starting index (inclusive).
+*     -   a zero-dimensional ndarray containing the ending index (exclusive).
 *
 * @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
 * @returns {ndarray} input ndarray
@@ -53,16 +56,39 @@ var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 *     'dtype': 'generic'
 * });
 *
-* var out = gfillNaN( [ x, alpha ] );
-* // returns <ndarray>[ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ]
+* var start = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var end = scalar2ndarray( 2, {
+*     'dtype': 'generic'
+* });
+*
+* var out = gfillNaN( [ x, alpha, start, end ] );
+* // returns <ndarray>[ 0.0, -2.0, 3.0, NaN, 4.0, -6.0 ]
 */
 function gfillNaN( arrays ) {
+	var stride;
+	var offset;
 	var alpha;
+	var start;
+	var end;
+	var N;
 	var x;
 
 	x = arrays[ 0 ];
 	alpha = ndarraylike2scalar( arrays[ 1 ] );
-	strided( numelDimension( x, 0 ), alpha, getData( x ), getStride( x, 0 ), getOffset( x ) ); // eslint-disable-line max-len
+
+	N = numelDimension( x, 0 );
+	start = clipIndex( ndarraylike2scalar( arrays[ 2 ] ), N );
+	end = clipIndex( ndarraylike2scalar( arrays[ 3 ] ), N );
+	if ( start >= end ) {
+		return x;
+	}
+	stride = getStride( x, 0 );
+	offset = getOffset( x ) + ( stride*start );
+
+	strided( end-start, alpha, getData( x ), stride, offset );
 	return x;
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-nan/test/test.js
@@ -56,7 +56,9 @@ tape( 'the function replaces elements equal to `NaN`', function test( t ) {
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = [ NaN, -2.0, 3.0, NaN, 4.0, -6.0 ];
@@ -64,8 +66,14 @@ tape( 'the function replaces elements equal to `NaN`', function test( t ) {
 	alpha = scalar2ndarray( 0.0, {
 		'dtype': 'generic'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 6, {
+		'dtype': 'generic'
+	});
 
-	actual = gfillNaN( [ x, alpha ] );
+	actual = gfillNaN( [ x, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = [ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ];
@@ -78,7 +86,9 @@ tape( 'the function supports an input ndarray having a non-unit stride', functio
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = [ NaN, -2.0, 3.0, NaN, 4.0, -6.0 ];
@@ -86,8 +96,14 @@ tape( 'the function supports an input ndarray having a non-unit stride', functio
 	alpha = scalar2ndarray( 0.0, {
 		'dtype': 'generic'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
-	actual = gfillNaN( [ x, alpha ] );
+	actual = gfillNaN( [ x, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = [ 0.0, -2.0, 3.0, NaN, 4.0, -6.0 ];
@@ -100,7 +116,9 @@ tape( 'the function supports an input ndarray having a negative stride', functio
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = [ NaN, -2.0, 3.0, NaN, 4.0, -6.0 ];
@@ -108,8 +126,14 @@ tape( 'the function supports an input ndarray having a negative stride', functio
 	alpha = scalar2ndarray( 0.0, {
 		'dtype': 'generic'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
-	actual = gfillNaN( [ x, alpha ] );
+	actual = gfillNaN( [ x, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = [ 0.0, -2.0, 3.0, NaN, 4.0, -6.0 ];
@@ -122,7 +146,9 @@ tape( 'the function supports an input ndarray having a non-zero offset', functio
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = [ NaN, -2.0, 3.0, NaN, 4.0, -6.0 ];
@@ -130,11 +156,256 @@ tape( 'the function supports an input ndarray having a non-zero offset', functio
 	alpha = scalar2ndarray( 0.0, {
 		'dtype': 'generic'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
-	actual = gfillNaN( [ x, alpha ] );
+	actual = gfillNaN( [ x, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = [ NaN, -2.0, 3.0, 0.0, 4.0, -6.0 ];
+	t.strictEqual( isSameArray( xbuf, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a nonnegative starting index', function test( t ) {
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = [ NaN, NaN, NaN, NaN ];
+	x = vector( xbuf, 4, 1, 0 );
+	alpha = scalar2ndarray( 0.0, {
+		'dtype': 'generic'
+	});
+	start = scalar2ndarray( 1, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
+
+	actual = gfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = [ NaN, 0.0, 0.0, 0.0 ];
+	t.strictEqual( isSameArray( xbuf, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative starting index', function test( t ) {
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = [ NaN, NaN, NaN, NaN ];
+	x = vector( xbuf, 4, 1, 0 );
+	alpha = scalar2ndarray( 0.0, {
+		'dtype': 'generic'
+	});
+	start = scalar2ndarray( -3, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
+
+	actual = gfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = [ NaN, 0.0, 0.0, 0.0 ];
+	t.strictEqual( isSameArray( xbuf, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a nonnegative ending index', function test( t ) {
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = [ NaN, NaN, NaN, NaN ];
+	x = vector( xbuf, 4, 1, 0 );
+	alpha = scalar2ndarray( 0.0, {
+		'dtype': 'generic'
+	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
+
+	actual = gfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = [ 0.0, 0.0, 0.0, NaN ];
+	t.strictEqual( isSameArray( xbuf, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative ending index', function test( t ) {
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = [ NaN, NaN, NaN, NaN ];
+	x = vector( xbuf, 4, 1, 0 );
+	alpha = scalar2ndarray( 0.0, {
+		'dtype': 'generic'
+	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( -1, {
+		'dtype': 'generic'
+	});
+
+	actual = gfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = [ 0.0, 0.0, 0.0, NaN ];
+	t.strictEqual( isSameArray( xbuf, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function clamps out-of-bounds starting and ending indices', function test( t ) {
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = [ NaN, NaN, NaN, NaN ];
+	x = vector( xbuf, 4, 1, 0 );
+	alpha = scalar2ndarray( 0.0, {
+		'dtype': 'generic'
+	});
+	start = scalar2ndarray( -10, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 10, {
+		'dtype': 'generic'
+	});
+
+	actual = gfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = [ 0.0, 0.0, 0.0, 0.0 ];
+	t.deepEqual( xbuf, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if a resolved starting index is greater than or equal to a resolved ending index, the function returns the input ndarray unchanged', function test( t ) {
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = [ NaN, NaN, NaN, NaN ];
+	x = vector( xbuf, 4, 1, 0 );
+	alpha = scalar2ndarray( 0.0, {
+		'dtype': 'generic'
+	});
+	expected = [ NaN, NaN, NaN, NaN ];
+
+	start = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
+	actual = gfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( isSameArray( xbuf, expected ), true, 'returns expected value' );
+
+	start = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 1, {
+		'dtype': 'generic'
+	});
+	actual = gfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( isSameArray( xbuf, expected ), true, 'returns expected value' );
+
+	start = scalar2ndarray( 5, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
+	actual = gfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( isSameArray( xbuf, expected ), true, 'returns expected value' );
+
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( -10, {
+		'dtype': 'generic'
+	});
+	actual = gfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( isSameArray( xbuf, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying a fill range for an input ndarray having a non-unit stride', function test( t ) {
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = [ NaN, -2.0, NaN, 4.0 ];
+	x = vector( xbuf, 2, 2, 0 );
+	alpha = scalar2ndarray( 0.0, {
+		'dtype': 'generic'
+	});
+	start = scalar2ndarray( 1, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
+
+	actual = gfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = [ NaN, -2.0, 0.0, 4.0 ];
 	t.strictEqual( isSameArray( xbuf, expected ), true, 'returns expected value' );
 
 	t.end();
@@ -144,7 +415,9 @@ tape( 'if none of the elements are equal to `NaN`, the function returns the inpu
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = [ 1.0, 2.0, 3.0, 4.0 ];
@@ -152,8 +425,14 @@ tape( 'if none of the elements are equal to `NaN`, the function returns the inpu
 	alpha = scalar2ndarray( 0.0, {
 		'dtype': 'generic'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
 
-	actual = gfillNaN( [ x, alpha ] );
+	actual = gfillNaN( [ x, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = [ 1.0, 2.0, 3.0, 4.0 ];
@@ -166,7 +445,9 @@ tape( 'the function returns the input ndarray unchanged when the input ndarray i
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = [];
@@ -174,8 +455,14 @@ tape( 'the function returns the input ndarray unchanged when the input ndarray i
 	alpha = scalar2ndarray( 0.0, {
 		'dtype': 'generic'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = gfillNaN( [ x, alpha ] );
+	actual = gfillNaN( [ x, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = [];


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1251.

## Description

> What is the purpose of this pull request?

This pull request:

-   add `start` and `end` parameter support to `blas/ext/base/ndarray/gfill-nan`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1251.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Primarily written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
