### PR TITLE
test: migrate `math/base/special/gamma` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/gamma/test/test.boost.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma/test/test.boost.js
@@ -23,10 +23,9 @@
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var gamma = require( './../lib/boost/gamma.js' );
 
 
@@ -107,8 +106,6 @@ tape( 'if `x <= -170.65`, the function returns zero', function test( t ) {
 
 tape( 'the function evaluates the gamma function (positive integers)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -118,17 +115,13 @@ tape( 'the function evaluates the gamma function (positive integers)', function 
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = gamma( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 10.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the gamma function (decimal values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -138,17 +131,13 @@ tape( 'the function evaluates the gamma function (decimal values)', function tes
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = gamma( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 10.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 11 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the gamma function (values near one)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -158,9 +147,7 @@ tape( 'the function evaluates the gamma function (values near one)', function te
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = gamma( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 10.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 13 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/gamma/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma/test/test.js
@@ -23,8 +23,7 @@
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var max = require( '@stdlib/math/base/special/maxn' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var gamma = require( './../lib' );
@@ -107,31 +106,23 @@ tape( 'if `x < -170.56749...`, the function returns zero', function test( t ) {
 });
 
 tape( 'the function evaluates the gamma function (positive integers)', function test( t ) {
-	var delta;
-	var tol;
 	var v;
 	var i;
 
 	for ( i = 0; i < data1.length; i++ ) {
 		v = gamma( data1[ i ] );
-		delta = abs( v - expected1[ i ] );
-		tol = 2.75e-12 * max( 1.0, abs( v ), abs( expected1[ i ] ) );
-		t.ok( delta <= tol, 'within tolerance. x: ' + data1[ i ] + '. Value: ' + v + '. Expected: ' + expected1[ i ] + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected1[ i ], 1009 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the gamma function (decimal values)', function test( t ) {
-	var delta;
-	var tol;
 	var v;
 	var i;
 
 	for ( i = 0; i < data2.length; i++ ) {
 		v = gamma( data2[ i ] );
-		delta = abs( v - expected2[ i ] );
-		tol = 2.75e-12 * max( 1.0, abs( v ), abs( expected2[ i ] ) );
-		t.ok( delta <= tol, 'within tolerance. x: ' + data2[ i ] + '. Value: ' + v + '. Expected: ' + expected2[ i ] + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected2[ i ], 1942 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -145,8 +136,6 @@ tape( 'if provided a positive integer, the function returns the factorial of (n-
 
 tape( 'the function uses a small value approximation near left boundaries (abs(x)<33)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -155,18 +144,13 @@ tape( 'the function uses a small value approximation near left boundaries (abs(x
 
 	expected = -1.8364310433257593e-6;
 
-	delta = abs( v - expected );
-	tol = 1.0e-14;
-
-	t.ok( delta < tol, 'within tolerance. x: ' + x + '. Value: ' + v + '. Expected: ' + expected + '. Tolerance: ' + tol + '.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function uses a small value approximation near right boundaries (abs(x)<33)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -175,10 +159,7 @@ tape( 'the function uses a small value approximation near right boundaries (abs(
 
 	expected = -3.856505190983844e-5;
 
-	delta = abs( v - expected );
-	tol = 1.0e-14;
-
-	t.ok( delta < tol, 'within tolerance. x: ' + x + '. Value: ' + v + '. Expected: ' + expected + '. Tolerance: ' + tol + '.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/gamma/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma/test/test.native.js
@@ -24,8 +24,7 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var max = require( '@stdlib/math/base/special/maxn' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -116,31 +115,23 @@ tape( 'if `x < -170.56749...`, the function returns zero', opts, function test( 
 });
 
 tape( 'the function evaluates the gamma function (positive integers)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var v;
 	var i;
 
 	for ( i = 0; i < data1.length; i++ ) {
 		v = gamma( data1[ i ] );
-		delta = abs( v - expected1[ i ] );
-		tol = 2.75e-12 * max( 1.0, abs( v ), abs( expected1[ i ] ) );
-		t.ok( delta <= tol, 'within tolerance. x: ' + data1[ i ] + '. Value: ' + v + '. Expected: ' + expected1[ i ] + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected1[ i ], 1009 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the gamma function (decimal values)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var v;
 	var i;
 
 	for ( i = 0; i < data2.length; i++ ) {
 		v = gamma( data2[ i ] );
-		delta = abs( v - expected2[ i ] );
-		tol = 2.75e-12 * max( 1.0, abs( v ), abs( expected2[ i ] ) );
-		t.ok( delta <= tol, 'within tolerance. x: ' + data2[ i ] + '. Value: ' + v + '. Expected: ' + expected2[ i ] + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected2[ i ], 1942 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -154,8 +145,6 @@ tape( 'if provided a positive integer, the function returns the factorial of (n-
 
 tape( 'the function uses a small value approximation near left boundaries (abs(x)<33)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -164,18 +153,13 @@ tape( 'the function uses a small value approximation near left boundaries (abs(x
 
 	expected = -1.8364310433257593e-6;
 
-	delta = abs( v - expected );
-	tol = 1.0e-14;
-
-	t.ok( delta < tol, 'within tolerance. x: ' + x + '. Value: ' + v + '. Expected: ' + expected + '. Tolerance: ' + tol + '.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function uses a small value approximation near right boundaries (abs(x)<33)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -184,10 +168,7 @@ tape( 'the function uses a small value approximation near right boundaries (abs(
 
 	expected = -3.856505190983844e-5;
 
-	delta = abs( v - expected );
-	tol = 1.0e-14;
-
-	t.ok( delta < tol, 'within tolerance. x: ' + x + '. Value: ' + v + '. Expected: ' + expected + '. Tolerance: ' + tol + '.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/gamma` from relative/absolute tolerance testing to ULP difference testing, using `@stdlib/assert/is-almost-same-value`.
-   updates `test/test.js`, `test/test.native.js`, and `test/test.boost.js`, replacing the `delta`/`tol` computations with `t.strictEqual( isAlmostSameValue( actual, expected, N ), true, 'returns expected value' )` and removing the now unused `abs`, `maxn`, and `EPS` requires.

The ULP bounds below are the measured minimums: each test suite passes at `N` and fails at `N-1` over the full fixture set. The `test.native.js` bounds were measured against the compiled add-on (not merely copied from `test/test.js`), and the C implementation was found to agree with the JavaScript implementation exactly on every fixture value.

| File | Test | ULP |
| --- | --- | --- |
| `test/test.js`, `test/test.native.js` | gamma function (positive integers), `fixtures/r/data1.json` | 1009 |
| `test/test.js`, `test/test.native.js` | gamma function (decimal values), `fixtures/r/data2.json` | 1942 |
| `test/test.js`, `test/test.native.js` | small value approximation near left boundary | 1 |
| `test/test.js`, `test/test.native.js` | small value approximation near right boundary | 1 |
| `test/test.boost.js` | gamma function (positive integers), `fixtures/cpp/integers.json` | 3 |
| `test/test.boost.js` | gamma function (decimal values), `fixtures/cpp/decimals.json` | 11 |
| `test/test.boost.js` | gamma function (values near one), `fixtures/cpp/near_one.json` | 13 |

The larger bounds in `test/test.js` and `test/test.native.js` reflect the precision of the R-generated reference fixtures (the previous tolerance was `2.75e-12 * max( 1.0, abs( v ), abs( expected ) )`, i.e., roughly `1.2e4` ULP); the `test/test.boost.js` fixtures are C++/Boost generated and correspondingly tighter. In all cases the new assertions are stricter than the tolerances they replace.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Test suites were run twice at the final bounds to confirm determinism, and `make lint-javascript-tests TESTS_FILTER=".*/math/base/special/gamma/.*"` is clean. Only test files are changed.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task: it selected the package, performed the mechanical test migration, and searched for the minimum passing ULP bound for each test suite empirically (bisecting on the fixture data and confirming each `N` fails at `N-1`).

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMfFtAWAz2EFmrDvQcsqKA)_