### PR TITLE
test: migrate `math/base/special/kernel-sincos` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/kernel-sincos/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-sincos/test/test.native.js
@@ -23,8 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var rempio2 = require( '@stdlib/math/base/special/rempio2' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -63,9 +62,7 @@ tape( 'the function returns `NaN` if provided a `NaN`', opts, function test( t )
 
 tape( 'the function evaluates the sine and cosine for input values on the interval `[-pi/4, pi/4]`', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -76,15 +73,9 @@ tape( 'the function evaluates the sine and cosine for input values on the interv
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = kernelSincos( x[i], 0.0 );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'returns expected value' );
-		} else {
-			delta = abs( y[0] - sine[i] );
 
-			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y[0], sine[ i ], 1 ), true, 'returns expected value' );
 		t.strictEqual( y[1], cosine[ i ], 'returns expected value' );
 	}
 	t.end();
@@ -92,9 +83,7 @@ tape( 'the function evaluates the sine and cosine for input values on the interv
 
 tape( 'the function can be used to compute the sine and cosine for input values outside of `[-pi/4, pi/4]` after argument reduction via `rempio2` (positive)', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var out;
 	var x;
 	var y;
@@ -110,39 +99,21 @@ tape( 'the function can be used to compute the sine and cosine for input values 
 		switch ( n & 3 ) {
 		case 0:
 			out = kernelSincos( y[ 0 ], y[ 1 ] );
-			if ( out[0] === sine[ i ] ) {
-				t.strictEqual( out[0], sine[ i ], 'returns expected value' );
-			} else {
-				delta = abs( out[0] - sine[i] );
 
-				// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-				tol = EPS * abs( sine[i] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+out[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-			}
+			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+			t.strictEqual( isAlmostSameValue( out[0], sine[ i ], 1 ), true, 'returns expected value' );
 			t.strictEqual( out[1], cosine[ i ], 'returns expected value' );
 			break;
 		case 2:
 			out = kernelSincos( y[ 0 ], y[ 1 ] );
 			out[ 0 ] = -out[ 0 ];
 			out[ 1 ] = -out[ 1 ];
-			if ( out[0] === sine[ i ] ) {
-				t.strictEqual( out[0], sine[ i ], 'returns expected value' );
-			} else {
-				delta = abs( out[0] - sine[i] );
 
-				// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-				tol = EPS * abs( sine[i] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+out[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-			}
-			if ( out[1] === cosine[ i ] ) {
-				t.strictEqual( out[1], cosine[ i ], 'returns expected value' );
-			} else {
-				delta = abs( out[1] - cosine[i] );
+			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+			t.strictEqual( isAlmostSameValue( out[0], sine[ i ], 1 ), true, 'returns expected value' );
 
-				// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-				tol = EPS * abs( cosine[i] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+out[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-			}
+			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+			t.strictEqual( isAlmostSameValue( out[1], cosine[ i ], 1 ), true, 'returns expected value' );
 			break;
 		default:
 			break;
@@ -153,9 +124,7 @@ tape( 'the function can be used to compute the sine and cosine for input values 
 
 tape( 'the function can be used to compute the sine and cosine for input values outside of `[-pi/4, pi/4]` after argument reduction via `rempio2` (negative)', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var out;
 	var x;
 	var y;
@@ -171,39 +140,21 @@ tape( 'the function can be used to compute the sine and cosine for input values 
 		switch ( n & 3 ) {
 		case 0:
 			out = kernelSincos( y[ 0 ], y[ 1 ] );
-			if ( out[0] === sine[ i ] ) {
-				t.strictEqual( out[0], sine[ i ], 'returns expected value' );
-			} else {
-				delta = abs( out[0] - sine[i] );
 
-				// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-				tol = EPS * abs( sine[i] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+out[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-			}
+			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+			t.strictEqual( isAlmostSameValue( out[0], sine[ i ], 1 ), true, 'returns expected value' );
 			t.strictEqual( out[1], cosine[ i ], 'returns expected value' );
 			break;
 		case 2:
 			out = kernelSincos( y[ 0 ], y[ 1 ] );
 			out[ 0 ] = -out[ 0 ];
 			out[ 1 ] = -out[ 1 ];
-			if ( out[0] === sine[ i ] ) {
-				t.strictEqual( out[0], sine[ i ], 'returns expected value' );
-			} else {
-				delta = abs( out[0] - sine[i] );
 
-				// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-				tol = EPS * abs( sine[i] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+out[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-			}
-			if ( out[1] === cosine[ i ] ) {
-				t.strictEqual( out[1], cosine[ i ], 'returns expected value' );
-			} else {
-				delta = abs( out[1] - cosine[i] );
+			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+			t.strictEqual( isAlmostSameValue( out[0], sine[ i ], 1 ), true, 'returns expected value' );
 
-				// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-				tol = EPS * abs( cosine[i] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+out[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-			}
+			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+			t.strictEqual( isAlmostSameValue( out[1], cosine[ i ], 1 ), true, 'returns expected value' );
 			break;
 		default:
 			break;


### PR DESCRIPTION
Resolves a part of #11352 

## Description

> What is the purpose of this pull request?

This pull request:

- migrates test/test.native.js of math/base/special/kernel-sincos from relative tolerance (EPS-based) assertions to ULP difference assertions via @stdlib/assert/is-almost-same-value.
- replaces the existing delta/tol tolerance-based assertions for the sine and cosine results with isAlmostSameValue assertions.
- removes the unused abs and EPS requires and the corresponding delta and tol variable declarations.
- applies a 1 ULP tolerance to the native implementation while retaining the existing exact-value assertions where applicable.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
