### PR TITLE
feat!: add `start` and `end` parameter support to `blas/ext/base/ndarray/sfill-not-equal`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/README.md
@@ -54,8 +54,16 @@ var alpha = scalar2ndarray( 5.0, {
     'dtype': 'float32'
 });
 
-sfillNotEqual( [ x, searchElement, alpha ] );
-// x => <ndarray>[ 0.0, 5.0, 5.0, 0.0, 5.0, 5.0 ]
+var start = scalar2ndarray( 0, {
+    'dtype': 'generic'
+});
+
+var end = scalar2ndarray( 3, {
+    'dtype': 'generic'
+});
+
+sfillNotEqual( [ x, searchElement, alpha, start, end ] );
+// x => <ndarray>[ 0.0, 5.0, 5.0, 0.0, 4.0, -6.0 ]
 ```
 
 The function has the following parameters:
@@ -65,6 +73,8 @@ The function has the following parameters:
     -   a one-dimensional input ndarray.
     -   a zero-dimensional ndarray containing the search element.
     -   a zero-dimensional ndarray containing the scalar constant.
+    -   a zero-dimensional ndarray containing the starting index (inclusive).
+    -   a zero-dimensional ndarray containing the ending index (exclusive).
 
 </section>
 
@@ -75,6 +85,7 @@ The function has the following parameters:
 ## Notes
 
 -   The input ndarray is modified **in-place** (i.e., the input ndarray is **mutated**).
+-   If a specified `start` or `end` index is negative, the function resolves the respective index by counting backward from the last element (where `-1` refers to the last element).
 -   When comparing elements, the function checks for equality using the strict equality operator `===`. As a consequence, `NaN` values are considered distinct (i.e., as `NaN !== NaN` always evaluates to `true`, `NaN` elements are always replaced), and `-0` and `+0` are considered the same.
 
 </section>
@@ -98,7 +109,7 @@ var opts = {
     'dtype': 'float32'
 };
 
-var x = discreteUniform( [ 10 ], 0, 3, opts );
+var x = discreteUniform( [ 20 ], 0, 3, opts );
 console.log( ndarray2array( x ) );
 
 var searchElement = scalar2ndarray( 1.0, opts );
@@ -107,7 +118,17 @@ console.log( 'Search Element: %d', ndarraylike2scalar( searchElement ) );
 var alpha = scalar2ndarray( 5.0, opts );
 console.log( 'Alpha: %d', ndarraylike2scalar( alpha ) );
 
-sfillNotEqual( [ x, searchElement, alpha ] );
+var start = scalar2ndarray( 5, {
+    'dtype': 'generic'
+});
+console.log( 'Start Index: %d', ndarraylike2scalar( start ) );
+
+var end = scalar2ndarray( 15, {
+    'dtype': 'generic'
+});
+console.log( 'End Index: %d', ndarraylike2scalar( end ) );
+
+sfillNotEqual( [ x, searchElement, alpha, start, end ] );
 console.log( ndarray2array( x ) );
 ```
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/benchmark/benchmark.js
@@ -48,11 +48,19 @@ var options = {
 function createBenchmark( len ) {
 	var searchElement;
 	var alpha;
+	var start;
+	var end;
 	var x;
 
 	x = uniform( [ len ], -100.0, 100.0, options );
 	searchElement = scalar2ndarray( 0.0, options );
 	alpha = scalar2ndarray( 5.0, options );
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( len, {
+		'dtype': 'generic'
+	});
 	return benchmark;
 
 	/**
@@ -67,7 +75,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			out = sfillNotEqual( [ x, searchElement, alpha ] );
+			out = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
 			if ( typeof out !== 'object' ) {
 				b.fail( 'should return an ndarray' );
 			}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/docs/repl.txt
@@ -7,6 +7,10 @@
     The input ndarray is modified *in-place* (i.e., the input ndarray is
     *mutated*).
 
+    If a specified `start` or `end` index is negative, the function resolves
+    the respective index by counting backward from the last element (where `-1`
+    refers to the last element).
+
     When comparing elements, the function checks for equality using the strict
     equality operator `===`. As a consequence, `NaN` values are considered
     distinct (i.e., as `NaN !== NaN` always evaluates to `true`, `NaN` elements
@@ -20,6 +24,8 @@
         - a one-dimensional input ndarray.
         - a zero-dimensional ndarray containing the search element.
         - a zero-dimensional ndarray containing the scalar constant.
+        - a zero-dimensional ndarray containing the starting index (inclusive).
+        - a zero-dimensional ndarray containing the ending index (exclusive).
 
     Returns
     -------
@@ -28,11 +34,15 @@
 
     Examples
     --------
-    > var x = new {{alias:@stdlib/ndarray/vector/float32}}( [ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ] );
-    > var v = {{alias:@stdlib/ndarray/from-scalar}}( 0.0, { 'dtype': 'float32' } );
-    > var alpha = {{alias:@stdlib/ndarray/from-scalar}}( 5.0, { 'dtype': 'float32' } );
-    > {{alias}}( [ x, v, alpha ] )
-    <ndarray>[ 0.0, 5.0, 5.0, 0.0, 5.0, 5.0 ]
+    > var buf = [ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ];
+    > var x = new {{alias:@stdlib/ndarray/vector/float32}}( buf );
+    > var opts = { 'dtype': 'float32' };
+    > var v = {{alias:@stdlib/ndarray/from-scalar}}( 0.0, opts );
+    > var alpha = {{alias:@stdlib/ndarray/from-scalar}}( 5.0, opts );
+    > var st = {{alias:@stdlib/ndarray/from-scalar}}( 0, { 'dtype': 'generic' } );
+    > var en = {{alias:@stdlib/ndarray/from-scalar}}( 3, { 'dtype': 'generic' } );
+    > {{alias}}( [ x, v, alpha, st, en ] )
+    <ndarray>[ 0.0, 5.0, 5.0, 0.0, 4.0, -6.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/docs/types/index.d.ts
@@ -32,6 +32,8 @@ import { float32ndarray, typedndarray } from '@stdlib/types/ndarray';
 *     -   a one-dimensional input ndarray.
 *     -   a zero-dimensional ndarray containing the search element.
 *     -   a zero-dimensional ndarray containing the scalar constant.
+*     -   a zero-dimensional ndarray containing the starting index (inclusive).
+*     -   a zero-dimensional ndarray containing the ending index (exclusive).
 *
 * -   When comparing elements, the function checks for equality using the strict equality operator `===`. As a consequence, `NaN` values are considered distinct (i.e., as `NaN !== NaN` always evaluates to `true`, `NaN` elements are always replaced), and `-0` and `+0` are considered the same.
 *
@@ -52,10 +54,18 @@ import { float32ndarray, typedndarray } from '@stdlib/types/ndarray';
 *     'dtype': 'float32'
 * });
 *
-* var out = sfillNotEqual( [ x, searchElement, alpha ] );
-* // returns <ndarray>[ 0.0, 5.0, 5.0, 0.0, 5.0, 5.0 ]
+* var start = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var end = scalar2ndarray( 3, {
+*     'dtype': 'generic'
+* });
+*
+* var out = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
+* // returns <ndarray>[ 0.0, 5.0, 5.0, 0.0, 4.0, -6.0 ]
 */
-declare function sfillNotEqual( arrays: [ float32ndarray, typedndarray<number>, typedndarray<number> ] ): float32ndarray;
+declare function sfillNotEqual( arrays: [ float32ndarray, typedndarray<number>, typedndarray<number>, typedndarray<number>, typedndarray<number> ] ): float32ndarray;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/docs/types/test.ts
@@ -36,8 +36,14 @@ import sfillNotEqual = require( './index' );
 	const alpha = scalar2ndarray( 5.0, {
 		'dtype': 'float32'
 	});
+	const start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	const end = scalar2ndarray( 10, {
+		'dtype': 'generic'
+	});
 
-	sfillNotEqual( [ x, searchElement, alpha ] ); // $ExpectType float32ndarray
+	sfillNotEqual( [ x, searchElement, alpha, start, end ] ); // $ExpectType float32ndarray
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
@@ -64,7 +70,13 @@ import sfillNotEqual = require( './index' );
 	const alpha = scalar2ndarray( 5.0, {
 		'dtype': 'float32'
 	});
+	const start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	const end = scalar2ndarray( 10, {
+		'dtype': 'generic'
+	});
 
 	sfillNotEqual(); // $ExpectError
-	sfillNotEqual( [ x, searchElement, alpha ], {} ); // $ExpectError
+	sfillNotEqual( [ x, searchElement, alpha, start, end ], {} ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/examples/index.js
@@ -28,7 +28,7 @@ var opts = {
 	'dtype': 'float32'
 };
 
-var x = discreteUniform( [ 10 ], 0, 3, opts );
+var x = discreteUniform( [ 20 ], 0, 3, opts );
 console.log( ndarray2array( x ) );
 
 var searchElement = scalar2ndarray( 1.0, opts );
@@ -37,5 +37,15 @@ console.log( 'Search Element: %d', ndarraylike2scalar( searchElement ) );
 var alpha = scalar2ndarray( 5.0, opts );
 console.log( 'Alpha: %d', ndarraylike2scalar( alpha ) );
 
-sfillNotEqual( [ x, searchElement, alpha ] );
+var start = scalar2ndarray( 5, {
+	'dtype': 'generic'
+});
+console.log( 'Start Index: %d', ndarraylike2scalar( start ) );
+
+var end = scalar2ndarray( 15, {
+	'dtype': 'generic'
+});
+console.log( 'End Index: %d', ndarraylike2scalar( end ) );
+
+sfillNotEqual( [ x, searchElement, alpha, start, end ] );
 console.log( ndarray2array( x ) );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/lib/index.js
@@ -38,8 +38,16 @@
 *     'dtype': 'float32'
 * });
 *
-* var out = sfillNotEqual( [ x, searchElement, alpha ] );
-* // returns <ndarray>[ 0.0, 5.0, 5.0, 0.0, 5.0, 5.0 ]
+* var start = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var end = scalar2ndarray( 3, {
+*     'dtype': 'generic'
+* });
+*
+* var out = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
+* // returns <ndarray>[ 0.0, 5.0, 5.0, 0.0, 4.0, -6.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/lib/main.js
@@ -21,11 +21,12 @@
 // MODULES //
 
 var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
+var clipIndex = require( '@stdlib/ndarray/base/clip-index' );
 var getStride = require( '@stdlib/ndarray/base/stride' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
-var strided = require( '@stdlib/blas/ext/base/sfill-not-equal' ).ndarray;
 var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
+var strided = require( '@stdlib/blas/ext/base/sfill-not-equal' ).ndarray;
 
 
 // MAIN //
@@ -40,6 +41,8 @@ var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 *     -   a one-dimensional input ndarray.
 *     -   a zero-dimensional ndarray containing the search element.
 *     -   a zero-dimensional ndarray containing the scalar constant.
+*     -   a zero-dimensional ndarray containing the starting index (inclusive).
+*     -   a zero-dimensional ndarray containing the ending index (exclusive).
 *
 * -   When comparing elements, the function checks for equality using the strict equality operator `===`. As a consequence, `NaN` values are considered distinct (i.e., as `NaN !== NaN` always evaluates to `true`, `NaN` elements are always replaced), and `-0` and `+0` are considered the same.
 *
@@ -60,18 +63,41 @@ var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 *     'dtype': 'float32'
 * });
 *
-* var out = sfillNotEqual( [ x, searchElement, alpha ] );
-* // returns <ndarray>[ 0.0, 5.0, 5.0, 0.0, 5.0, 5.0 ]
+* var start = scalar2ndarray( 0, {
+*     'dtype': 'generic'
+* });
+*
+* var end = scalar2ndarray( 3, {
+*     'dtype': 'generic'
+* });
+*
+* var out = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
+* // returns <ndarray>[ 0.0, 5.0, 5.0, 0.0, 4.0, -6.0 ]
 */
 function sfillNotEqual( arrays ) {
 	var searchElement;
+	var stride;
+	var offset;
 	var alpha;
+	var start;
+	var end;
+	var N;
 	var x;
 
 	x = arrays[ 0 ];
 	searchElement = ndarraylike2scalar( arrays[ 1 ] );
 	alpha = ndarraylike2scalar( arrays[ 2 ] );
-	strided( numelDimension( x, 0 ), searchElement, alpha, getData( x ), getStride( x, 0 ), getOffset( x ) ); // eslint-disable-line max-len
+
+	N = numelDimension( x, 0 );
+	start = clipIndex( ndarraylike2scalar( arrays[ 3 ] ), N );
+	end = clipIndex( ndarraylike2scalar( arrays[ 4 ] ), N );
+	if ( start >= end ) {
+		return x;
+	}
+	stride = getStride( x, 0 );
+	offset = getOffset( x ) + ( stride*start );
+
+	strided( end-start, searchElement, alpha, getData( x ), stride, offset );
 	return x;
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sfill-not-equal/test/test.js
@@ -59,7 +59,9 @@ tape( 'the function replaces elements not equal to a provided search element', f
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Float32Array( [ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ] );
@@ -70,8 +72,14 @@ tape( 'the function replaces elements not equal to a provided search element', f
 	alpha = scalar2ndarray( 5.0, {
 		'dtype': 'float32'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 6, {
+		'dtype': 'generic'
+	});
 
-	actual = sfillNotEqual( [ x, searchElement, alpha ] );
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Float32Array( [ 0.0, 5.0, 5.0, 0.0, 5.0, 5.0 ] );
@@ -85,7 +93,9 @@ tape( 'the function supports an input ndarray having a non-unit stride', functio
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Float32Array( [ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ] );
@@ -96,8 +106,14 @@ tape( 'the function supports an input ndarray having a non-unit stride', functio
 	alpha = scalar2ndarray( 5.0, {
 		'dtype': 'float32'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
-	actual = sfillNotEqual( [ x, searchElement, alpha ] );
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Float32Array( [ 0.0, -2.0, 5.0, 0.0, 5.0, -6.0 ] );
@@ -111,7 +127,9 @@ tape( 'the function supports an input ndarray having a negative stride', functio
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Float32Array( [ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ] );
@@ -122,8 +140,14 @@ tape( 'the function supports an input ndarray having a negative stride', functio
 	alpha = scalar2ndarray( 5.0, {
 		'dtype': 'float32'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
-	actual = sfillNotEqual( [ x, searchElement, alpha ] );
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Float32Array( [ 0.0, -2.0, 5.0, 0.0, 5.0, -6.0 ] );
@@ -137,7 +161,9 @@ tape( 'the function supports an input ndarray having a non-zero offset', functio
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Float32Array( [ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ] );
@@ -148,11 +174,284 @@ tape( 'the function supports an input ndarray having a non-zero offset', functio
 	alpha = scalar2ndarray( 5.0, {
 		'dtype': 'float32'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
-	actual = sfillNotEqual( [ x, searchElement, alpha ] );
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Float32Array( [ 0.0, -2.0, 3.0, 0.0, 5.0, 5.0 ] );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a nonnegative starting index', function test( t ) {
+	var searchElement;
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Float32Array( [ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ] );
+	x = vector( xbuf, 6, 1, 0 );
+	searchElement = scalar2ndarray( 0.0, {
+		'dtype': 'float32'
+	});
+	alpha = scalar2ndarray( 5.0, {
+		'dtype': 'float32'
+	});
+	start = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 6, {
+		'dtype': 'generic'
+	});
+
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Float32Array( [ 0.0, -2.0, 5.0, 0.0, 5.0, 5.0 ] );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative starting index', function test( t ) {
+	var searchElement;
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Float32Array( [ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ] );
+	x = vector( xbuf, 6, 1, 0 );
+	searchElement = scalar2ndarray( 0.0, {
+		'dtype': 'float32'
+	});
+	alpha = scalar2ndarray( 5.0, {
+		'dtype': 'float32'
+	});
+	start = scalar2ndarray( -4, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 6, {
+		'dtype': 'generic'
+	});
+
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Float32Array( [ 0.0, -2.0, 5.0, 0.0, 5.0, 5.0 ] );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a nonnegative ending index', function test( t ) {
+	var searchElement;
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Float32Array( [ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ] );
+	x = vector( xbuf, 6, 1, 0 );
+	searchElement = scalar2ndarray( 0.0, {
+		'dtype': 'float32'
+	});
+	alpha = scalar2ndarray( 5.0, {
+		'dtype': 'float32'
+	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
+
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Float32Array( [ 0.0, 5.0, 5.0, 0.0, 4.0, -6.0 ] );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative ending index', function test( t ) {
+	var searchElement;
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Float32Array( [ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ] );
+	x = vector( xbuf, 6, 1, 0 );
+	searchElement = scalar2ndarray( 0.0, {
+		'dtype': 'float32'
+	});
+	alpha = scalar2ndarray( 5.0, {
+		'dtype': 'float32'
+	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( -3, {
+		'dtype': 'generic'
+	});
+
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Float32Array( [ 0.0, 5.0, 5.0, 0.0, 4.0, -6.0 ] );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function clamps out-of-bounds starting and ending indices', function test( t ) {
+	var searchElement;
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Float32Array( [ 0.0, -2.0, 3.0, 0.0, 4.0, -6.0 ] );
+	x = vector( xbuf, 6, 1, 0 );
+	searchElement = scalar2ndarray( 0.0, {
+		'dtype': 'float32'
+	});
+	alpha = scalar2ndarray( 5.0, {
+		'dtype': 'float32'
+	});
+	start = scalar2ndarray( -10, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 10, {
+		'dtype': 'generic'
+	});
+
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Float32Array( [ 0.0, 5.0, 5.0, 0.0, 5.0, 5.0 ] );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if a resolved starting index is greater than or equal to a resolved ending index, the function returns the input ndarray unchanged', function test( t ) {
+	var searchElement;
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Float32Array( [ 0.0, -2.0, 3.0, 0.0 ] );
+	x = vector( xbuf, 4, 1, 0 );
+	searchElement = scalar2ndarray( 0.0, {
+		'dtype': 'float32'
+	});
+	alpha = scalar2ndarray( 5.0, {
+		'dtype': 'float32'
+	});
+	expected = new Float32Array( [ 0.0, -2.0, 3.0, 0.0 ] );
+
+	start = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	start = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 1, {
+		'dtype': 'generic'
+	});
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	start = scalar2ndarray( 5, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( -10, {
+		'dtype': 'generic'
+	});
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying a fill range for an input ndarray having a non-unit stride', function test( t ) {
+	var searchElement;
+	var expected;
+	var actual;
+	var alpha;
+	var start;
+	var xbuf;
+	var end;
+	var x;
+
+	xbuf = new Float32Array( [ 0.0, -2.0, 3.0, 4.0 ] );
+	x = vector( xbuf, 2, 2, 0 );
+	searchElement = scalar2ndarray( 0.0, {
+		'dtype': 'float32'
+	});
+	alpha = scalar2ndarray( 5.0, {
+		'dtype': 'float32'
+	});
+	start = scalar2ndarray( 1, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 2, {
+		'dtype': 'generic'
+	});
+
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
+	t.strictEqual( actual, x, 'returns expected value' );
+
+	expected = new Float32Array( [ 0.0, -2.0, 5.0, 4.0 ] );
 	t.strictEqual( isSameFloat32Array( getData( actual ), expected ), true, 'returns expected value' );
 
 	t.end();
@@ -163,7 +462,9 @@ tape( 'if all elements are equal to a provided search element, the function retu
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Float32Array( [ 0.0, 0.0, 0.0, 0.0 ] );
@@ -174,8 +475,14 @@ tape( 'if all elements are equal to a provided search element, the function retu
 	alpha = scalar2ndarray( 5.0, {
 		'dtype': 'float32'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
 
-	actual = sfillNotEqual( [ x, searchElement, alpha ] );
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Float32Array( [ 0.0, 0.0, 0.0, 0.0 ] );
@@ -189,7 +496,9 @@ tape( 'if provided a search element equal to `NaN`, the function replaces all el
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Float32Array( [ NaN, 1.0, NaN ] );
@@ -200,8 +509,14 @@ tape( 'if provided a search element equal to `NaN`, the function replaces all el
 	alpha = scalar2ndarray( 5.0, {
 		'dtype': 'float32'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
-	actual = sfillNotEqual( [ x, searchElement, alpha ] );
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Float32Array( [ 5.0, 5.0, 5.0 ] );
@@ -215,7 +530,9 @@ tape( 'the function replaces `NaN` elements', function test( t ) {
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Float32Array( [ NaN, 0.0, NaN ] );
@@ -226,8 +543,14 @@ tape( 'the function replaces `NaN` elements', function test( t ) {
 	alpha = scalar2ndarray( 5.0, {
 		'dtype': 'float32'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 3, {
+		'dtype': 'generic'
+	});
 
-	actual = sfillNotEqual( [ x, searchElement, alpha ] );
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Float32Array( [ 5.0, 0.0, 5.0 ] );
@@ -241,7 +564,9 @@ tape( 'the function considers `-0` and `+0` to be the same value', function test
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Float32Array( [ -0.0, 1.0, 0.0, -0.0 ] );
@@ -252,8 +577,14 @@ tape( 'the function considers `-0` and `+0` to be the same value', function test
 	alpha = scalar2ndarray( 5.0, {
 		'dtype': 'float32'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 4, {
+		'dtype': 'generic'
+	});
 
-	actual = sfillNotEqual( [ x, searchElement, alpha ] );
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Float32Array( [ -0.0, 5.0, 0.0, -0.0 ] );
@@ -265,7 +596,7 @@ tape( 'the function considers `-0` and `+0` to be the same value', function test
 		'dtype': 'float32'
 	});
 
-	actual = sfillNotEqual( [ x, searchElement, alpha ] );
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Float32Array( [ -0.0, 5.0, 0.0, -0.0 ] );
@@ -279,7 +610,9 @@ tape( 'the function returns the input ndarray unchanged when the input ndarray i
 	var expected;
 	var actual;
 	var alpha;
+	var start;
 	var xbuf;
+	var end;
 	var x;
 
 	xbuf = new Float32Array( [] );
@@ -290,8 +623,14 @@ tape( 'the function returns the input ndarray unchanged when the input ndarray i
 	alpha = scalar2ndarray( 5.0, {
 		'dtype': 'float32'
 	});
+	start = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
+	end = scalar2ndarray( 0, {
+		'dtype': 'generic'
+	});
 
-	actual = sfillNotEqual( [ x, searchElement, alpha ] );
+	actual = sfillNotEqual( [ x, searchElement, alpha, start, end ] );
 	t.strictEqual( actual, x, 'returns expected value' );
 
 	expected = new Float32Array( [] );


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1255.

## Description

> What is the purpose of this pull request?

This pull request:

-   add `start` and `end` parameter support to `blas/ext/base/ndarray/sfill-not-equal`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1255.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Primarily written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
