### PR TITLE
test: migrate `stats/base/dists/beta/quantile` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/beta/quantile/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/quantile/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -161,10 +160,8 @@ tape( 'if provided a nonpositive `alpha`, the created function always returns `N
 tape( 'the created function evaluates the quantile for `p` given large `alpha` and `beta`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var p;
 	var y;
 	var i;
@@ -176,13 +173,7 @@ tape( 'the created function evaluates the quantile for `p` given large `alpha` a
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( alpha[i], beta[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 18 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -190,10 +181,8 @@ tape( 'the created function evaluates the quantile for `p` given large `alpha` a
 tape( 'the created function evaluates the quantile for `p` given large `alpha`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var p;
 	var y;
 	var i;
@@ -205,13 +194,7 @@ tape( 'the created function evaluates the quantile for `p` given large `alpha`',
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( alpha[i], beta[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 9 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -219,10 +202,8 @@ tape( 'the created function evaluates the quantile for `p` given large `alpha`',
 tape( 'the created function evaluates the quantile for `p` given large `beta`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var p;
 	var y;
 	var i;
@@ -234,13 +215,7 @@ tape( 'the created function evaluates the quantile for `p` given large `beta`', 
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( alpha[i], beta[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 29 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/quantile/test/test.quantile.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/quantile/test/test.quantile.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var quantile = require( './../lib' );
 
 
@@ -118,10 +117,8 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', function t
 
 tape( 'the function evaluates the quantile for `x` given large `alpha` and `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var p;
 	var y;
 	var i;
@@ -132,13 +129,7 @@ tape( 'the function evaluates the quantile for `x` given large `alpha` and `beta
 	beta = bothLarge.beta;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 18 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -146,9 +137,7 @@ tape( 'the function evaluates the quantile for `x` given large `alpha` and `beta
 tape( 'the function evaluates the quantile for `x` given large `alpha`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
 	var beta;
-	var tol;
 	var p;
 	var y;
 	var i;
@@ -159,13 +148,7 @@ tape( 'the function evaluates the quantile for `x` given large `alpha`', functio
 	beta = largeAlpha.beta;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 9 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -173,9 +156,7 @@ tape( 'the function evaluates the quantile for `x` given large `alpha`', functio
 tape( 'the function evaluates the quantile for `x` given large `beta`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
 	var beta;
-	var tol;
 	var p;
 	var y;
 	var i;
@@ -186,13 +167,7 @@ tape( 'the function evaluates the quantile for `x` given large `beta`', function
 	beta = largeBeta.beta;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 29 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/beta/quantile` from relative tolerance testing (`delta <= tol`, where `tol = 20.0 * EPS * abs( expected )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   replaces the `if ( y === expected[i] ) { ... } else { ... }` tolerance branches with `t.strictEqual( isAlmostSameValue( y, expected[ i ], N ), true, 'returns expected value' );`.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires, along with the `delta` and `tol` variable declarations.

Only `test/test.quantile.js` and `test/test.factory.js` are modified; the package has no `test/test.native.js`. `test/test.js` was left untouched, as it contains no tolerance-based assertions.

### ULP bounds

Each fixture set is asserted against the measured minimum ULP bound for that fixture set, and the same bound is used for the corresponding test in both `test.quantile.js` and `test.factory.js`:

| Fixture | ULP | Measured minimum |
| ------- | --- | ---------------- |
| `both_large.json` | `18` | `18` (fails at `17`) |
| `large_alpha.json` | `9` | `9` (fails at `8`) |
| `large_beta.json` | `29` | `29` (fails at `28`) |

The bounds were determined by starting from a high ULP value and lowering to the smallest integer which still passes over the full fixture set (1000 values per fixture). Decrementing any of the three bounds by one causes failures (1, 3, and 1 assertions, respectively), confirming the bounds are tight. The full suite was run twice at the final values with identical results (`3023` + `3021` + `3` assertions passing, no failures).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed locally:

-   `make test TESTS_FILTER=".*/stats/base/dists/beta/quantile/.*"` — passing (run twice).
-   ESLint against `etc/eslint/.eslintrc.tests.js` — 0 errors, 0 warnings.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code, running as an unattended scheduled task, mirroring the idiom established by previously merged ULP migration PRs. The ULP bounds were measured empirically, and the tests and linter were run locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value


---
_Generated by [Claude Code](https://claude.ai/code/session_014Cv2JMqyGWr6vf5Yd2aGyH)_