### PR TITLE
test: migrate `math/base/special/gammaincinv` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/gammaincinv/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/gammaincinv/test/test.js
@@ -184,7 +184,7 @@ tape( 'the function inverts the lower incomplete gamma function', function test(
 		b2 = isnan( expected[ i ] );
 		t.strictEqual( b1, b2, 'returned result is ' + ( (b1) ? '' : 'not' ) + ' NaN' );
 		if ( !b1 || !b2 ) {
-			t.strictEqual( isAlmostSameValue( actual, expected[ i ], 3.0 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValue( actual, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -206,7 +206,7 @@ tape( 'the function inverts the upper incomplete gamma function when `upper=true
 		b2 = isnan( upperExpected[ i ] );
 		t.strictEqual( b1, b2, 'returned result is ' + ( (b1) ? '' : 'not' ) + ' NaN' );
 		if ( !b1 || !b2 ) {
-			t.strictEqual( isAlmostSameValue( actual, upperExpected[ i ], 40.0 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValue( actual, upperExpected[ i ], 40 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -228,7 +228,7 @@ tape( 'the function inverts the lower incomplete gamma function for `p` smaller 
 		b2 = isnan( smallExpected[ i ] );
 		t.strictEqual( b1, b2, 'returned result is ' + ( (b1) ? '' : 'not' ) + ' NaN' );
 		if ( !b1 || !b2 ) {
-			t.strictEqual( isAlmostSameValue( actual, smallExpected[ i ], 375.0 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValue( actual, smallExpected[ i ], 375 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -251,7 +251,7 @@ tape( 'the function inverts the lower incomplete gamma function for `p` larger t
 		b2 = isnan( largeExpected[ i ] );
 		t.strictEqual( b1, b2, 'returned result is ' + ( (b1) ? '' : 'not' ) + ' NaN' );
 		if ( !b1 || !b2 ) {
-			t.strictEqual( isAlmostSameValue( actual, largeExpected[ i ], 45.0 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValue( actual, largeExpected[ i ], 45 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/gammaincinv/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/gammaincinv/test/test.js
@@ -24,7 +24,6 @@ var tape = require( 'tape' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
 var isfinite = require( '@stdlib/math/base/assert/is-finite' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var gammaincinv = require( './../lib' );
@@ -185,7 +184,7 @@ tape( 'the function inverts the lower incomplete gamma function', function test(
 		b2 = isnan( expected[ i ] );
 		t.strictEqual( b1, b2, 'returned result is ' + ( (b1) ? '' : 'not' ) + ' NaN' );
 		if ( !b1 || !b2 ) {
-			t.ok( abs( actual - expected[ i ] ) < 4e-14, 'returned result is within tolerance. actual: ' + actual + '; expected: ' + expected[ i ] + '.' );
+			t.strictEqual( isAlmostSameValue( actual, expected[ i ], 3.0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -207,7 +206,7 @@ tape( 'the function inverts the upper incomplete gamma function when `upper=true
 		b2 = isnan( upperExpected[ i ] );
 		t.strictEqual( b1, b2, 'returned result is ' + ( (b1) ? '' : 'not' ) + ' NaN' );
 		if ( !b1 || !b2 ) {
-			t.strictEqual( isAlmostSameValue( actual, upperExpected[ i ], 40.0 ), true, 'returned result is within tolerance. actual: ' + actual + '; expected: ' + upperExpected[ i ] + '.' );
+			t.strictEqual( isAlmostSameValue( actual, upperExpected[ i ], 40.0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -229,7 +228,7 @@ tape( 'the function inverts the lower incomplete gamma function for `p` smaller 
 		b2 = isnan( smallExpected[ i ] );
 		t.strictEqual( b1, b2, 'returned result is ' + ( (b1) ? '' : 'not' ) + ' NaN' );
 		if ( !b1 || !b2 ) {
-			t.ok( abs( actual - smallExpected[ i ] ) < 6e-15, 'returned result is within tolerance. actual: ' + actual + '; expected: ' + smallExpected[ i ] + '.' );
+			t.strictEqual( isAlmostSameValue( actual, smallExpected[ i ], 375.0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -252,7 +251,7 @@ tape( 'the function inverts the lower incomplete gamma function for `p` larger t
 		b2 = isnan( largeExpected[ i ] );
 		t.strictEqual( b1, b2, 'returned result is ' + ( (b1) ? '' : 'not' ) + ' NaN' );
 		if ( !b1 || !b2 ) {
-			t.ok( abs( actual - largeExpected[ i ] ) < 2e-13, 'returned result is within tolerance. actual: ' + actual + '; expected: ' + largeExpected[ i ] + '.' );
+			t.strictEqual( isAlmostSameValue( actual, largeExpected[ i ], 45.0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for math/base/special/gammaincinv from relative tolerance (abs-based) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
- updates test/test.js only. test/test.native.js was already migrated to ULP-based testing prior to this PR and is unchanged.
- removes the now-unused abs import.
The ULP bound was tightened empirically: starting from the maximum observed ULP difference across each fixture set and confirming that one less fails at least one assertion.

Measured minimum ULP bounds (test/test.js):

| Fixture                          | ULP   |
|-----------------------------------|-------|
| general (arg1/arg2/expected)      | 3.0   |
| small p (p < 1e-4)                | 375.0 |
| large p (p > 0.9)                 | 45.0  |

Each bound is the exact minimum that passes: lowering any of the three by 1 causes at least one assertion to fail. The pre-existing "upper incomplete gamma" block (already using isAlmostSameValue with 40.0) was not touched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
