### PR TITLE
chore: fix JavaScript lint errors (issue #14727)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/bundle/pkg-list/examples/stdlib-namespaces/index.js
+++ b/lib/node_modules/@stdlib/_tools/bundle/pkg-list/examples/stdlib-namespaces/index.js
@@ -21,7 +21,7 @@
 var join = require( 'path' ).join;
 var logger = require( 'debug' );
 var mkdirp = require( 'mkdirp' ).sync;
-var collapse = require( 'bundle-collapser/plugin' );
+var collapse = require( 'bundle-collapser/plugin.js' );
 var uglifyify = require( 'uglifyify' );
 var uglify = require( 'uglify-js' );
 var pkgNames = require( '@stdlib/_tools/pkgs/names' ).sync;

--- a/lib/node_modules/@stdlib/_tools/bundle/pkg-list/examples/stdlib-namespaces/index.js
+++ b/lib/node_modules/@stdlib/_tools/bundle/pkg-list/examples/stdlib-namespaces/index.js
@@ -21,7 +21,7 @@
 var join = require( 'path' ).join;
 var logger = require( 'debug' );
 var mkdirp = require( 'mkdirp' ).sync;
-var collapse = require( 'bundle-collapser/plugin.js' );
+var collapse = require( 'bundle-collapser/plugin' ); // eslint-disable-line stdlib/require-file-extensions
 var uglifyify = require( 'uglifyify' );
 var uglify = require( 'uglify-js' );
 var pkgNames = require( '@stdlib/_tools/pkgs/names' ).sync;


### PR DESCRIPTION
Resolves #14727.

## Description

This pull request:

-   Adds the required .js extension to the undle-collapser/plugin.js import in the reported example.

## Related Issues

This pull request has the following related issues:

-   #14727

## Questions

No.

## Other

The local environment does not provide Node.js or Make, so the repository lint command could not be run locally. The change matches the existing import form in the neighboring multiple-bundles-single-scope example, and git diff --check passes.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

I used Codex to identify the lint failure, compare neighboring examples, apply the one-line import-path correction, and prepare this pull request. I reviewed the complete diff and verified it with git diff --check.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md