### PR TITLE
test: migrate `stats/base/dists/triangular/pdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/pdf/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -129,8 +128,6 @@ tape( 'the function returns `2/(b-a)` if provided `x = c`', opts, function test(
 
 tape( 'the function evaluates the pdf for `x` given a small range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -145,21 +142,13 @@ tape( 'the function evaluates the pdf for `x` given a small range `b - a`', opts
 	c = smallRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given a medium range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -174,21 +163,13 @@ tape( 'the function evaluates the pdf for `x` given a medium range `b - a`', opt
 	c = mediumRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given a large range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -203,13 +184,7 @@ tape( 'the function evaluates the pdf for `x` given a large range `b - a`', opts
 	c = largeRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/pdf/test/test.pdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( './../lib' );
 
 
@@ -120,8 +119,6 @@ tape( 'the function returns `2/(b-a)` if provided `x = c`', function test( t ) {
 
 tape( 'the function evaluates the pdf for `x` given a small range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -136,21 +133,13 @@ tape( 'the function evaluates the pdf for `x` given a small range `b - a`', func
 	c = smallRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given a medium range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -165,21 +154,13 @@ tape( 'the function evaluates the pdf for `x` given a medium range `b - a`', fun
 	c = mediumRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given a large range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -194,13 +175,7 @@ tape( 'the function evaluates the pdf for `x` given a large range `b - a`', func
 	c = largeRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the tests for `@stdlib/stats/base/dists/triangular/pdf` from relative-tolerance testing to ULP (units in the last place) difference testing, per the tracking issue.
-   Replaces the `delta`/`tol` (`EPS`-based) comparisons in `test/test.pdf.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' )`.
-   The minimum ULP bound (`1`) was determined by measuring the actual ULP difference between the computed and expected values across all three fixture sets (`small_range`, `medium_range`, `large_range`); the measured maximum ULP difference was `0` (exact matches) for both the JavaScript and native implementations, so `1` is used as the tightest bound with a minimal safety margin.
-   No other tests, behavior, or files were changed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, which selected the candidate package, studied prior-art conversions referenced in #11352, applied the `isAlmostSameValue` migration, and measured the minimum ULP bound against the fixtures.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rzw1RqpoWAyYt7LpzpLvNp)_