### PR TITLE
docs: add Git notes correcting recent commit messages

### DIFF
--- a/docs/git-notes/ff9f24a58f6622074b4ea9eb893cdb8d1526b74a.txt
+++ b/docs/git-notes/ff9f24a58f6622074b4ea9eb893cdb8d1526b74a.txt
@@ -1,0 +1,10 @@
+---
+type: amend-message
+---
+feat: add C implementation for `stats/base/dists/negative-binomial/logpmf`
+
+PR-URL: #10132
+
+Signed-off-by: Philipp Burckhardt <pburckhardt@outlook.com>
+Co-authored-by: Philipp Burckhardt <pburckhardt@outlook.com>
+Reviewed-by: Athan Reines <kgryte@gmail.com>


### PR DESCRIPTION
Audit of commits merged to `develop` in the last 24 hours (44 non-merge commits reviewed) for spelling/grammar errors, incorrect PR/issue references, malformed trailers, and Conventional Commits compliance.

One issue found:

- `ff9f24a5`: wrong `Reviewed-by` trailer — the merged commit for PR #10132 (`feat: add C implementation for stats/base/dists/negative-binomial/logpmf`) lists `Reviewed-by: Philipp Burckhardt <pburckhardt@outlook.com>`, but the PR's review history on GitHub shows only Athan Reines (`Planeshifter`) submitted an approving review; Philipp Burckhardt did not review the PR. The note corrects `Reviewed-by` to `Athan Reines <kgryte@gmail.com>` and preserves all other trailers as-is.

All other referenced `PR-URL`/`Closes`/`Ref` numbers pointing to `stdlib-js/stdlib` were spot-checked against the GitHub API and matched. References to `stdlib-js/metr-issue-tracker` issues could not be verified because this session's GitHub access is scoped to `stdlib-js/stdlib` only.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).