### PR TITLE
test: migrate `stats/base/dists/pareto-type1/mean` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/mean/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mean = require( './../lib' );
 
 
@@ -111,10 +110,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the mean of a Pareto (Type I) distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -123,13 +120,7 @@ tape( 'the function returns the mean of a Pareto (Type I) distribution', functio
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = mean( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/mean/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -127,10 +126,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 
 tape( 'the function evaluates the mean for a Pareto Type I distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var y;
 	var i;
 
@@ -139,13 +136,7 @@ tape( 'the function evaluates the mean for a Pareto Type I distribution', opts, 
 	beta = data.beta;
 	for ( i = 0; i < alpha.length; i++ ) {
 		y = mean( alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'alpha: ' + alpha[ i ] + ', beta: ' + beta[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: ' + alpha[ i ] + '. beta: ' + beta[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/pareto-type1/mean` from relative tolerance testing to ULP difference testing, per #11352.

Changes are confined to `test/test.js` and `test/test.native.js`. In each, the fixture loop's `delta`/`tol` computation and the `y === expected[i]` branch are replaced with a single `isAlmostSameValue` assertion, `@stdlib/assert/is-almost-same-value` is added to the module requires, and the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires are removed.

**ULP bound: `0` in both `test/test.js` and `test/test.native.js`.**

This is the measured minimum, not a guess. Before editing, the JS and native implementations were each evaluated against all 1000 Julia fixture cases and the smallest passing ULP value was searched for per case; the maximum over the full fixture set was `0` for both — i.e. every returned value is bit-identical to the expected value. This is consistent with the implementation, which is a single multiply and a single divide, `( alpha*beta ) / ( alpha-1.0 )`, expressed identically in JavaScript and in C, with no multiply-add pattern available for contraction.

The previous bounds were `1.0 * EPS` (`test.js`) and `2.0 * EPS` (`test.native.js`); both are tightened to exact equality.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed:

-   `make test TESTS_FILTER=".*/stats/base/dists/pareto-type1/mean/.*"` passes.
-   The native addon was built locally so that `test/test.native.js` actually exercised the C implementation rather than being skipped; it passes with the same `0` ULP bound.
-   Both files were run twice at the final bound to confirm determinism (no FMA/architecture-dependent variation).
-   Both files lint clean under `etc/eslint/.eslintrc.tests.js`.
-   Only the two test files are changed; no build artifacts are included.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an automated task. The conversion follows the idiom already established by previously merged `stats/base/dists/pareto-type1` conversions (`median`, `mode`, `kurtosis`), and the ULP bound was determined empirically by measuring the per-case ULP distance across the full fixture set rather than by trial and error.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_019NmQ9EpAg228C666Z8Pr3U)_