### PR TITLE
test: migrate `stats/base/dists/discrete-uniform/entropy` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/entropy/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/entropy/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var entropy = require( './../lib' );
 
 
@@ -76,8 +75,6 @@ tape( 'if provided `a > b`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function returns the entropy of a discrete uniform distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -88,13 +85,7 @@ tape( 'the function returns the entropy of a discrete uniform distribution', fun
 	b = data.b;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/entropy/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/entropy/test/test.native.js
@@ -22,9 +22,8 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -60,8 +59,6 @@ tape( 'if provided `a > b`, the function returns `NaN`', opts, function test( t 
 
 tape( 'the function returns the entropy of a discrete uniform distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -72,13 +69,7 @@ tape( 'the function returns the entropy of a discrete uniform distribution', opt
 	b = data.b;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/discrete-uniform/entropy` from relative tolerance assertions to ULP difference assertions.

Specifically, in both `test/test.js` and `test/test.native.js`, the fixture loop previously branched on exact equality and otherwise compared a computed `delta` against a computed `tol` (`1.0 * EPS * abs( expected[ i ] )`). That branch is replaced with a single

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
```

assertion, `@stdlib/assert/is-almost-same-value` is added as a dependency of the tests, and the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires (along with the `delta` and `tol` locals) are removed.

**ULP bound: `0` (both `test/test.js` and `test/test.native.js`).**

The bound was tightened empirically: measuring `ulpdiff( y, expected[ i ] )` over the full 1000-case Julia fixture set yields a maximum ULP difference of `0`, i.e. every returned value is bit-for-bit identical to the expected value, so `0` is the minimum admissible value. This is expected, since both the JavaScript and C implementations compute `ln( b-a+1 )` via stdlib's own `ln` and therefore agree exactly.

Verification:

-   `make test TESTS_FILTER=".*/stats/base/dists/discrete-uniform/entropy/.*"` — 1008 passing in `test/test.js`.
-   The native add-on was built locally (`node-gyp rebuild`) so that `test/test.native.js` was not skipped — 1003 passing.
-   Both suites were run twice at the final bound to confirm the result is deterministic (no FMA/architecture-dependent variation).
-   `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/discrete-uniform/entropy/.*"` — clean.

Only the two test files are changed; no source, fixture, benchmark, or documentation files were touched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The `editorconfig` pre-commit hook could not run in this environment because it attempts to download the `editorconfig-checker` binary from GitHub releases, which is not reachable here. The two changed files were instead checked manually for the relevant `.editorconfig` rules (LF line endings, UTF-8, tab indentation, no trailing whitespace, final newline).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. Claude selected the package, mirrored the conversion idiom from previously merged ULP migration commits, measured the minimum ULP bound against the fixture set, and ran the tests and test linter locally.

* * *

@stdlib-js/reviewers


---
_Generated by [Claude Code](https://claude.ai/code/session_01CNj6Z8wGyBkXj4Jh3iEgXz)_