### PR TITLE
chore: add missing metadata keywords to `stats/base/ndarray/dmeanstdev`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/ndarray/dmeanstdev/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dmeanstdev/package.json
@@ -50,8 +50,11 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
     "statistics",
     "stats",
+    "mathematics",
+    "math",
     "mean",
     "standard deviation",
     "stddev",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request adds the standard `stdmath`, `mathematics`, and `math` keywords to the `package.json` of `stats/base/ndarray/dmeanstdev`, the sole member of the 193-package `stats/base/ndarray` namespace that omitted them (99.5% sibling conformance). Metadata-only; no runtime behavior changes.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

### `stats/base/ndarray/dmeanstdev`

`dmeanstdev` carried a truncated keyword block missing `stdmath`, `mathematics`, and `math` — tags all 192 of its siblings use, including the `dmean` and `dstdev` reductions it combines. The omission is an authoring oversight, not a semantic distinction: the package computes the arithmetic mean and corrected sample standard deviation, squarely math and statistics. Restoring the three keywords aligns discoverability with the rest of the namespace and touches nothing else.

The correction was surfaced by a majority-vote drift scan: structural and semantic features were extracted from all 193 namespace members, the per-feature majority (≥75%) computed, and outliers validated before any change. This was the only high-signal, mechanical, non-behavioral correction to survive filtering. Candidate additions of the empty `__stdlib__` manifest key to three members were deliberately dropped — that field is present in under 40% of stdlib packages ecosystem-wide, so its local absence is not treated as drift. Signature differences (the `*-by` accessor variants) and native-only artifacts were excluded as intentional deviations, and features without a clear majority (README `References`/`C APIs` sections) were excluded from the vote.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was produced by an automated stdlib cross-package drift-detection routine running on Claude Code. The routine extracted per-package structural and semantic features across the `stats/base/ndarray` namespace, computed the majority convention per feature, validated the single surviving metadata outlier through independent review passes, and applied the mechanical keyword fix. The change was verified against the sibling majority pattern before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7qiwfpDQJsJ6FF93ykYae)_