### PR TITLE
feat!: add `start` and `end` parameter support to `blas/ext/base/ndarray/sfill-nan`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/README.md
@@ -50,8 +50,16 @@ var alpha = scalar2ndarray( 0.0, {
     'dtype': 'float32'
 });
 
-sfillNaN( [ x, alpha ] );
-// x => <ndarray>[ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ]
+var start = scalar2ndarray( 0, {
+    'dtype': 'float32'
+});
+
+var end = scalar2ndarray( 3, {
+    'dtype': 'float32'
+});
+
+sfillNaN( [ x, alpha, start, end ] );
+// x => <ndarray>[ 0.0, -2.0, 3.0, NaN, 4.0, -6.0 ]
 ```
 
 The function has the following parameters:
@@ -60,6 +68,8 @@ The function has the following parameters:
 
     -   a one-dimensional input ndarray.
     -   a zero-dimensional ndarray containing the scalar constant.
+    -   a zero-dimensional ndarray containing the starting index (inclusive).
+    -   a zero-dimensional ndarray containing the ending index (exclusive).
 
 </section>
 
@@ -70,6 +80,7 @@ The function has the following parameters:
 ## Notes
 
 -   The input ndarray is modified **in-place** (i.e., the input ndarray is **mutated**).
+-   If a specified `start` or `end` index is negative, the function resolves the respective index by counting backward from the last element (where `-1` refers to the last element).
 
 </section>
 
@@ -98,7 +109,13 @@ console.log( ndarray2array( x ) );
 var alpha = scalar2ndarray( 5.0, opts );
 console.log( 'Alpha: %d', ndarraylike2scalar( alpha ) );
 
-sfillNaN( [ x, alpha ] );
+var start = scalar2ndarray( 2, opts );
+console.log( 'Start Index: %d', ndarraylike2scalar( start ) );
+
+var end = scalar2ndarray( 8, opts );
+console.log( 'End Index: %d', ndarraylike2scalar( end ) );
+
+sfillNaN( [ x, alpha, start, end ] );
 console.log( ndarray2array( x ) );
 ```
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/benchmark/benchmark.js
@@ -63,10 +63,14 @@ function clbk( value, indices ) {
 */
 function createBenchmark( len ) {
 	var alpha;
+	var start;
+	var end;
 	var x;
 
 	x = fillBy( zeros( [ len ], options ), clbk );
 	alpha = scalar2ndarray( 0.0, options );
+	start = scalar2ndarray( 0, options );
+	end = scalar2ndarray( len, options );
 	return benchmark;
 
 	/**
@@ -81,7 +85,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			out = sfillNaN( [ x, alpha ] );
+			out = sfillNaN( [ x, alpha, start, end ] );
 			if ( typeof out !== 'object' ) {
 				b.fail( 'should return an ndarray' );
 			}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/docs/repl.txt
@@ -6,6 +6,10 @@
     The input ndarray is modified *in-place* (i.e., the input ndarray is
     *mutated*).
 
+    If a specified `start` or `end` index is negative, the function resolves
+    the respective index by counting backward from the last element (where `-1`
+    refers to the last element).
+
     Parameters
     ----------
     arrays: ArrayLikeObject<ndarray>
@@ -13,6 +17,8 @@
 
         - a one-dimensional input ndarray.
         - a zero-dimensional ndarray containing the scalar constant.
+        - a zero-dimensional ndarray containing the starting index (inclusive).
+        - a zero-dimensional ndarray containing the ending index (exclusive).
 
     Returns
     -------
@@ -22,9 +28,12 @@
     Examples
     --------
     > var x = new {{alias:@stdlib/ndarray/vector/float32}}( [ NaN, -2.0, 3.0, NaN, 4.0, -6.0 ] );
-    > var alpha = {{alias:@stdlib/ndarray/from-scalar}}( 0.0, { 'dtype': 'float32' } );
-    > {{alias}}( [ x, alpha ] )
-    <ndarray>[ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ]
+    > var opts = { 'dtype': 'float32' };
+    > var alpha = {{alias:@stdlib/ndarray/from-scalar}}( 0.0, opts );
+    > var st = {{alias:@stdlib/ndarray/from-scalar}}( 0, opts );
+    > var en = {{alias:@stdlib/ndarray/from-scalar}}( 3, opts );
+    > {{alias}}( [ x, alpha, st, en ] )
+    <ndarray>[ 0.0, -2.0, 3.0, NaN, 4.0, -6.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/docs/types/index.d.ts
@@ -31,6 +31,8 @@ import { float32ndarray, typedndarray } from '@stdlib/types/ndarray';
 *
 *     -   a one-dimensional input ndarray.
 *     -   a zero-dimensional ndarray containing the scalar constant.
+*     -   a zero-dimensional ndarray containing the starting index (inclusive).
+*     -   a zero-dimensional ndarray containing the ending index (exclusive).
 *
 * @param arrays - array-like object containing ndarrays
 * @returns input ndarray
@@ -45,10 +47,18 @@ import { float32ndarray, typedndarray } from '@stdlib/types/ndarray';
 *     'dtype': 'float32'
 * });
 *
-* var out = sfillNaN( [ x, alpha ] );
-* // returns <ndarray>[ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ]
+* var start = scalar2ndarray( 0, {
+*     'dtype': 'float32'
+* });
+*
+* var end = scalar2ndarray( 3, {
+*     'dtype': 'float32'
+* });
+*
+* var out = sfillNaN( [ x, alpha, start, end ] );
+* // returns <ndarray>[ 0.0, -2.0, 3.0, NaN, 4.0, -6.0 ]
 */
-declare function sfillNaN( arrays: [ float32ndarray, typedndarray<number> ] ): float32ndarray;
+declare function sfillNaN( arrays: [ float32ndarray, typedndarray<number>, typedndarray<number>, typedndarray<number> ] ): float32ndarray;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/docs/types/test.ts
@@ -33,8 +33,14 @@ import sfillNaN = require( './index' );
 	const alpha = scalar2ndarray( 0.0, {
 		'dtype': 'float32'
 	});
+	const start = scalar2ndarray( 0, {
+		'dtype': 'float32'
+	});
+	const end = scalar2ndarray( 10, {
+		'dtype': 'float32'
+	});
 
-	sfillNaN( [ x, alpha ] ); // $ExpectType float32ndarray
+	sfillNaN( [ x, alpha, start, end ] ); // $ExpectType float32ndarray
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
@@ -58,7 +64,13 @@ import sfillNaN = require( './index' );
 	const alpha = scalar2ndarray( 0.0, {
 		'dtype': 'float32'
 	});
+	const start = scalar2ndarray( 0, {
+		'dtype': 'float32'
+	});
+	const end = scalar2ndarray( 10, {
+		'dtype': 'float32'
+	});
 
 	sfillNaN(); // $ExpectError
-	sfillNaN( [ x, alpha ], {} ); // $ExpectError
+	sfillNaN( [ x, alpha, start, end ], {} ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/examples/index.js
@@ -34,5 +34,11 @@ console.log( ndarray2array( x ) );
 var alpha = scalar2ndarray( 5.0, opts );
 console.log( 'Alpha: %d', ndarraylike2scalar( alpha ) );
 
-sfillNaN( [ x, alpha ] );
+var start = scalar2ndarray( 2, opts );
+console.log( 'Start Index: %d', ndarraylike2scalar( start ) );
+
+var end = scalar2ndarray( 8, opts );
+console.log( 'End Index: %d', ndarraylike2scalar( end ) );
+
+sfillNaN( [ x, alpha, start, end ] );
 console.log( ndarray2array( x ) );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/lib/index.js
@@ -34,8 +34,16 @@
 *     'dtype': 'float32'
 * });
 *
-* var out = sfillNaN( [ x, alpha ] );
-* // returns <ndarray>[ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ]
+* var start = scalar2ndarray( 0, {
+*     'dtype': 'float32'
+* });
+*
+* var end = scalar2ndarray( 3, {
+*     'dtype': 'float32'
+* });
+*
+* var out = sfillNaN( [ x, alpha, start, end ] );
+* // returns <ndarray>[ 0.0, -2.0, 3.0, NaN, 4.0, -6.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/lib/main.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
+var clipIndex = require( '@stdlib/ndarray/base/clip-index' );
 var getStride = require( '@stdlib/ndarray/base/stride' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
@@ -39,6 +40,8 @@ var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 *
 *     -   a one-dimensional input ndarray.
 *     -   a zero-dimensional ndarray containing the scalar constant.
+*     -   a zero-dimensional ndarray containing the starting index (inclusive).
+*     -   a zero-dimensional ndarray containing the ending index (exclusive).
 *
 * @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
 * @returns {ndarray} input ndarray
@@ -53,16 +56,39 @@ var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 *     'dtype': 'float32'
 * });
 *
-* var out = sfillNaN( [ x, alpha ] );
-* // returns <ndarray>[ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ]
+* var start = scalar2ndarray( 0, {
+*     'dtype': 'float32'
+* });
+*
+* var end = scalar2ndarray( 3, {
+*     'dtype': 'float32'
+* });
+*
+* var out = sfillNaN( [ x, alpha, start, end ] );
+* // returns <ndarray>[ 0.0, -2.0, 3.0, NaN, 4.0, -6.0 ]
 */
 function sfillNaN( arrays ) {
+	var stride;
+	var offset;
 	var alpha;
+	var start;
+	var end;
+	var N;
 	var x;
 
 	x = arrays[ 0 ];
 	alpha = ndarraylike2scalar( arrays[ 1 ] );
-	strided( numelDimension( x, 0 ), alpha, getData( x ), getStride( x, 0 ), getOffset( x ) ); // eslint-disable-line max-len
+
+	N = numelDimension( x, 0 );
+	start = clipIndex( ndarraylike2scalar( arrays[ 2 ] ), N );
+	end = clipIndex( ndarraylike2scalar( arrays[ 3 ] ), N );
+	if ( start >= end ) {
+		return x;
+	}
+	stride = getStride( x, 0 );
+	offset = getOffset( x ) + ( stride*start );
+
+	strided( end-start, alpha, getData( x ), stride, offset );
 	return x;
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-nan/test/test.js
@@ -58,7 +58,9 @@ tape( 'the function replaces elements equal to `NaN`', function test( t ) {
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Float32Array( [ NaN, -2.0, 3.0, NaN, 4.0, -6.0 ] );
@@ -66,8 +68,14 @@ tape( 'the function replaces elements equal to `NaN`', function test( t ) {
 	alpha = scalar2ndarray( 0.0, {
 		'dtype': 'float32'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'float32'
+	});
+	end = scalar2ndarray( 6, {
+		'dtype': 'float32'
+	});
 
-	actual = sfillNaN( [ x, alpha ] );
+	actual = sfillNaN( [ x, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Float32Array( [ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ] );
@@ -80,7 +88,9 @@ tape( 'the function supports an input ndarray having a non-unit stride', functio
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Float32Array( [ NaN, -2.0, 3.0, NaN, 4.0, -6.0 ] );
@@ -88,8 +98,14 @@ tape( 'the function supports an input ndarray having a non-unit stride', functio
 	alpha = scalar2ndarray( 0.0, {
 		'dtype': 'float32'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'float32'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'float32'
+	});
 
-	actual = sfillNaN( [ x, alpha ] );
+	actual = sfillNaN( [ x, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Float32Array( [ 0.0, -2.0, 3.0, NaN, 4.0, -6.0 ] );
@@ -102,7 +118,9 @@ tape( 'the function supports an input ndarray having a negative stride', functio
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Float32Array( [ NaN, -2.0, 3.0, NaN, 4.0, -6.0 ] );
@@ -110,8 +128,14 @@ tape( 'the function supports an input ndarray having a negative stride', functio
 	alpha = scalar2ndarray( 0.0, {
 		'dtype': 'float32'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'float32'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'float32'
+	});
 
-	actual = sfillNaN( [ x, alpha ] );
+	actual = sfillNaN( [ x, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Float32Array( [ 0.0, -2.0, 3.0, NaN, 4.0, -6.0 ] );
@@ -124,7 +148,9 @@ tape( 'the function supports an input ndarray having a non-zero offset', functio
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Float32Array( [ NaN, -2.0, 3.0, NaN, 4.0, -6.0 ] );
@@ -132,11 +158,256 @@ tape( 'the function supports an input ndarray having a non-zero offset', functio
 	alpha = scalar2ndarray( 0.0, {
 		'dtype': 'float32'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'float32'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'float32'
+	});
 
-	actual = sfillNaN( [ x, alpha ] );
+	actual = sfillNaN( [ x, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Float32Array( [ NaN, -2.0, 3.0, 0.0, 4.0, -6.0 ] );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a nonnegative starting index', function test( t ) {
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Float32Array( [ NaN, -2.0, 3.0, NaN, 4.0, -6.0 ] );
+	x = vector( xbuf, 6, 1, 0 );
+	alpha = scalar2ndarray( 0.0, {
+		'dtype': 'float32'
+	});
+	start = scalar2ndarray( 2, {
+		'dtype': 'float32'
+	});
+	end = scalar2ndarray( 6, {
+		'dtype': 'float32'
+	});
+
+	actual = sfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Float32Array( [ NaN, -2.0, 3.0, 0.0, 4.0, -6.0 ] );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative starting index', function test( t ) {
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Float32Array( [ NaN, -2.0, 3.0, NaN, 4.0, -6.0 ] );
+	x = vector( xbuf, 6, 1, 0 );
+	alpha = scalar2ndarray( 0.0, {
+		'dtype': 'float32'
+	});
+	start = scalar2ndarray( -4, {
+		'dtype': 'float32'
+	});
+	end = scalar2ndarray( 6, {
+		'dtype': 'float32'
+	});
+
+	actual = sfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Float32Array( [ NaN, -2.0, 3.0, 0.0, 4.0, -6.0 ] );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a nonnegative ending index', function test( t ) {
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Float32Array( [ NaN, -2.0, 3.0, NaN, 4.0, -6.0 ] );
+	x = vector( xbuf, 6, 1, 0 );
+	alpha = scalar2ndarray( 0.0, {
+		'dtype': 'float32'
+	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'float32'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'float32'
+	});
+
+	actual = sfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Float32Array( [ 0.0, -2.0, 3.0, NaN, 4.0, -6.0 ] );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative ending index', function test( t ) {
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Float32Array( [ NaN, -2.0, 3.0, NaN, 4.0, -6.0 ] );
+	x = vector( xbuf, 6, 1, 0 );
+	alpha = scalar2ndarray( 0.0, {
+		'dtype': 'float32'
+	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'float32'
+	});
+	end = scalar2ndarray( -3, {
+		'dtype': 'float32'
+	});
+
+	actual = sfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Float32Array( [ 0.0, -2.0, 3.0, NaN, 4.0, -6.0 ] );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function clamps out-of-bounds starting and ending indices', function test( t ) {
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Float32Array( [ NaN, -2.0, 3.0, NaN, 4.0, -6.0 ] );
+	x = vector( xbuf, 6, 1, 0 );
+	alpha = scalar2ndarray( 0.0, {
+		'dtype': 'float32'
+	});
+	start = scalar2ndarray( -10, {
+		'dtype': 'float32'
+	});
+	end = scalar2ndarray( 10, {
+		'dtype': 'float32'
+	});
+
+	actual = sfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Float32Array( [ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ] );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if a resolved starting index is greater than or equal to a resolved ending index, the function returns the input ndarray unchanged', function test( t ) {
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Float32Array( [ NaN, -2.0, 3.0, NaN ] );
+	x = vector( xbuf, 4, 1, 0 );
+	alpha = scalar2ndarray( 0.0, {
+		'dtype': 'float32'
+	});
+	expected = new Float32Array( [ NaN, -2.0, 3.0, NaN ] );
+
+	start = scalar2ndarray( 2, {
+		'dtype': 'float32'
+	});
+	end = scalar2ndarray( 2, {
+		'dtype': 'float32'
+	});
+	actual = sfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	start = scalar2ndarray( 3, {
+		'dtype': 'float32'
+	});
+	end = scalar2ndarray( 1, {
+		'dtype': 'float32'
+	});
+	actual = sfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	start = scalar2ndarray( 5, {
+		'dtype': 'float32'
+	});
+	end = scalar2ndarray( 4, {
+		'dtype': 'float32'
+	});
+	actual = sfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	start = scalar2ndarray( 0, {
+		'dtype': 'float32'
+	});
+	end = scalar2ndarray( -10, {
+		'dtype': 'float32'
+	});
+	actual = sfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying a fill range for an input ndarray having a non-unit stride', function test( t ) {
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Float32Array( [ NaN, -2.0, 3.0, 4.0 ] );
+	x = vector( xbuf, 2, 2, 0 );
+	alpha = scalar2ndarray( 0.0, {
+		'dtype': 'float32'
+	});
+	start = scalar2ndarray( 1, {
+		'dtype': 'float32'
+	});
+	end = scalar2ndarray( 2, {
+		'dtype': 'float32'
+	});
+
+	actual = sfillNaN( [ x, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Float32Array( [ NaN, -2.0, 3.0, 4.0 ] );
 	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
 
 	t.end();
@@ -146,7 +417,9 @@ tape( 'if none of the elements are equal to `NaN`, the function returns the inpu
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Float32Array( [ 1.0, 2.0, 3.0, 4.0 ] );
@@ -154,8 +427,14 @@ tape( 'if none of the elements are equal to `NaN`, the function returns the inpu
 	alpha = scalar2ndarray( 0.0, {
 		'dtype': 'float32'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'float32'
+	});
+	end = scalar2ndarray( 4, {
+		'dtype': 'float32'
+	});
 
-	actual = sfillNaN( [ x, alpha ] );
+	actual = sfillNaN( [ x, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Float32Array( [ 1.0, 2.0, 3.0, 4.0 ] );
@@ -168,7 +447,9 @@ tape( 'the function returns the input ndarray unchanged when the input ndarray i
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Float32Array( [] );
@@ -176,8 +457,14 @@ tape( 'the function returns the input ndarray unchanged when the input ndarray i
 	alpha = scalar2ndarray( 0.0, {
 		'dtype': 'float32'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'float32'
+	});
+	end = scalar2ndarray( 0, {
+		'dtype': 'float32'
+	});
 
-	actual = sfillNaN( [ x, alpha ] );
+	actual = sfillNaN( [ x, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Float32Array( [] );


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1254.

## Description

> What is the purpose of this pull request?

This pull request:

-   add `start` and `end` parameter support to `blas/ext/base/ndarray/sfill-nan`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1254.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Primarily written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
