### PR TITLE
test: migrate `stats/base/dists/negative-binomial/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/stdev/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -87,8 +86,6 @@ tape( 'if provided a success probability `p` outside of `[0,1]`, the function re
 
 tape( 'the function returns the standard deviation of a negative binomial distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var r;
 	var p;
 	var y;
@@ -99,13 +96,7 @@ tape( 'the function returns the standard deviation of a negative binomial distri
 	p = data.p;
 	for ( i = 0; i < r.length; i++ ) {
 		y = stdev( r[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'r:'+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/stdev/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -96,8 +95,6 @@ tape( 'if provided a success probability `p` outside of `[0,1]`, the function re
 
 tape( 'the function returns the standard deviation of a negative binomial distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var r;
 	var p;
 	var y;
@@ -108,13 +105,7 @@ tape( 'the function returns the standard deviation of a negative binomial distri
 	p = data.p;
 	for ( i = 0; i < r.length; i++ ) {
 		y = stdev( r[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'r:'+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/negative-binomial/stdev` from relative tolerance testing to ULP difference testing, per #11352.

Changes are confined to `test/test.js` and `test/test.native.js`. In each, the fixture loop's `delta`/`tol` computation and the `y === expected[i]` branch are replaced with a single `isAlmostSameValue` assertion, `@stdlib/assert/is-almost-same-value` is added to the module requires, and the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires are removed. No other test cases, loop bounds, or fixtures are touched.

**ULP bound: `1` in both `test/test.js` and `test/test.native.js`.**

This is the measured minimum, not a guess. The JS and native implementations were each evaluated against all 200 Julia fixture cases, and for each case the smallest passing ULP value was searched for; the maximum over the full fixture set was `1` for both. The worst case is `r = 94`, `p = 0.1917697882524807`, where the returned `45.45182001928158` differs from the expected `45.451820019281584` by exactly one representable step. Lowering the bound to `0` fails 54 of the 200 cases, so `1` is the tightest integer bound that holds.

The C and JavaScript implementations return bit-identical results for all 200 fixture cases, which is consistent with the implementation being a single `sqrt`, multiply, and divide — `sqrt( ( 1.0-p ) * r ) / p` — expressed identically in both languages, with no multiply-add pattern available for contraction.

The previous bound was `1.0 * EPS` in both files (guarded by an exact-equality fast path). A `1` ULP bound is at least as tight everywhere, and strictly tighter for values just above a power of two, where `1.0 * EPS * |expected|` spans nearly two representable steps.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed:

-   `make test TESTS_FILTER=".*/stats/base/dists/negative-binomial/stdev/.*"` passes: 211/211 in `test/test.js` and 211/211 in `test/test.native.js`.
-   The native addon was built locally via `make install-node-addons NODE_ADDONS_PATTERN="negative-binomial/stdev"` so that `test/test.native.js` actually exercised the C implementation rather than being skipped; it passes at the same `1` ULP bound.
-   The full suite was run twice at the final bound to confirm determinism (no FMA/architecture-dependent variation).
-   Both files lint clean under `etc/eslint/.eslintrc.tests.js` (`make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/negative-binomial/stdev/.*"`).
-   Only the two test files are changed; no build artifacts are included.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an automated task. The conversion mirrors the idiom established by previously merged `stats/base/dists/*` conversions (for example `pareto-type1/mean`, `erlang/stdev`, `logistic/stdev`), and the ULP bound was determined empirically by measuring the per-case ULP distance across the full fixture set for both the JavaScript and C implementations, rather than by trial and error.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDAHuSkiQXDb4w6uSLZy3X)_