### PR TITLE
test: migrate `stats/base/dists/exponential/quantile` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/quantile/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/quantile/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -126,8 +125,6 @@ tape( 'the created function evaluates the quantile for `x` given parameter `lamb
 	var expected;
 	var quantile;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -138,13 +135,7 @@ tape( 'the created function evaluates the quantile for `x` given parameter `lamb
 	for ( i = 0; i < x.length; i++ ) {
 		quantile = factory( lambda[i] );
 		y = quantile( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 110.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 172 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/quantile/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/quantile/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -112,8 +111,6 @@ tape( 'if provided a negative `lambda`, the function always returns `NaN`', opts
 tape( 'the function evaluates the quantile for `x` given parameter `lambda`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -123,13 +120,7 @@ tape( 'the function evaluates the quantile for `x` given parameter `lambda`', op
 	lambda = data.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = quantile( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 110.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 172 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/quantile/test/test.quantile.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/quantile/test/test.quantile.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var quantile = require( './../lib' );
 
 
@@ -103,8 +102,6 @@ tape( 'if provided a negative `lambda`, the function always returns `NaN`', func
 tape( 'the function evaluates the quantile for `x` given parameter `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -114,13 +111,7 @@ tape( 'the function evaluates the quantile for `x` given parameter `lambda`', fu
 	lambda = data.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = quantile( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 110.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 172 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/exponential/quantile` from relative-tolerance assertions (`delta <= tol`, with `delta = abs( y - expected[ i ] )` and `tol = 110.0 * EPS * abs( expected[ i ] )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the same migration to all three test files containing tolerance-based fixture loops: `test/test.quantile.js`, `test/test.factory.js`, and `test/test.native.js`. (`test/test.js` contains only smoke tests and is unchanged.)
-   preserves all existing test cases and structure, including the non-tolerance assertions (`NaN` parameters, `p` outside `[0,1]`, `+infinity` for `lambda`, and negative `lambda`) and the `Inf`/`-Inf` fixture normalization.

The ULP bound used is:

| Test file               | Fixture block                          | ULP |
| ----------------------- | -------------------------------------- | :-: |
| `test/test.quantile.js` | `fixtures/r/data.json` (1000 cases)    | 172 |
| `test/test.factory.js`  | `fixtures/r/data.json` (1000 cases)    | 172 |
| `test/test.native.js`   | `fixtures/r/data.json` (1000 cases)    | 172 |

`172` is the measured minimum: starting from `N = 64` and searching upward/tightening, `N = 172` passes over the full fixture set while `N = 171` fails on exactly one fixture entry (`p = 0.001001001001001001`, `lambda = 38.7`, where the returned value `0.000025878613361486335` differs from the R expected value `0.000025878613361486918` by exactly 172 ULP). The suite was run twice at the final `N` to confirm deterministic passing (1013 assertions per file, all passing on both runs, no FMA/arch variation).

Because the native add-on is not built in this environment, `test/test.native.js` is skipped locally and its bound could not be measured by running that file directly. Instead, the C implementation was compiled standalone against its resolved C dependency closure (`math/base/special/ln`, `math/base/assert/is-nan`, `number/float64/base/get-high-word`, `number/float64/base/set-high-word`) and evaluated over all 1000 fixture inputs: its results are bit-for-bit identical to the JavaScript implementation for every input, so the same bound of `172` applies to all three files.

Linting was checked over the changed files and is clean. The only files changed are the three test files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code: the assistant mechanically converted the tolerance-based assertions to `isAlmostSameValue`, agentically searched for the minimum ULP bound, verified that the C implementation matches the JavaScript implementation bit-for-bit over the fixture set, confirmed determinism across two full runs, and ran the local lint and test suites before submitting.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqHfZoyCjBJq9czBC8NaNb)_