### PR TITLE
test: migrate `stats/base/dists/rayleigh/quantile` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/test/test.factory.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -121,9 +120,7 @@ tape( 'if `sigma` equals `0`, the created function evaluates a degenerate distri
 tape( 'the created function evaluates the quantile function at `p` given small scale parameter `sigma`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -134,15 +131,7 @@ tape( 'the created function evaluates the quantile function at `p` given small s
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( sigma[i] );
 		y = quantile( p[i] );
-		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -150,9 +139,7 @@ tape( 'the created function evaluates the quantile function at `p` given small s
 tape( 'the created function evaluates the quantile function at `p` given medium scale parameter `sigma`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -163,15 +150,7 @@ tape( 'the created function evaluates the quantile function at `p` given medium 
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( sigma[i] );
 		y = quantile( p[i] );
-		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -179,9 +158,7 @@ tape( 'the created function evaluates the quantile function at `p` given medium 
 tape( 'the created function evaluates the quantile function at `p` given large scale parameter `sigma`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -192,15 +169,7 @@ tape( 'the created function evaluates the quantile function at `p` given large s
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( sigma[i] );
 		y = quantile( p[i] );
-		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -103,9 +102,7 @@ tape( 'if provided `sigma` equals `0`, the function evaluates a degenerate distr
 
 tape( 'the function evaluates the quantile function at `p` given small scale parameter `sigma`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -115,24 +112,14 @@ tape( 'the function evaluates the quantile function at `p` given small scale par
 	sigma = smallScale.sigma;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], sigma[i] );
-		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the quantile function at `p` given medium scale parameter `sigma`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -142,24 +129,14 @@ tape( 'the function evaluates the quantile function at `p` given medium scale pa
 	sigma = mediumScale.sigma;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], sigma[i] );
-		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the quantile function at `p` given large scale parameter `sigma`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -169,15 +146,7 @@ tape( 'the function evaluates the quantile function at `p` given large scale par
 	sigma = largeScale.sigma;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], sigma[i] );
-		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/test/test.quantile.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/test/test.quantile.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var quantile = require( './../lib' );
 
 
@@ -94,9 +93,7 @@ tape( 'if provided `sigma` equals `0`, the function evaluates a degenerate distr
 
 tape( 'the function evaluates the quantile function at `p` given small scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -106,24 +103,14 @@ tape( 'the function evaluates the quantile function at `p` given small scale par
 	sigma = smallScale.sigma;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], sigma[i] );
-		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the quantile function at `p` given medium scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -133,24 +120,14 @@ tape( 'the function evaluates the quantile function at `p` given medium scale pa
 	sigma = mediumScale.sigma;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], sigma[i] );
-		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the quantile function at `p` given large scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -160,15 +137,7 @@ tape( 'the function evaluates the quantile function at `p` given large scale par
 	sigma = largeScale.sigma;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], sigma[i] );
-		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for `stats/base/dists/rayleigh/quantile` from relative tolerance (`EPS`/`delta`/`tol`) assertions to ULP difference assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   updates `test/test.quantile.js`, `test/test.factory.js`, and `test/test.native.js`. No other files are changed.

The ULP bound was tightened agentically: starting from a high bound and lowering to the minimum integer which still passes over the full fixture set (`small_scale`, `medium_scale`, `large_scale`; 1000 cases each, 3000 total per file).

Measured minimum ULP bounds:

| File | Fixture | ULP |
| ---- | ------- | --- |
| `test/test.quantile.js` | `small_scale` | `1` |
| `test/test.quantile.js` | `medium_scale` | `1` |
| `test/test.quantile.js` | `large_scale` | `1` |
| `test/test.factory.js` | `small_scale` | `1` |
| `test/test.factory.js` | `medium_scale` | `1` |
| `test/test.factory.js` | `large_scale` | `1` |
| `test/test.native.js` | `small_scale` | `1` |
| `test/test.native.js` | `medium_scale` | `1` |
| `test/test.native.js` | `large_scale` | `1` |

Each bound is the exact maximum observed ULP difference over its fixture: lowering `1` to `0` fails 305 assertions (`small_scale`), 332 assertions (`medium_scale`), and 297 assertions (`large_scale`) in each of the three files. The JavaScript and C implementations returned bit-identical results for every fixture value, so the same bounds apply in `test/test.native.js` as in the JavaScript tests.

For reference, the previous relative tolerance was `1.0 * EPS * abs( expected[ i ] )` for all three fixture sets, which corresponds to a looser accuracy budget than a 1 ULP bound, so this is a tightening rather than a relaxation.

The previous assertions were also guarded by `if ( expected[i] !== null )`. None of the three fixture files contain `null` expected values, so the guard was dead code and has been removed along with the tolerance branch, matching the idiom used in previously converted packages.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Verification: `test/test.js` (3 assertions), `test/test.quantile.js` (3013 assertions), `test/test.factory.js` (3014 assertions), and `test/test.native.js` (3013 assertions) all pass. The native add-on was built locally so that `test/test.native.js` was actually exercised rather than skipped.
-   The full suite was run twice at the final bounds to confirm determinism (no FMA/architecture-dependent variation).
-   ESLint (tests configuration, `etc/eslint/.eslintrc.tests.js`) is clean for all changed files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This PR was authored by Claude Code as part of an automated, mechanical migration of existing test assertions to ULP-based assertions, following the idiom established in previously merged PRs referencing #11352. The ULP bounds were determined empirically by running the fixtures and minimizing the accepted bound.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDdta6rnNBBxqNpFpzZVHi)_