### PR TITLE
test: migrate `math/base/special/betaln` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/betaln/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/betaln/test/test.native.js
@@ -25,9 +25,8 @@ var tape = require( 'tape' );
 var isInfinite = require( '@stdlib/math/base/assert/is-infinite' );
 var isnan = require( '@stdlib/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
 
 
 // VARIABLES //
@@ -90,8 +89,6 @@ tape( 'the function returns +Infinity if at least one argument is zero', opts, f
 
 tape( 'the function evaluates the natural logarithm of the beta function', opts, function test( t ) {
 	var actual;
-	var delta;
-	var tol;
 	var b1;
 	var b2;
 	var i;
@@ -105,9 +102,7 @@ tape( 'the function evaluates the natural logarithm of the beta function', opts,
 		b2 = isnan( expected[ i ] );
 		t.strictEqual( b1, b2, 'returned result is ' + ( (b1) ? '' : 'not' ) + ' NaN' );
 		if ( !b1 ) {
-			delta = abs( actual - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'returned result is within tolerance. actual: ' + actual + '; expected: ' + expected[ i ] + '.' );
+			t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of https://github.com/stdlib-js/stdlib/issues/11352.

## Description

This pull request migrates the native tests for `math/base/special/betaln` from relative-tolerance assertions to ULP-based assertions using `@stdlib/assert/is-almost-same-value`. The change is limited to this package's `test.native.js` file; no implementation or unrelated tests were changed.

The existing 2 ULP tolerance is preserved from the package's prior relative-tolerance budget, and the assertion message follows the RFC guidance.

## Testing

The repository's documented `make test` command could not be run in this Windows environment because GNU Make is unavailable. The focused test command should run in CI.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

### AI Assistance

- [x] Yes
- [ ] No

I used AI assistance to inspect the tracking issue and locate the existing relative-tolerance assertions. The code change itself is limited to the mechanical migration described by the RFC.