### PR TITLE
docs: improve doctests for ndarray instances in `ndarray/ones`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/ones/README.md
+++ b/lib/node_modules/@stdlib/ndarray/ones/README.md
@@ -122,7 +122,6 @@ var dt = String( getDType( arr ) );
 
 ```javascript
 var dtypes = require( '@stdlib/ndarray/dtypes' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var ones = require( '@stdlib/ndarray/ones' );
 
 // Get a list of data types:
@@ -135,7 +134,7 @@ for ( i = 0; i < dt.length; i++ ) {
     arr = ones( [ 2, 2 ], {
         'dtype': dt[ i ]
     });
-    console.log( ndarray2array( arr ) );
+    console.log( arr );
 }
 ```
 

--- a/lib/node_modules/@stdlib/ndarray/ones/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/ones/examples/index.js
@@ -19,7 +19,6 @@
 'use strict';
 
 var dtypes = require( '@stdlib/ndarray/dtypes' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var ones = require( './../lib' );
 
 // Get a list of data types:
@@ -32,5 +31,5 @@ for ( i = 0; i < dt.length; i++ ) {
 	arr = ones( [ 2, 2 ], {
 		'dtype': dt[ i ]
 	});
-	console.log( ndarray2array( arr ) );
+	console.log( arr );
 }


### PR DESCRIPTION
Progresses #9329.

## Description

> What is the purpose of this pull request?

This pull request:

-   Removes the ndarray2array import wherever it was only being used for illustrative doctest values.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-  #9329 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
