### PR TITLE
test: migrate `stats/base/dists/erlang/pdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/pdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -168,9 +167,7 @@ tape( 'if provided `k` is not a nonnegative integer, the created function always
 tape( 'the created function evaluates the pdf for `x` given large `k` and `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var pdf;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -183,13 +180,7 @@ tape( 'the created function evaluates the pdf for `x` given large `k` and `lambd
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( k[i], lambda[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 180.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 271 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -197,9 +188,7 @@ tape( 'the created function evaluates the pdf for `x` given large `k` and `lambd
 tape( 'the created function evaluates the pdf for `x` given a large shape parameter `k`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var pdf;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -212,13 +201,7 @@ tape( 'the created function evaluates the pdf for `x` given a large shape parame
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( k[i], lambda[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 90.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 154 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -226,9 +209,7 @@ tape( 'the created function evaluates the pdf for `x` given a large shape parame
 tape( 'the created function evaluates the pdf for `x` given a large rate parameter `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var pdf;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -241,13 +222,7 @@ tape( 'the created function evaluates the pdf for `x` given a large rate paramet
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( k[i], lambda[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 100.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 146 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/pdf/test/test.pdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( './../lib' );
 
 
@@ -117,8 +116,6 @@ tape( 'if provided `lambda <= 0`, the function returns `NaN`', function test( t 
 tape( 'the function evaluates the pdf for `x` given large `k` and `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -130,13 +127,7 @@ tape( 'the function evaluates the pdf for `x` given large `k` and `lambda`', fun
 	lambda = bothLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 180.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 271 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -144,8 +135,6 @@ tape( 'the function evaluates the pdf for `x` given large `k` and `lambda`', fun
 tape( 'the function evaluates the pdf for `x` given large shape parameter `k`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -157,13 +146,7 @@ tape( 'the function evaluates the pdf for `x` given large shape parameter `k`', 
 	lambda = largeShape.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 90.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 154 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -171,8 +154,6 @@ tape( 'the function evaluates the pdf for `x` given large shape parameter `k`', 
 tape( 'the function evaluates the pdf for `x` given large rate parameter `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -184,13 +165,7 @@ tape( 'the function evaluates the pdf for `x` given large rate parameter `lambda
 	lambda = largeRate.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 100.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 146 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/erlang/pdf` from relative tolerance testing to ULP difference testing.

Specifically, `test/test.pdf.js` and `test/test.factory.js` are updated to replace the `delta`/`tol` computation with `@stdlib/assert/is-almost-same-value`, and the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires are removed. The package has no C implementation, so there is no `test/test.native.js` to update, and `test/test.js` contains no tolerance-based assertions.

Three Julia fixtures are exercised (1000 cases each), and each is given its own bound, which is the measured minimum over that fixture:

| Fixture | Previous tolerance | ULP bound | Worst case |
| --- | --- | --- | --- |
| `both_large.json` | `180.0 * EPS * abs( expected[ i ] )` | **271** | `x = 4.522887156354011`, `k = 11`, `lambda = 29.25588256202781` |
| `large_shape.json` | `90.0 * EPS * abs( expected[ i ] )` | **154** | `x = 0.0012734228532729208`, `k = 10`, `lambda = 5.668294773024138` |
| `large_rate.json` | `100.0 * EPS * abs( expected[ i ] )` | **146** | `x = 3.805558533887737`, `k = 7`, `lambda = 18.90381811016824` |

The bounds are identical for `main.js` and `factory.js`, as the latter delegates to the same code path.

Each bound was tightened from a high starting value down to the smallest integer which still passes over the full fixture set. At one ULP lower (`270`/`153`/`145`), exactly one assertion fails per fixture, confirming the bounds are minimal. The suite was run twice at the final bounds to confirm the result is deterministic.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Only test files are modified; no source, documentation, or benchmark files are touched.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated conversion task. The migration mirrors the idiom established in previously merged conversions (e.g. `stats/base/dists/halfnormal/logpdf`, `stats/base/dists/triangular/pdf`), and each ULP bound was determined empirically by measuring the per-fixture ULP difference and verifying that the next smaller bound fails.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtXPtWGkMoRUXLChqjqebJ)_