### PR TITLE
test: migrate `stats/base/dists/halfnormal/logpdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/logpdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/logpdf/test/test.factory.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -94,8 +93,6 @@ tape( 'the created function returns `-Infinity` if provided `x < 0`', function t
 
 tape( 'the created function evaluates the logpdf', function test( t ) {
 	var logpdf;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -105,13 +102,7 @@ tape( 'the created function evaluates the logpdf', function test( t ) {
 		logpdf = factory( data.sigma[i] );
 		y = logpdf( x[i] );
 		if ( data.expected[i] !== null ) {
-			if ( y === data.expected[i] ) {
-				t.strictEqual( y, data.expected[i], 'x: '+x[i]+', sigma: '+data.sigma[i]+', y: '+y+', expected: '+data.expected[i] );
-			} else {
-				delta = abs( y - data.expected[ i ] );
-				tol = 40.0 * EPS * abs( data.expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+data.sigma[i]+'. y: '+y+'. E: '+data.expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, data.expected[ i ], 4 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/logpdf/test/test.logpdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/logpdf/test/test.logpdf.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logpdf = require( './../lib/main.js' );
 
 
@@ -75,9 +74,7 @@ tape( 'if provided `x < 0`, the function returns `-Infinity`', function test( t 
 
 tape( 'the function evaluates the logpdf', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -89,13 +86,7 @@ tape( 'the function evaluates the logpdf', function test( t ) {
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 40.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/logpdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/logpdf/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -84,9 +83,7 @@ tape( 'if provided `x < 0`, the function returns `-Infinity`', opts, function te
 
 tape( 'the function evaluates the logpdf', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -98,13 +95,7 @@ tape( 'the function evaluates the logpdf', opts, function test( t ) {
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 40.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/halfnormal/logpdf` from relative tolerance testing to ULP difference testing.

Specifically, `test/test.logpdf.js`, `test/test.factory.js`, and `test/test.native.js` are updated to replace the `delta`/`tol` computation (previously `40.0 * EPS * abs( expected[ i ] )`) with `@stdlib/assert/is-almost-same-value`, and the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires are removed.

The ULP constant used in all three files is **4**, which is the measured minimum over the full 1000-case Julia fixture set:

-   `main.js` (JavaScript): maximum observed ULP difference is 4.
-   `factory.js` (JavaScript): maximum observed ULP difference is 4.
-   `native.js` (C): maximum observed ULP difference is 4.

The bound was tightened from a high starting value down to the smallest integer which still passes; at `3` all three files fail two assertions (the worst case being `x = 0.2430826624208926`, `sigma = 0.1403330726611418`, where the expected value is `0.23771503646137082` and the returned value is `0.2377150364613707`). The full suite was run twice at `4` to confirm the result is deterministic, once with the native add-on built locally so that `test.native.js` was exercised rather than skipped.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Only test files are modified; no source, documentation, or benchmark files are touched.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated conversion task. The migration mirrors the idiom established in previously merged conversions (e.g. `stats/base/dists/laplace/logpdf`), and the ULP bound was determined empirically by measuring the per-fixture ULP difference and verifying that the next smaller bound fails.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_017DVQFhN7YRDovSi3Zxt3sL)_