### PR TITLE
test: migrate `math/base/special/ellipj` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ellipj/test/test.assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/ellipj/test/test.assign.js
@@ -25,8 +25,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var HALF_PI = require( '@stdlib/constants/float64/half-pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var ellipj = require( './../lib/assign.js' );
 
 
@@ -100,8 +99,6 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (medium po
 	var snExpected;
 	var cnExpected;
 	var dnExpected;
-	var delta;
-	var tol;
 	var sn;
 	var cn;
 	var dn;
@@ -124,29 +121,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (medium po
 		cn = y[1];
 		dn = y[2];
 
-		if ( sn === snExpected[i] ) {
-			t.strictEqual( sn, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+sn+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( sn - snExpected[i] );
-			tol = 18.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+sn+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cn === cnExpected[i] ) {
-			t.strictEqual( cn, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cn+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cn - cnExpected[i] );
-			tol = 14.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cn+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dn === dnExpected[i] ) {
-			t.strictEqual( dn, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dn+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dn - dnExpected[i] );
-			tol = 40.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dn+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( sn, snExpected[i], 4750 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cn, cnExpected[i], 9327 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dn, dnExpected[i], 155 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -155,8 +132,6 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (modulus n
 	var snExpected;
 	var cnExpected;
 	var dnExpected;
-	var delta;
-	var tol;
 	var sn;
 	var cn;
 	var dn;
@@ -179,29 +154,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (modulus n
 		cn = y[1];
 		dn = y[2];
 
-		if ( sn === snExpected[i] ) {
-			t.strictEqual( sn, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+sn+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( sn - snExpected[i] );
-			tol = 7.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+sn+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cn === cnExpected[i] ) {
-			t.strictEqual( cn, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cn+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cn - cnExpected[i] );
-			tol = 5.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cn+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dn === dnExpected[i] ) {
-			t.strictEqual( dn, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dn+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dn - dnExpected[i] );
-			tol = 5.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dn+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( sn, snExpected[i], 9944 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cn, cnExpected[i], 12 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dn, dnExpected[i], 12 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -210,8 +165,6 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (small pos
 	var snExpected;
 	var cnExpected;
 	var dnExpected;
-	var delta;
-	var tol;
 	var sn;
 	var cn;
 	var dn;
@@ -234,29 +187,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (small pos
 		cn = y[1];
 		dn = y[2];
 
-		if ( sn === snExpected[i] ) {
-			t.strictEqual( sn, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+sn+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( sn - snExpected[i] );
-			tol = 12.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+sn+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cn === cnExpected[i] ) {
-			t.strictEqual( cn, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cn+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cn - cnExpected[i] );
-			tol = 12.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cn+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dn === dnExpected[i] ) {
-			t.strictEqual( dn, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dn+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dn - dnExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dn+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( sn, snExpected[i], 9866 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cn, cnExpected[i], 9792 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dn, dnExpected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -265,8 +198,6 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (zero modu
 	var snExpected;
 	var cnExpected;
 	var dnExpected;
-	var delta;
-	var tol;
 	var sn;
 	var cn;
 	var dn;
@@ -289,21 +220,8 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (zero modu
 		cn = y[1];
 		dn = y[2];
 
-		if ( sn === snExpected[i] ) {
-			t.strictEqual( sn, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+sn+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( sn - snExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+sn+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cn === cnExpected[i] ) {
-			t.strictEqual( cn, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cn+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cn - cnExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cn+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( sn, snExpected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cn, cnExpected[i], 1 ), true, 'returns expected value' );
 
 		// There is no reason for this to be anything but exactly identical, i.e. 1.0.
 		t.strictEqual( dn, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dn+', dnExpected: '+dnExpected[i] );
@@ -315,8 +233,6 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (unity mod
 	var snExpected;
 	var cnExpected;
 	var dnExpected;
-	var delta;
-	var tol;
 	var sn;
 	var cn;
 	var dn;
@@ -339,29 +255,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (unity mod
 		cn = y[1];
 		dn = y[2];
 
-		if ( sn === snExpected[i] ) {
-			t.strictEqual( sn, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+sn+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( sn - snExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+sn+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cn === cnExpected[i] ) {
-			t.strictEqual( cn, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cn+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cn - cnExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cn+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dn === dnExpected[i] ) {
-			t.strictEqual( dn, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dn+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dn - dnExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dn+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( sn, snExpected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cn, cnExpected[i], 2 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dn, dnExpected[i], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -372,8 +268,6 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (spot chec
 	var dnExpected;
 	var amExpected;
 	var tolerance;
-	var delta;
-	var tol;
 	var sn;
 	var cn;
 	var dn;
@@ -401,38 +295,14 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (spot chec
 
 		tolerance = spotChecks.tolerance[ i ];
 
-		if ( sn === snExpected[i] ) {
-			t.strictEqual( sn, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+sn+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( sn - snExpected[i] );
-			tol = tolerance * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+sn+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cn === cnExpected[i] ) {
-			t.strictEqual( cn, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cn+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cn - cnExpected[i] );
-			tol = tolerance * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cn+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dn === dnExpected[i] ) {
-			t.strictEqual( dn, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dn+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dn - dnExpected[i] );
-			tol = tolerance * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dn+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( sn, snExpected[i], 154 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cn, cnExpected[i], 986545 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dn, dnExpected[i], 986506 ), true, 'returns expected value' );
 
 		if ( amExpected[i] === null ) {
 			t.strictEqual( isnan(am), true, 'is NaN. u: '+u[i]+'. m: '+m[i]+', am: '+am+'.' );
-		} else if ( am === amExpected[i] ) {
-			t.strictEqual( am, amExpected[i], 'u: '+u[i]+', m: '+m[i]+', am: '+am+', amExpected: '+amExpected[i] );
 		} else {
-			delta = abs( am - amExpected[i] );
-			tol = tolerance * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', am: '+am+'. E: '+amExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( am, amExpected[i], tolerance ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/ellipj/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/base/special/ellipj/test/test.main.js
@@ -25,8 +25,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var HALF_PI = require( '@stdlib/constants/float64/half-pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var ellipj = require( './../lib/main.js' );
 
 
@@ -88,8 +87,6 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (medium po
 	var cnExpected;
 	var dnExpected;
 	var sncndn;
-	var delta;
-	var tol;
 	var sn;
 	var cn;
 	var dn;
@@ -108,29 +105,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (medium po
 		cn = sncndn[1];
 		dn = sncndn[2];
 
-		if ( sn === snExpected[i] ) {
-			t.strictEqual( sn, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+sn+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( sn - snExpected[i] );
-			tol = 18.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+sn+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cn === cnExpected[i] ) {
-			t.strictEqual( cn, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cn+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cn - cnExpected[i] );
-			tol = 14.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cn+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dn === dnExpected[i] ) {
-			t.strictEqual( dn, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dn+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dn - dnExpected[i] );
-			tol = 40.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dn+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( sn, snExpected[i], 4750 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cn, cnExpected[i], 9327 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dn, dnExpected[i], 155 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -140,8 +117,6 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (modulus n
 	var cnExpected;
 	var dnExpected;
 	var sncndn;
-	var delta;
-	var tol;
 	var sn;
 	var cn;
 	var dn;
@@ -160,29 +135,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (modulus n
 		cn = sncndn[1];
 		dn = sncndn[2];
 
-		if ( sn === snExpected[i] ) {
-			t.strictEqual( sn, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+sn+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( sn - snExpected[i] );
-			tol = 7.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+sn+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cn === cnExpected[i] ) {
-			t.strictEqual( cn, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cn+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cn - cnExpected[i] );
-			tol = 5.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cn+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dn === dnExpected[i] ) {
-			t.strictEqual( dn, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dn+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dn - dnExpected[i] );
-			tol = 5.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dn+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( sn, snExpected[i], 9944 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cn, cnExpected[i], 12 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dn, dnExpected[i], 12 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -192,8 +147,6 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (small pos
 	var cnExpected;
 	var dnExpected;
 	var sncndn;
-	var delta;
-	var tol;
 	var sn;
 	var cn;
 	var dn;
@@ -212,29 +165,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (small pos
 		cn = sncndn[1];
 		dn = sncndn[2];
 
-		if ( sn === snExpected[i] ) {
-			t.strictEqual( sn, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+sn+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( sn - snExpected[i] );
-			tol = 12.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+sn+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cn === cnExpected[i] ) {
-			t.strictEqual( cn, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cn+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cn - cnExpected[i] );
-			tol = 12.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cn+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dn === dnExpected[i] ) {
-			t.strictEqual( dn, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dn+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dn - dnExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dn+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( sn, snExpected[i], 9866 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cn, cnExpected[i], 9792 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dn, dnExpected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -244,8 +177,6 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (zero modu
 	var cnExpected;
 	var dnExpected;
 	var sncndn;
-	var delta;
-	var tol;
 	var sn;
 	var cn;
 	var dn;
@@ -264,21 +195,8 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (zero modu
 		cn = sncndn[1];
 		dn = sncndn[2];
 
-		if ( sn === snExpected[i] ) {
-			t.strictEqual( sn, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+sn+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( sn - snExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+sn+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cn === cnExpected[i] ) {
-			t.strictEqual( cn, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cn+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cn - cnExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cn+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( sn, snExpected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cn, cnExpected[i], 1 ), true, 'returns expected value' );
 
 		// There is no reason for this to be anything but exactly identical, i.e. 1.0.
 		t.strictEqual( dn, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dn+', dnExpected: '+dnExpected[i] );
@@ -291,8 +209,6 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (unity mod
 	var cnExpected;
 	var dnExpected;
 	var sncndn;
-	var delta;
-	var tol;
 	var sn;
 	var cn;
 	var dn;
@@ -311,29 +227,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (unity mod
 		cn = sncndn[1];
 		dn = sncndn[2];
 
-		if ( sn === snExpected[i] ) {
-			t.strictEqual( sn, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+sn+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( sn - snExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+sn+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cn === cnExpected[i] ) {
-			t.strictEqual( cn, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cn+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cn - cnExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cn+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dn === dnExpected[i] ) {
-			t.strictEqual( dn, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dn+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dn - dnExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dn+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( sn, snExpected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cn, cnExpected[i], 2 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dn, dnExpected[i], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/ellipj/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/ellipj/test/test.native.js
@@ -26,8 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var HALF_PI = require( '@stdlib/constants/float64/half-pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -97,8 +96,6 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (medium po
 	var cnExpected;
 	var dnExpected;
 	var sncndn;
-	var delta;
-	var tol;
 	var sn;
 	var cn;
 	var dn;
@@ -117,29 +114,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (medium po
 		cn = sncndn[1];
 		dn = sncndn[2];
 
-		if ( sn === snExpected[i] ) {
-			t.strictEqual( sn, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+sn+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( sn - snExpected[i] );
-			tol = 18.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+sn+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cn === cnExpected[i] ) {
-			t.strictEqual( cn, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cn+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cn - cnExpected[i] );
-			tol = 14.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cn+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dn === dnExpected[i] ) {
-			t.strictEqual( dn, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dn+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dn - dnExpected[i] );
-			tol = 40.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dn+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( sn, snExpected[i], 4750 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cn, cnExpected[i], 9327 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dn, dnExpected[i], 155 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -149,8 +126,6 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (modulus n
 	var cnExpected;
 	var dnExpected;
 	var sncndn;
-	var delta;
-	var tol;
 	var sn;
 	var cn;
 	var dn;
@@ -169,29 +144,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (modulus n
 		cn = sncndn[1];
 		dn = sncndn[2];
 
-		if ( sn === snExpected[i] ) {
-			t.strictEqual( sn, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+sn+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( sn - snExpected[i] );
-			tol = 7.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+sn+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cn === cnExpected[i] ) {
-			t.strictEqual( cn, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cn+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cn - cnExpected[i] );
-			tol = 5.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cn+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dn === dnExpected[i] ) {
-			t.strictEqual( dn, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dn+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dn - dnExpected[i] );
-			tol = 5.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dn+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( sn, snExpected[i], 9944 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cn, cnExpected[i], 12 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dn, dnExpected[i], 12 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -201,8 +156,6 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (small pos
 	var cnExpected;
 	var dnExpected;
 	var sncndn;
-	var delta;
-	var tol;
 	var sn;
 	var cn;
 	var dn;
@@ -221,29 +174,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (small pos
 		cn = sncndn[1];
 		dn = sncndn[2];
 
-		if ( sn === snExpected[i] ) {
-			t.strictEqual( sn, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+sn+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( sn - snExpected[i] );
-			tol = 12.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+sn+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cn === cnExpected[i] ) {
-			t.strictEqual( cn, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cn+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cn - cnExpected[i] );
-			tol = 12.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cn+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dn === dnExpected[i] ) {
-			t.strictEqual( dn, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dn+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dn - dnExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dn+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( sn, snExpected[i], 9866 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cn, cnExpected[i], 9792 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dn, dnExpected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -253,8 +186,6 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (zero modu
 	var cnExpected;
 	var dnExpected;
 	var sncndn;
-	var delta;
-	var tol;
 	var sn;
 	var cn;
 	var dn;
@@ -273,21 +204,8 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (zero modu
 		cn = sncndn[1];
 		dn = sncndn[2];
 
-		if ( sn === snExpected[i] ) {
-			t.strictEqual( sn, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+sn+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( sn - snExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+sn+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cn === cnExpected[i] ) {
-			t.strictEqual( cn, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cn+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cn - cnExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cn+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( sn, snExpected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cn, cnExpected[i], 1 ), true, 'returns expected value' );
 
 		// There is no reason for this to be anything but exactly identical, i.e. 1.0.
 		t.strictEqual( dn, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dn+', dnExpected: '+dnExpected[i] );
@@ -300,8 +218,6 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (unity mod
 	var cnExpected;
 	var dnExpected;
 	var sncndn;
-	var delta;
-	var tol;
 	var sn;
 	var cn;
 	var dn;
@@ -320,29 +236,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (unity mod
 		cn = sncndn[1];
 		dn = sncndn[2];
 
-		if ( sn === snExpected[i] ) {
-			t.strictEqual( sn, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+sn+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( sn - snExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+sn+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cn === cnExpected[i] ) {
-			t.strictEqual( cn, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cn+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cn - cnExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cn+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dn === dnExpected[i] ) {
-			t.strictEqual( dn, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dn+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dn - dnExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dn+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( sn, snExpected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cn, cnExpected[i], 2 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dn, dnExpected[i], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/ellipj/test/test.sncndn.js
+++ b/lib/node_modules/@stdlib/math/base/special/ellipj/test/test.sncndn.js
@@ -27,8 +27,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var HALF_PI = require( '@stdlib/constants/float64/half-pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var sn = require( './../lib/sn.js' );
 var cn = require( './../lib/cn.js' );
 var dn = require( './../lib/dn.js' );
@@ -106,11 +105,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (medium po
 	var snExpected;
 	var cnExpected;
 	var dnExpected;
-	var delta;
 	var snval;
 	var cnval;
 	var dnval;
-	var tol;
 	var u;
 	var m;
 	var i;
@@ -125,29 +122,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (medium po
 		cnval = cn( u[i], m[i] );
 		dnval = dn( u[i], m[i] );
 
-		if ( snval === snExpected[i] ) {
-			t.strictEqual( snval, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+snval+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( snval - snExpected[i] );
-			tol = 18.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+snval+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cnval === cnExpected[i] ) {
-			t.strictEqual( cnval, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cnval+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cnval - cnExpected[i] );
-			tol = 14.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cnval+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dnval === dnExpected[i] ) {
-			t.strictEqual( dnval, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dnval+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dnval - dnExpected[i] );
-			tol = 40.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dnval+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( snval, snExpected[i], 4750 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cnval, cnExpected[i], 9327 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dnval, dnExpected[i], 155 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -156,11 +133,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (modulus n
 	var snExpected;
 	var cnExpected;
 	var dnExpected;
-	var delta;
 	var snval;
 	var cnval;
 	var dnval;
-	var tol;
 	var u;
 	var m;
 	var i;
@@ -175,29 +150,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (modulus n
 		cnval = cn( u[i], m[i] );
 		dnval = dn( u[i], m[i] );
 
-		if ( snval === snExpected[i] ) {
-			t.strictEqual( snval, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+snval+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( snval - snExpected[i] );
-			tol = 7.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+snval+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cnval === cnExpected[i] ) {
-			t.strictEqual( cnval, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cnval+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cnval - cnExpected[i] );
-			tol = 5.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cnval+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dnval === dnExpected[i] ) {
-			t.strictEqual( dnval, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dnval+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dnval - dnExpected[i] );
-			tol = 5.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dnval+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( snval, snExpected[i], 9944 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cnval, cnExpected[i], 12 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dnval, dnExpected[i], 12 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -206,11 +161,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (small pos
 	var snExpected;
 	var cnExpected;
 	var dnExpected;
-	var delta;
 	var snval;
 	var cnval;
 	var dnval;
-	var tol;
 	var u;
 	var m;
 	var i;
@@ -225,29 +178,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (small pos
 		cnval = cn( u[i], m[i] );
 		dnval = dn( u[i], m[i] );
 
-		if ( snval === snExpected[i] ) {
-			t.strictEqual( snval, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+snval+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( snval - snExpected[i] );
-			tol = 12.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+snval+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cnval === cnExpected[i] ) {
-			t.strictEqual( cnval, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cnval+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cnval - cnExpected[i] );
-			tol = 12.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cnval+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dnval === dnExpected[i] ) {
-			t.strictEqual( dnval, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dnval+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dnval - dnExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dnval+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( snval, snExpected[i], 9866 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cnval, cnExpected[i], 9792 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dnval, dnExpected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -256,11 +189,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (zero modu
 	var snExpected;
 	var cnExpected;
 	var dnExpected;
-	var delta;
 	var snval;
 	var cnval;
 	var dnval;
-	var tol;
 	var u;
 	var m;
 	var i;
@@ -275,21 +206,8 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (zero modu
 		cnval = cn( u[i], m[i] );
 		dnval = dn( u[i], m[i] );
 
-		if ( snval === snExpected[i] ) {
-			t.strictEqual( snval, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+snval+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( snval - snExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+snval+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cnval === cnExpected[i] ) {
-			t.strictEqual( cnval, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cnval+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cnval - cnExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cnval+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( snval, snExpected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cnval, cnExpected[i], 1 ), true, 'returns expected value' );
 
 		// There is no reason for this to be anything but exactly identical, i.e. 1.0.
 		t.strictEqual( dnval, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dnval+', dnExpected: '+dnExpected[i] );
@@ -301,11 +219,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (unity mod
 	var snExpected;
 	var cnExpected;
 	var dnExpected;
-	var delta;
 	var snval;
 	var cnval;
 	var dnval;
-	var tol;
 	var u;
 	var m;
 	var i;
@@ -320,29 +236,9 @@ tape( 'the function evaluates the Jacobi elliptic functions sn, cn dn (unity mod
 		cnval = cn( u[i], m[i] );
 		dnval = dn( u[i], m[i] );
 
-		if ( snval === snExpected[i] ) {
-			t.strictEqual( snval, snExpected[i], 'u: '+u[i]+', m: '+m[i]+', sn: '+snval+', snExpected: '+snExpected[i] );
-		} else {
-			delta = abs( snval - snExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', sn: '+snval+'. E: '+snExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( cnval === cnExpected[i] ) {
-			t.strictEqual( cnval, cnExpected[i], 'u: '+u[i]+', m: '+m[i]+', cn: '+cnval+', cnExpected: '+cnExpected[i] );
-		} else {
-			delta = abs( cnval - cnExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', cn: '+cnval+'. E: '+cnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
-
-		if ( dnval === dnExpected[i] ) {
-			t.strictEqual( dnval, dnExpected[i], 'u: '+u[i]+', m: '+m[i]+', dn: '+dnval+', dnExpected: '+dnExpected[i] );
-		} else {
-			delta = abs( dnval - dnExpected[i] );
-			tol = 1.0 * EPS;
-			t.strictEqual( delta <= tol, true, 'within tolerance. u: '+u[i]+'. m: '+m[i]+', dn: '+dnval+'. E: '+dnExpected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( snval, snExpected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( cnval, cnExpected[i], 2 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( dnval, dnExpected[i], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Progresses #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for math/base/special/ellipj from relative tolerance (EPS/delta/tol) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
-   updates test/test.assign.js, test/test.main.js, test/test.native.js, and test/test.sncndn.js. No other files are changed.
-   removes the now-unused EPS and abs imports and the corresponding delta/tol variable declarations from each file.

Most ULP bounds were carried over from the pre-existing tolerance blocks and verified to be the minimum integer that still passes across each fixture (medium_positive_modulus, near_unity_modulus, small_positive_modulus, zero_modulus, unity_modulus, and spot_checks in test.assign.js only).

One outlier is worth calling out explicitly. In the spot_checks fixture (test/test.assign.js), the case u=60, m=0.9999999999 requires much larger ULP bounds than any other input in that block: cn=986545, dn=986506 (versus sn=154 for the same block). Inspecting the actual computed values shows this is not a correctness issue  actual and expected agree to roughly 10 significant digits (e.g. cn: 0.00044827749287320586 vs 0.00044827749281972515, an absolute difference of ~5.3e-14). At this input, m is extremely close to 1 (a known difficult region for Jacobi elliptic functions) and cn/dn evaluate to very small magnitudes (~4.5e-4), where the representable floating-point gap is extremely fine, so even a tiny absolute error translates into a large ULP count. The am comparison for the same row already used a fixture-supplied tolerance of 250, consistent with the fixture's author anticipating this row was numerically harder than the others.


## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
