### PR TITLE
feat: add C implementation for `stats/base/ndarray/snanmskmax`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/README.md
@@ -44,8 +44,8 @@ Computes the maximum value of a one-dimensional single-precision floating-point 
 var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
 var Uint8Vector = require( '@stdlib/ndarray/vector/uint8' );
 
-var x = new Float32Vector( [ 1.0, -2.0, 4.0, 2.0 ] );
-var mask = new Uint8Vector( [ 0, 0, 1, 0 ] );
+var x = new Float32Vector( [ 1.0, -2.0, 4.0, 2.0, NaN ] );
+var mask = new Uint8Vector( [ 0, 0, 1, 0, 0 ] );
 
 var v = snanmskmax( [ x, mask ] );
 // returns 2.0

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/benchmark/benchmark.native.js
@@ -1,0 +1,144 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var bernoulli = require( '@stdlib/random/base/bernoulli' );
+var fillBy = require( '@stdlib/ndarray/fill-by' );
+var zeros = require( '@stdlib/ndarray/zeros' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var resolve = require( 'path' ).resolve;
+var tryRequire = require( '@stdlib/utils/try-require' );
+var snanmskmax = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+
+var opts = {
+	'skip': snanmskmax instanceof Error
+};
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'float32'
+};
+var moptions = {
+	'dtype': 'uint8'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Returns a random number.
+*
+* @private
+* @returns {number} random number
+*/
+function rand() {
+	if ( bernoulli( 0.8 ) < 1 ) {
+		return NaN;
+	}
+	return uniform( -10.0, 10.0 );
+}
+
+/**
+* Returns a random mask value.
+*
+* @private
+* @returns {integer} random mask value
+*/
+function mrand() {
+	return bernoulli( 0.2 );
+}
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var mask;
+	var x;
+
+	x = fillBy( zeros( [ len ], options ), rand );
+	mask = fillBy( zeros( [ len ], moptions ), mrand );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			x.set( i%len, i );
+			v = snanmskmax( [ x, mask ] );
+			if ( isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:len=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/benchmark/benchmark.native.js
@@ -20,19 +20,19 @@
 
 // MODULES //
 
+var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var bernoulli = require( '@stdlib/random/base/bernoulli' );
+var tryRequire = require( '@stdlib/utils/try-require' );
 var fillBy = require( '@stdlib/ndarray/fill-by' );
 var zeros = require( '@stdlib/ndarray/zeros' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
-var resolve = require( 'path' ).resolve;
-var tryRequire = require( '@stdlib/utils/try-require' );
-var snanmskmax = tryRequire( resolve( __dirname, './../lib/native.js' ) );
 
+var snanmskmax = tryRequire( resolve( __dirname, './../lib/native.js' ) );
 var opts = {
 	'skip': snanmskmax instanceof Error
 };
@@ -137,7 +137,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		bench( format( '%s:len=%d', pkg, len ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/benchmark/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.length.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/benchmark/c/benchmark.length.c
@@ -1,0 +1,168 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/ndarray/snanmskmax.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/dtypes.h"
+#include "stdlib/ndarray/orders.h"
+#include "stdlib/ndarray/index_modes.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+#include <sys/time.h>
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total );
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param iterations   number of iterations
+* @param elapsed      elapsed time in seconds
+*/
+static void print_results( int iterations, double elapsed ) {
+	double rate = (double)iterations / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", iterations );
+	printf( "  elapsed: %g\n", elapsed );
+	printf( "  rate: %g\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec / 1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1).
+*
+* @return random number
+*/
+static float rand_float( void ) {
+	return (float)rand() / ( (float)RAND_MAX + 1.0f );
+}
+
+/**
+* Runs a benchmark.
+*
+* @param iterations   number of iterations
+* @param len          array length
+* @return             elapsed time in seconds
+*/
+static double benchmark( int iterations, int len ) {
+	float *x;
+	uint8_t *mask;
+	int i;
+	double t;
+	double elapsed;
+
+	x = (float *)malloc( len * sizeof( float ) );
+	mask = (uint8_t *)malloc( len * sizeof( uint8_t ) );
+	if ( x == NULL || mask == NULL ) {
+		printf( "unable to allocate memory\n" );
+		exit( 1 );
+	}
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = ( rand_float() * 20.0f ) - 10.0f;
+		mask[ i ] = ( rand_float() < 0.2f ) ? 1 : 0;
+	}
+
+	int64_t shape[] = { len };
+	int64_t strides[] = { 1 };
+	int64_t mstrides[] = { 1 };
+
+	// cppcheck-suppress invalidPointerCast
+	struct ndarray *X = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT32, (uint8_t *)x, 1, shape, strides, 0, STDLIB_NDARRAY_ROW_MAJOR, STDLIB_NDARRAY_INDEX_ERROR, 1, (int8_t[]){ STDLIB_NDARRAY_INDEX_ERROR } );
+	// cppcheck-suppress invalidPointerCast
+	struct ndarray *Mask = stdlib_ndarray_allocate( STDLIB_NDARRAY_UINT8, (uint8_t *)mask, 1, shape, mstrides, 0, STDLIB_NDARRAY_ROW_MAJOR, STDLIB_NDARRAY_INDEX_ERROR, 1, (int8_t[]){ STDLIB_NDARRAY_INDEX_ERROR } );
+
+	const struct ndarray *arrays[] = { X, Mask };
+
+	float v = 0.0f;
+	t = tic();
+	for ( i = 0; i < iterations; i++ ) {
+		v = stdlib_stats_snanmskmax( arrays );
+		if ( v != v ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( v != v ) {
+		printf( "should not return NaN\n" );
+	}
+	stdlib_ndarray_free( X );
+	stdlib_ndarray_free( Mask );
+
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int count;
+	int iter;
+	int len;
+	int i;
+
+	// Use a reproducible random seed:
+	srand( 1 );
+
+	print_version();
+	count = 0;
+	for ( i = 1; i <= 6; i++ ) {
+		len = (int)pow( 10, i );
+		iter = 1000000 / (int)pow( 10, i-1 );
+		printf( "# c::%s:len=%d\n", "snanmskmax", len );
+		elapsed = benchmark( iter, len );
+		print_results( iter, elapsed );
+		printf( "ok %d benchmark finished\n", ++count );
+	}
+	print_summary( count, count );
+
+	return 0;
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/examples/c/example.c
@@ -1,0 +1,65 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/ndarray/snanmskmax.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/dtypes.h"
+#include "stdlib/ndarray/orders.h"
+#include "stdlib/ndarray/index_modes.h"
+#include <stdint.h>
+#include <stdio.h>
+
+int main( void ) {
+	float x[] = { 1.0f, -2.0f, 4.0f, 2.0f };
+	uint8_t mask[] = { 0, 0, 1, 0 };
+
+	int64_t ndims = 1;
+	int64_t shape[] = { 4 };
+	int64_t strides[] = { 4 };
+	int64_t mstrides[] = { 1 };
+	int64_t offset = 0;
+	enum STDLIB_NDARRAY_ORDER order = STDLIB_NDARRAY_ROW_MAJOR;
+	enum STDLIB_NDARRAY_INDEX_MODE imode = STDLIB_NDARRAY_INDEX_ERROR;
+	int8_t submodes[] = { imode };
+	int64_t nsubmodes = 1;
+
+	// cppcheck-suppress invalidPointerCast
+	struct ndarray *X = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT32, (uint8_t *)x, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+	if ( X == NULL ) {
+		printf( "Error allocating memory.\n" );
+		return 1;
+	}
+
+	// cppcheck-suppress invalidPointerCast
+	struct ndarray *Mask = stdlib_ndarray_allocate( STDLIB_NDARRAY_UINT8, (uint8_t *)mask, ndims, shape, mstrides, offset, order, imode, nsubmodes, submodes );
+	if ( Mask == NULL ) {
+		printf( "Error allocating memory.\n" );
+		stdlib_ndarray_free( X );
+		return 1;
+	}
+
+	const struct ndarray *arrays[] = { X, Mask };
+
+	float v = stdlib_stats_snanmskmax( arrays );
+	printf( "Maximum value: %f\n", v );
+
+	stdlib_ndarray_free( X );
+	stdlib_ndarray_free( Mask );
+
+	return 0;
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/include.gypi
@@ -1,0 +1,51 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/include/stdlib/stats/base/ndarray/snanmskmax.h
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/include/stdlib/stats/base/ndarray/snanmskmax.h
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_STATS_BASE_NDARRAY_snanmskmax_H
+#define STDLIB_STATS_BASE_NDARRAY_snanmskmax_H
+
+#include "stdlib/ndarray/ctor.h"
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Compute the maximum value of a one-dimensional single-precision floating-point ndarray according to a mask, ignoring `NaN` values.
+*/
+float stdlib_stats_snanmskmax( const struct ndarray *arrays[] );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_STATS_BASE_NDARRAY_snanmskmax_H

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/lib/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@
 * var Uint8Vector = require( '@stdlib/ndarray/vector/uint8' );
 * var snanmskmax = require( '@stdlib/stats/base/ndarray/snanmskmax' );
 *
-* var x = new Float32Vector( [ 1.0, -2.0, 4.0, 2.0 ] );
-* var mask = new Uint8Vector( [ 0, 0, 1, 0 ] );
+* var x = new Float32Vector( [ 1.0, -2.0, 4.0, 2.0, NaN ] );
+* var mask = new Uint8Vector( [ 0, 0, 1, 0, 0 ] );
 *
 * var v = snanmskmax( [ x, mask ] );
 * // returns 2.0
@@ -37,6 +37,9 @@
 
 // MODULES //
 
+var join = require( 'path' ).join;
+var tryRequire = require( '@stdlib/utils/try-require' );
+var isError = require( '@stdlib/assert/is-error' );
 var main = require( './main.js' );
 
 
@@ -53,4 +56,4 @@ if ( isError( tmp ) ) {
 
 // EXPORTS //
 
-module.exports = main;
+module.exports = snanmskmax;

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/lib/index.js
@@ -40,6 +40,17 @@
 var main = require( './main.js' );
 
 
+// MAIN //
+
+var snanmskmax;
+var tmp = tryRequire( join( __dirname, './native.js' ) );
+if ( isError( tmp ) ) {
+	snanmskmax = main;
+} else {
+	snanmskmax = tmp;
+}
+
+
 // EXPORTS //
 
 module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/lib/native.js
@@ -20,17 +20,15 @@
 
 // MODULES //
 
-var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
-var getStride = require( '@stdlib/ndarray/base/stride' );
-var getOffset = require( '@stdlib/ndarray/base/offset' );
+var serialize = require( '@stdlib/ndarray/base/serialize-meta-data' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
-var strided = require( '@stdlib/stats/strided/snanmskmax' ).ndarray;
+var addon = require( './../src/addon.node' );
 
 
 // MAIN //
 
 /**
-* Computes the maximum value of a one-dimensional single-precision floating-point ndarray according to a mask, ignoring `NaN` values.
+* Compute the maximum value of a one-dimensional single-precision floating-point ndarray according to a mask, ignoring `NaN` values.
 *
 * ## Notes
 *
@@ -55,7 +53,7 @@ var strided = require( '@stdlib/stats/strided/snanmskmax' ).ndarray;
 function snanmskmax( arrays ) {
 	var mask = arrays[ 1 ];
 	var x = arrays[ 0 ];
-	return strided( numelDimension( x, 0 ), getData( x ), getStride( x, 0 ), getOffset( x ), getData( mask ), getStride( mask, 0 ), getOffset( mask ) ); // eslint-disable-line max-len
+	return addon( getData( x ), serialize( x ), getData( mask ), serialize( mask ) ); // eslint-disable-line max-len
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/manifest.json
@@ -1,0 +1,109 @@
+{
+  "options": {
+    "task": "build",
+    "wasm": false
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/math/base/assert/is-positive-zerof",
+        "@stdlib/ndarray/ctor",
+        "@stdlib/ndarray/base/napi/addon-arguments",
+        "@stdlib/napi/export",
+        "@stdlib/napi/argv",
+        "@stdlib/napi/create-double"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/math/base/assert/is-positive-zerof",
+        "@stdlib/ndarray/ctor",
+        "@stdlib/ndarray/dtypes",
+        "@stdlib/ndarray/index-modes",
+        "@stdlib/ndarray/orders",
+        "@stdlib/ndarray/base/bytes-per-element"
+      ]
+    },
+    {
+      "task": "examples",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/math/base/assert/is-positive-zerof",
+        "@stdlib/ndarray/ctor",
+        "@stdlib/ndarray/dtypes",
+        "@stdlib/ndarray/index-modes",
+        "@stdlib/ndarray/orders",
+        "@stdlib/ndarray/base/bytes-per-element"
+      ]
+    },
+    {
+      "task": "",
+      "wasm": true,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/ndarray/ctor"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/package.json
@@ -14,11 +14,14 @@
     }
   ],
   "main": "./lib",
+  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
+    "include": "./include",
     "lib": "./lib",
+    "src": "./src",
     "test": "./test"
   },
   "types": "./docs/types",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/src/addon.c
@@ -1,0 +1,63 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/ndarray/snanmskmax.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/base/napi/addon_arguments.h"
+#include "stdlib/napi/export.h"
+#include "stdlib/napi/create_double.h"
+#include "stdlib/napi/argv.h"
+#include <node_api.h>
+#include <assert.h>
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon( napi_env env, napi_callback_info info ) {
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 4 );
+
+	// Process provided arguments:
+	struct ndarray *arrays[ 2 ];
+	napi_value err;
+	napi_status status = stdlib_ndarray_napi_addon_arguments( env, argv, 4, 2, arrays, &err );
+	assert( status == napi_ok );
+	if ( err != NULL ) {
+		status = napi_throw( env, err );
+		assert( status == napi_ok );
+		return NULL;
+	}
+	// Create a const-qualified view of the argument pointer list:
+	const struct ndarray *arr[ 2 ] = { arrays[ 0 ], arrays[ 1 ] };
+
+	// Perform computation:
+	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_stats_snanmskmax( arr ), v );
+
+	// Free allocated memory:
+	stdlib_ndarray_free( arrays[ 0 ] );
+	stdlib_ndarray_free( arrays[ 1 ] );
+	arrays[ 0 ] = NULL;
+	arrays[ 1 ] = NULL;
+
+	return v;
+}
+
+STDLIB_NAPI_MODULE_EXPORT_FCN( addon )

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/src/main.c
@@ -1,0 +1,105 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/ndarray/snanmskmax.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/math/base/assert/is_nanf.h"
+#include "stdlib/math/base/assert/is_positive_zerof.h"
+#include <stdint.h>
+
+/**
+* Computes the maximum value of a single-precision floating-point strided array according to a mask, ignoring `NaN` values.
+*
+* @param N             number of indexed elements
+* @param x             input array
+* @param strideX       x stride length
+* @param offsetX       starting index for x
+* @param mask          mask array
+* @param strideMask    mask stride length
+* @param offsetMask    starting index for mask
+* @return              maximum value
+*/
+static float stdlib_strided_snanmskmax_ndarray( const int64_t N, const float *x, const int64_t strideX, const int64_t offsetX, const uint8_t *mask, const int64_t strideMask, const int64_t offsetMask ) {
+	int64_t ix;
+	int64_t im;
+	int64_t i;
+	float max;
+	float v;
+
+	if ( N <= 0 ) {
+		v = 0.0f;
+		return v / v; // NaN
+	}
+
+	ix = offsetX;
+	im = offsetMask;
+	
+	for ( i = 0; i < N; i++ ) {
+		if ( mask[ im ] == 0 ) {
+			v = x[ ix ];
+			if ( !stdlib_base_is_nanf( v ) ) {
+				max = v;
+				break;
+			}
+		}
+		ix += strideX;
+		im += strideMask;
+	}
+	if ( i == N ) {
+		v = 0.0f;
+		return v / v; // NaN
+	}
+	
+	i += 1;
+	ix += strideX;
+	im += strideMask;
+	for ( ; i < N; i++ ) {
+		if ( mask[ im ] == 0 ) {
+			v = x[ ix ];
+			if ( !stdlib_base_is_nanf( v ) ) {
+				if ( v > max || ( v == max && v == 0.0f && stdlib_base_is_positive_zerof( v ) ) ) {
+					max = v;
+				}
+			}
+		}
+		ix += strideX;
+		im += strideMask;
+	}
+	return max;
+}
+
+/**
+* Compute the maximum value of a one-dimensional single-precision floating-point ndarray according to a mask, ignoring `NaN` values.
+*
+* ## Notes
+*
+* -   The function expects the following ndarrays:
+*
+*     -   a one-dimensional input ndarray.
+*     -   a one-dimensional mask ndarray.
+*
+* @param arrays    list containing ndarrays
+* @return          maximum value
+*/
+float stdlib_stats_snanmskmax( const struct ndarray *arrays[] ) {
+	const struct ndarray *x = arrays[ 0 ];
+
+	const struct ndarray *mask = arrays[ 1 ];
+
+	return stdlib_strided_snanmskmax_ndarray( stdlib_ndarray_dimension( x, 0 ), (const float *)stdlib_ndarray_data( x ), stdlib_ndarray_stride_elements( x, 0 ), stdlib_ndarray_offset_elements( x ), (const uint8_t *)stdlib_ndarray_data( mask ), stdlib_ndarray_stride_elements( mask, 0 ), stdlib_ndarray_offset_elements( mask ) );
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/src/main.c
@@ -48,7 +48,7 @@ static float stdlib_strided_snanmskmax_ndarray( const int64_t N, const float *x,
 
 	ix = offsetX;
 	im = offsetMask;
-	
+
 	for ( i = 0; i < N; i++ ) {
 		if ( mask[ im ] == 0 ) {
 			v = x[ ix ];
@@ -64,7 +64,7 @@ static float stdlib_strided_snanmskmax_ndarray( const int64_t N, const float *x,
 		v = 0.0f;
 		return v / v; // NaN
 	}
-	
+
 	i += 1;
 	ix += strideX;
 	im += strideMask;

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/test/test.js
@@ -20,15 +20,16 @@
 
 // MODULES //
 
+var proxyquire = require( 'proxyquire' );
 var tape = require( 'tape' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
-var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var IS_BROWSER = require( '@stdlib/assert/is-browser' );
 var Float32Array = require( '@stdlib/array/float32' );
-var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
 var Uint8Array = require( '@stdlib/array/uint8' );
-var proxyquire = require( 'proxyquire' );
+var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var snanmskmax = require( './../lib' );
+
 
 // VARIABLES //
 

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/test/test.js
@@ -21,12 +21,20 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var Float32Array = require( '@stdlib/array/float32' );
-var Uint8Array = require( '@stdlib/array/uint8' );
-var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var Float32Array = require( '@stdlib/array/float32' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+var proxyquire = require( 'proxyquire' );
 var snanmskmax = require( './../lib' );
+
+// VARIABLES //
+
+var opts = {
+	'skip': IS_BROWSER
+};
 
 
 // FUNCTIONS //
@@ -53,6 +61,41 @@ tape( 'main export is a function', function test( t ) {
 	t.ok( true, __filename );
 	t.strictEqual( typeof snanmskmax, 'function', 'main export is a function' );
 	t.end();
+});
+
+tape( 'if a native implementation is available, the main export is the native implementation', opts, function test( t ) {
+	var snanmskmax = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
+
+	t.strictEqual( snanmskmax, mock, 'returns expected value' );
+	t.end();
+
+	function tryRequire() {
+		return mock;
+	}
+
+	function mock() {
+		// Mock...
+	}
+});
+
+tape( 'if a native implementation is not available, the main export is a JavaScript implementation', opts, function test( t ) {
+	var snanmskmax;
+	var main;
+
+	main = require( './../lib/main.js' );
+
+	snanmskmax = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
+
+	t.strictEqual( snanmskmax, main, 'returns expected value' );
+	t.end();
+
+	function tryRequire() {
+		return new Error( 'Cannot find module' );
+	}
 });
 
 tape( 'the function has an arity of 1', function test( t ) {

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/test/test.main.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/test/test.main.js
@@ -26,7 +26,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
-var snanmskmax = require( './../lib' );
+var snanmskmax = require( './../lib/main.js' );
 
 
 // FUNCTIONS //

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmskmax/test/test.native.js
@@ -20,13 +20,20 @@
 
 // MODULES //
 
+var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var Float32Array = require( '@stdlib/array/float32' );
-var Uint8Array = require( '@stdlib/array/uint8' );
-var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
+var Float32Array = require( '@stdlib/array/float32' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var Uint8Array = require( '@stdlib/array/uint8' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
-var snanmskmax = require( './../lib' );
+var isError = require( '@stdlib/assert/is-error' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+
+var snanmskmax = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': isError( snanmskmax )
+};
 
 
 // FUNCTIONS //
@@ -49,18 +56,18 @@ function vector( dtype, buffer, length, stride, offset ) {
 
 // TESTS //
 
-tape( 'main export is a function', function test( t ) {
+tape( 'main export is a function', opts, function test( t ) {
 	t.ok( true, __filename );
 	t.strictEqual( typeof snanmskmax, 'function', 'main export is a function' );
 	t.end();
 });
 
-tape( 'the function has an arity of 1', function test( t ) {
+tape( 'the function has an arity of 1', opts, function test( t ) {
 	t.strictEqual( snanmskmax.length, 1, 'has expected arity' );
 	t.end();
 });
 
-tape( 'the function calculates the maximum value of a one-dimensional ndarray according to a mask, ignoring `NaN` values', function test( t ) {
+tape( 'the function calculates the maximum value of a one-dimensional ndarray according to a mask, ignoring `NaN` values', opts, function test( t ) {
 	var mask;
 	var x;
 	var v;
@@ -118,7 +125,7 @@ tape( 'the function calculates the maximum value of a one-dimensional ndarray ac
 	t.end();
 });
 
-tape( 'if provided an empty ndarray, the function returns `NaN`', function test( t ) {
+tape( 'if provided an empty ndarray, the function returns `NaN`', opts, function test( t ) {
 	var mask;
 	var x;
 	var v;
@@ -132,7 +139,7 @@ tape( 'if provided an empty ndarray, the function returns `NaN`', function test(
 	t.end();
 });
 
-tape( 'if provided an ndarray containing a single element, the function returns the first element', function test( t ) {
+tape( 'if provided an ndarray containing a single element, the function returns the first element', opts, function test( t ) {
 	var mask;
 	var x;
 	var v;
@@ -146,7 +153,7 @@ tape( 'if provided an ndarray containing a single element, the function returns 
 	t.end();
 });
 
-tape( 'the function supports one-dimensional ndarrays having non-unit strides', function test( t ) {
+tape( 'the function supports one-dimensional ndarrays having non-unit strides', opts, function test( t ) {
 	var mask;
 	var x;
 	var v;
@@ -182,7 +189,7 @@ tape( 'the function supports one-dimensional ndarrays having non-unit strides', 
 	t.end();
 });
 
-tape( 'the function supports one-dimensional ndarrays having negative strides', function test( t ) {
+tape( 'the function supports one-dimensional ndarrays having negative strides', opts, function test( t ) {
 	var mask;
 	var x;
 	var v;
@@ -218,7 +225,7 @@ tape( 'the function supports one-dimensional ndarrays having negative strides', 
 	t.end();
 });
 
-tape( 'the function supports one-dimensional ndarrays having non-zero offsets', function test( t ) {
+tape( 'the function supports one-dimensional ndarrays having non-zero offsets', opts, function test( t ) {
 	var mask;
 	var x;
 	var v;


### PR DESCRIPTION
Part of [#14034](https://github.com/stdlib-js/stdlib/issues/14034).

### Description
**What is the purpose of this pull request?**

This pull request:
- adds the native C implementation for `snanmskrange`.
- adds the Node-API boilerplate and `tryRequire` dispatcher to safely fall back to the pure JS implementation.
- includes the required C benchmarks, native JS benchmarks, and C examples mirroring the canonical structure.

### Related Issues
**Does this pull request have any related issues?**

This pull request has the following related issues:
- Part of [\[RFC\] : add C implementations for @stdlib/stats/base/ndarray packages (tracking issue) #14034](https://github.com/stdlib-js/stdlib/issues/14034)

### Questions
**Any questions for reviewers of this pull request?**

- No.

### Other
**Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.**

- No.

### Checklist
**Please ensure the following tasks are completed before submitting this pull request.**

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance
**When authoring the changes proposed in this PR, did you use any kind of AI assistance?**

- [x] Yes
- [ ] No

**If you answered "yes" above, how did you use AI assistance?**

- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [ ] Research and understanding

### Disclosure
**If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.**

I utilized AI assistance to help implement the documentation, carefully adhering to the provided reference implementations and canonical `@stdlib` structures.