### PR TITLE
test: migrate `stats/base/dists/betaprime/kurtosis` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/kurtosis/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/kurtosis/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var kurtosis = require( './../lib' );
 
 
@@ -111,10 +110,8 @@ tape( 'if provided `beta <= 4`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the excess kurtosis of a beta prime distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -123,13 +120,7 @@ tape( 'the function returns the excess kurtosis of a beta prime distribution', f
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = kurtosis( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 320.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 369 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/kurtosis/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/kurtosis/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -120,10 +119,8 @@ tape( 'if provided `beta <= 4`, the function returns `NaN`', opts, function test
 
 tape( 'the function returns the excess kurtosis of a beta prime distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -132,13 +129,7 @@ tape( 'the function returns the excess kurtosis of a beta prime distribution', o
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = kurtosis( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 320.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 369 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/betaprime/kurtosis` from relative tolerance assertions to ULP difference assertions.

Specifically, in both `test/test.js` and `test/test.native.js`, the fixture loop previously branched on exact equality and otherwise compared a computed `delta` against a computed `tol` (`320.0 * EPS * abs( expected[ i ] )`). That branch is replaced with a single

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], 369 ), true, 'returns expected value' );
```

assertion, `@stdlib/assert/is-almost-same-value` is added as a dependency of the tests, and the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires (along with the `delta` and `tol` locals) are removed.

**ULP bound: `369` (both `test/test.js` and `test/test.native.js`).**

The bound was tightened empirically. Measuring `ulpdiff( y, expected[ i ] )` over the full 100-case Python fixture set yields a maximum ULP difference of `369`, attained at `alpha = 19.971069118488785`, `beta = 18.29265599414557`. Sweeping the bound upwards from `0` confirms `369` is the minimum admissible value: running the suite at `368` fails exactly that one case, while `369` passes all of them. The JavaScript and C implementations were measured independently and both require the same bound of `369`.

Verification:

-   `make test TESTS_FILTER=".*/stats/base/dists/betaprime/kurtosis/.*"` — 119 passing in `test/test.js`.
-   The native add-on was built locally (`node-gyp rebuild`) so that `test/test.native.js` was not skipped — 119 passing.
-   Both suites were run twice at the final bound to confirm the result is deterministic (no FMA/architecture-dependent variation).
-   `make eslint-tests TESTS_FILTER=".*/stats/base/dists/betaprime/kurtosis/.*"` — clean.

Only the two test files are changed; no source, fixture, benchmark, or documentation files were touched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The `editorconfig` pre-commit hook could not run in this environment because it attempts to download the `editorconfig-checker` binary from GitHub releases, which is not reachable here. The two changed files were instead checked manually for the relevant `.editorconfig` rules (LF line endings, UTF-8, tab indentation, no trailing whitespace, final newline).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. Claude selected the package, mirrored the conversion idiom from previously merged ULP migration commits, measured the minimum ULP bound against the fixture set, and ran the tests and test linter locally.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_013gUyuE14QfhKCjNXJ7RSJj)_