### PR TITLE
chore: fix JavaScript lint errors (issue #14727)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/bundle/pkg-list/examples/stdlib-namespaces/index.js
+++ b/lib/node_modules/@stdlib/_tools/bundle/pkg-list/examples/stdlib-namespaces/index.js
@@ -21,7 +21,7 @@
 var join = require( 'path' ).join;
 var logger = require( 'debug' );
 var mkdirp = require( 'mkdirp' ).sync;
-var collapse = require( 'bundle-collapser/plugin' );
+var collapse = require( 'bundle-collapser/plugin.js' );
 var uglifyify = require( 'uglifyify' );
 var uglify = require( 'uglify-js' );
 var pkgNames = require( '@stdlib/_tools/pkgs/names' ).sync;


### PR DESCRIPTION
## Description

Adds the missing `.js` file extension to the `bundle-collapser/plugin` require statement in the stdlib-namespaces example file.

The `stdlib/require-file-extensions` ESLint rule requires that require statements of files end with a whitelisted file extension (`.js`, `.json`, `.node`). The `bundle-collapser` package includes a `plugin.js` file, so adding the extension is the correct fix.

## Related Issues

Resolves #14727

## Changes

- `lib/node_modules/@stdlib/_tools/bundle/pkg-list/examples/stdlib-namespaces/index.js`: Changed `require( 'bundle-collapser/plugin')` to `require( 'bundle-collapser/plugin.js')`

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)