### PR TITLE
test: migrate `stats/base/dists/frechet/logcdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/logcdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/logcdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -154,8 +153,6 @@ tape( 'the created function evaluates the logcdf for `x` given large `alpha`', f
 	var expected;
 	var logcdf;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -168,13 +165,7 @@ tape( 'the created function evaluates the logcdf for `x` given large `alpha`', f
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( alpha[i], s[i], 0.0 );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. m: 0. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 24 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -183,8 +174,6 @@ tape( 'the created function evaluates the logcdf for `x` given large `s`', funct
 	var expected;
 	var logcdf;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -197,13 +186,7 @@ tape( 'the created function evaluates the logcdf for `x` given large `s`', funct
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( alpha[i], s[i], 0.0 );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -212,8 +195,6 @@ tape( 'the created function evaluates the logcdf for `x` given large `alpha` and
 	var expected;
 	var logcdf;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -226,13 +207,7 @@ tape( 'the created function evaluates the logcdf for `x` given large `alpha` and
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( alpha[i], s[i], 0.0 );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 20 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/logcdf/test/test.logcdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/logcdf/test/test.logcdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logcdf = require( './../lib' );
 
 
@@ -135,8 +134,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', function test
 tape( 'the function evaluates the logcdf for `x` given large `alpha`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -148,13 +145,7 @@ tape( 'the function evaluates the logcdf for `x` given large `alpha`', function 
 	s = largeShape.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], alpha[i], s[i], 0.0 );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 24 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -162,8 +153,6 @@ tape( 'the function evaluates the logcdf for `x` given large `alpha`', function 
 tape( 'the function evaluates the logcdf for `x` given large `s`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -175,13 +164,7 @@ tape( 'the function evaluates the logcdf for `x` given large `s`', function test
 	s = largeScale.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], alpha[i], s[i], 0.0 );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -189,8 +172,6 @@ tape( 'the function evaluates the logcdf for `x` given large `s`', function test
 tape( 'the function evaluates the logcdf for `x` given large `alpha` and `s`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -202,13 +183,7 @@ tape( 'the function evaluates the logcdf for `x` given large `alpha` and `s`', f
 	s = bothLarge.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], alpha[i], s[i], 0.0 );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. m: 0. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 20 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/logcdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/logcdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -144,8 +143,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', opts, functio
 tape( 'the function evaluates the logcdf for `x` given large `alpha`', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -157,13 +154,7 @@ tape( 'the function evaluates the logcdf for `x` given large `alpha`', opts, fun
 	s = largeShape.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], alpha[i], s[i], 0.0 );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 24 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -171,8 +162,6 @@ tape( 'the function evaluates the logcdf for `x` given large `alpha`', opts, fun
 tape( 'the function evaluates the logcdf for `x` given large `s`', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -184,13 +173,7 @@ tape( 'the function evaluates the logcdf for `x` given large `s`', opts, functio
 	s = largeScale.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], alpha[i], s[i], 0.0 );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -198,8 +181,6 @@ tape( 'the function evaluates the logcdf for `x` given large `s`', opts, functio
 tape( 'the function evaluates the logcdf for `x` given large `alpha` and `s`', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -211,13 +192,7 @@ tape( 'the function evaluates the logcdf for `x` given large `alpha` and `s`', o
 	s = bothLarge.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], alpha[i], s[i], 0.0 );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. m: 0. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 20 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for `stats/base/dists/frechet/logcdf` from relative tolerance (`EPS`/`delta`/`tol`) assertions to ULP difference assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   updates `test/test.logcdf.js`, `test/test.factory.js`, and `test/test.native.js`. No other files are changed.

The ULP bound was tightened agentically: starting from a high bound and lowering to the minimum integer which still passes over the full fixture set (`large_shape`, `large_scale`, `both_large`; 1000 cases each, 3000 total per file).

Measured minimum ULP bounds:

| File | Fixture | ULP |
| ---- | ------- | --- |
| `test/test.logcdf.js` | `large_shape` | `24` |
| `test/test.logcdf.js` | `large_scale` | `2` |
| `test/test.logcdf.js` | `both_large` | `20` |
| `test/test.factory.js` | `large_shape` | `24` |
| `test/test.factory.js` | `large_scale` | `2` |
| `test/test.factory.js` | `both_large` | `20` |
| `test/test.native.js` | `large_shape` | `24` |
| `test/test.native.js` | `large_scale` | `2` |
| `test/test.native.js` | `both_large` | `20` |

Each bound is the exact maximum observed ULP difference over its fixture: lowering `24` to `23` fails one assertion, `20` to `19` fails one assertion, and `2` to `1` fails twenty-nine assertions. The JavaScript and C implementations returned bit-identical results for every fixture value, so the same bounds apply in `test/test.native.js` as in the JavaScript tests.

For reference, the previous relative tolerances were `20.0 * EPS` (`large_shape`, `both_large`) and `10.0 * EPS` (`large_scale`), which correspond to looser accuracy budgets than the ULP bounds above, so this is a tightening rather than a relaxation.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Verification: `test/test.js` (3 assertions), `test/test.logcdf.js` (3025 assertions), `test/test.factory.js` (3022 assertions), and `test/test.native.js` (3025 assertions) all pass. The native add-on was built locally so that `test/test.native.js` was actually exercised rather than skipped.
-   The full suite was run twice at the final bounds to confirm determinism (no FMA/architecture-dependent variation).
-   ESLint (tests configuration, `etc/eslint/.eslintrc.tests.js`) is clean for all changed files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This PR was authored by Claude Code as part of an automated, mechanical migration of existing test assertions to ULP-based assertions, following the idiom established in previously merged PRs referencing #11352. The ULP bounds were determined empirically by running the fixtures and minimizing the accepted bound.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNXbmetYcbrxtMYbT4hMtS)_