### PR TITLE
test: migrate `stats/base/dists/rayleigh/variance` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/variance/test/test.js
@@ -27,11 +27,6 @@ var NINF = require( '@stdlib/constants/float64/ninf' );
 var variance = require( './../lib' );
 
 
-// VARIABLES //
-
-var ULP = 1;
-
-
 // FIXTURES //
 
 var data = require( './fixtures/julia/data.json' );
@@ -73,7 +68,7 @@ tape( 'the function returns the variance of a Rayleigh distribution', function t
 	sigma = data.sigma;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = variance( sigma[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/variance/test/test.js
@@ -21,11 +21,15 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var variance = require( './../lib' );
+
+
+// VARIABLES //
+
+var ULP = 1;
 
 
 // FIXTURES //
@@ -61,9 +65,7 @@ tape( 'if provided a scale `sigma` that is not a nonnegative number, the functio
 
 tape( 'the function returns the variance of a Rayleigh distribution', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var y;
 
@@ -71,13 +73,7 @@ tape( 'the function returns the variance of a Rayleigh distribution', function t
 	sigma = data.sigma;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = variance( sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], ', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/variance/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/variance/test/test.native.js
@@ -34,7 +34,6 @@ var variance = tryRequire( resolve( __dirname, './../lib/native.js' ) );
 var opts = {
 	'skip': ( variance instanceof Error )
 };
-var ULP = 1;
 
 
 // FIXTURES //
@@ -78,7 +77,7 @@ tape( 'the function returns the variance of a Rayleigh distribution', opts, func
 	sigma = data.sigma;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = variance( sigma[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/variance/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/variance/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -35,6 +34,7 @@ var variance = tryRequire( resolve( __dirname, './../lib/native.js' ) );
 var opts = {
 	'skip': ( variance instanceof Error )
 };
+var ULP = 1;
 
 
 // FIXTURES //
@@ -70,9 +70,7 @@ tape( 'if provided a scale `sigma` that is not a nonnegative number, the functio
 
 tape( 'the function returns the variance of a Rayleigh distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var y;
 
@@ -80,13 +78,7 @@ tape( 'the function returns the variance of a Rayleigh distribution', opts, func
 	sigma = data.sigma;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = variance( sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], ', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the test suite for `@stdlib/stats/base/dists/rayleigh/variance` from relative-tolerance testing to ULP (units in the last place) based assertions, per the migration described in #11352.
-   Replaces the `delta`/`tol` relative-tolerance comparison in the fixture-driven test with `@stdlib/assert/is-almost-same-value`, using a single named `ULP` constant declared at the top of each test file.
-   Applies the change to both `test/test.js` and `test/test.native.js`.
-   The measured minimum ULP bound required for the full fixture set to pass is **`ULP = 1`** (computed directly from the ULP distance between actual and expected values across all fixtures, and confirmed by two full, deterministic test runs).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, running as an unattended scheduled task. It searched the repository for packages still using the relative-tolerance test idiom, studied the git history of several already-converted packages (including the sibling package `stats/base/dists/rayleigh/cdf`) to mirror the established idiom, applied the conversion, and determined the minimum ULP bound by computing the exact ULP distance between actual and expected values across the fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gq3QMPaaCzn3MByHKYd6ud)_