### PR TITLE
test: migrate `math/base/special/sincospi` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sincospi/test/test.assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/test/test.assign.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Float64Array = require( '@stdlib/array/float64' );
 var sincospi = require( './../lib/assign.js' );
@@ -137,7 +136,6 @@ tape( 'the function computes the sin(πx) and cos(πx) for fractional part equal
 });
 
 tape( 'the function computes the sin(πx) and cos(πx) for decimal input', function test( t ) {
-	var delta;
 	var out;
 	var x;
 	var y;
@@ -152,19 +150,8 @@ tape( 'the function computes the sin(πx) and cos(πx) for decimal input', funct
 		out = [ 0.0, 0.0 ];
 		y = sincospi( x[ i ], out, 1, 0 );
 		t.strictEqual( y, out, 'returns output array' );
-
-		if ( y[ 0 ] === s[ i ] ) {
-			t.strictEqual( y[ 0 ], s[ i ], 'x: '+x[ i ]+'. Expected: '+s[ i ] );
-		} else {
-			delta = abs( y[ 0 ] - s[ i ] );
-			t.ok( delta <= EPS, 'within tolerance. x: '+x[ i ]+'. Value: '+y[ 0 ]+'. Expected: '+s[ i ]+'. Tolerance: '+EPS+'.' );
-		}
-		if ( y[ 1 ] === c[ i ] ) {
-			t.strictEqual( y[ 1 ], c[ i ], 'x: '+x[ i ]+'. Expected: '+c[ i ] );
-		} else {
-			delta = abs( y[ 1 ] - c[ i ] );
-			t.ok( delta <= EPS, 'within tolerance. x: '+x[ i ]+'. Value: '+y[ 1 ]+'. Expected: '+c[ i ]+'. Tolerance: '+EPS+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], s[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], c[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/test/test.main.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var sincospi = require( './../lib/main.js' );
 
@@ -112,7 +111,6 @@ tape( 'the function computes the sin(πx) and cos(πx) for fractional part equal
 });
 
 tape( 'the function computes the sin(πx) and cos(πx) for decimal input', function test( t ) {
-	var delta;
 	var x;
 	var y;
 	var i;
@@ -124,19 +122,8 @@ tape( 'the function computes the sin(πx) and cos(πx) for decimal input', funct
 	c = decimals.cos;
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincospi( x[ i ] );
-
-		if ( y[ 0 ] === s[ i ] ) {
-			t.strictEqual( y[ 0 ], s[ i ], 'x: '+x[ i ]+'. Expected: '+s[ i ] );
-		} else {
-			delta = abs( y[ 0 ] - s[ i ] );
-			t.ok( delta <= EPS, 'within tolerance. x: '+x[ i ]+'. Value: '+y[ 0 ]+'. Expected: '+s[ i ]+'. Tolerance: '+EPS+'.' );
-		}
-		if ( y[ 1 ] === c[ i ] ) {
-			t.strictEqual( y[ 1 ], c[ i ], 'x: '+x[ i ]+'. Expected: '+c[ i ] );
-		} else {
-			delta = abs( y[ 1 ] - c[ i ] );
-			t.ok( delta <= EPS, 'within tolerance. x: '+x[ i ]+'. Value: '+y[ 1 ]+'. Expected: '+c[ i ]+'. Tolerance: '+EPS+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], s[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], c[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/test/test.native.js
@@ -23,10 +23,9 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -121,7 +120,6 @@ tape( 'the function computes the sin(πx) and cos(πx) for fractional part equal
 });
 
 tape( 'the function computes the sin(πx) and cos(πx) for decimal input', opts, function test( t ) {
-	var delta;
 	var x;
 	var y;
 	var i;
@@ -133,19 +131,8 @@ tape( 'the function computes the sin(πx) and cos(πx) for decimal input', opts,
 	c = decimals.cos;
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincospi( x[ i ] );
-
-		if ( y[ 0 ] === s[ i ] ) {
-			t.strictEqual( y[ 0 ], s[ i ], 'x: '+x[ i ]+'. Expected: '+s[ i ] );
-		} else {
-			delta = abs( y[ 0 ] - s[ i ] );
-			t.ok( delta <= EPS, 'within tolerance. x: '+x[ i ]+'. Value: '+y[ 0 ]+'. Expected: '+s[ i ]+'. Tolerance: '+EPS+'.' );
-		}
-		if ( y[ 1 ] === c[ i ] ) {
-			t.strictEqual( y[ 1 ], c[ i ], 'x: '+x[ i ]+'. Expected: '+c[ i ] );
-		} else {
-			delta = abs( y[ 1 ] - c[ i ] );
-			t.ok( delta <= EPS, 'within tolerance. x: '+x[ i ]+'. Value: '+y[ 1 ]+'. Expected: '+c[ i ]+'. Tolerance: '+EPS+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], s[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], c[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the tests for `math/base/special/sincospi` from relative/absolute tolerance testing to ULP difference testing, per #11352.
-   Replaces the `delta = abs( y - expected )` / `t.ok( delta <= EPS, ... )` blocks in the decimal fixture loops with `t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );`, adding the `@stdlib/assert/is-almost-same-value` require and removing the now-unused `@stdlib/constants/float64/eps` and `@stdlib/math/base/special/abs` requires.
-   Updates `test/test.main.js`, `test/test.assign.js`, and `test/test.native.js`. Only test files are changed; no implementation, fixture, or documentation changes.

**ULP bound: 1 ULP** (all three test files).

The bound was tightened to the measured minimum rather than assumed. Over the full `decimals` fixture set (2003 cases × sine and cosine = 4006 comparisons), the maximum ULP difference is exactly 1 for both the JavaScript and the C implementation. The `integers` fixture set matches exactly (0 ULP) and its assertions are left as strict equality, unchanged. The worst case for both implementations is identical:

```
x        = -99.5004995004995   (cos)
actual   = 0.0015692264556667224
expected = 0.0015692264556667226
```

A bound of `0` therefore fails, so `1` is the minimum passing integer.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   The idiom follows the previously merged conversions in this family, in particular `math/base/special/kernel-sincos` (#14751).
-   `test/test.main.js` and `test/test.assign.js` were run twice at the final bound to check for nondeterminism; both runs were identical (8618 and 12939 assertions respectively, all passing).
-   The C implementation's bound was measured by compiling `src/main.c` and its transitive C dependencies into a standalone harness and evaluating it over the same fixtures, since the native add-on is not built in this environment (`test/test.native.js` is skipped locally). Reviewers may wish to confirm the native tests pass in CI where the add-on is built.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running as an automated task configured by @kgryte. The test edits, the ULP measurement, and the verification runs described above were all performed by the agent. The idiom was mirrored from previously merged conversions in the same package family.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01KuxUAxpU3F8SUMrhwohMZT)_