### PR TITLE
bench: refactor to use string interpolation in `stats/incr/nancv`

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nancv/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/incr/nancv/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var incrnancv = require( './../lib' );
 
@@ -46,7 +47,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::accumulator', function benchmark( b ) {
+bench( format( '%s::accumulator', pkg ), function benchmark( b ) {
 	var acc;
 	var v;
 	var i;
@@ -68,7 +69,7 @@ bench( pkg+'::accumulator', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::accumulator,known_mean', function benchmark( b ) {
+bench( format( '%s::accumulator,known_mean', pkg ), function benchmark( b ) {
 	var acc;
 	var v;
 	var i;


### PR DESCRIPTION
Progresses #8647.

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors the JavaScript benchmark in @stdlib/stats/incr/nancv to use @stdlib/string/format for string interpolation instead of string concatenation when specifying the benchmark name

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself."

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
