### PR TITLE
test: migrate `stats/base/dists/planck/skewness` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/planck/skewness/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/skewness/test/test.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var skewness = require( './../lib' );
 
 
@@ -61,8 +60,6 @@ tape( 'if provided a shape parameter `lambda` which is nonpositive, the function
 tape( 'the function returns the skewness of a Planck distribution', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var y;
 
@@ -70,13 +67,7 @@ tape( 'the function returns the skewness of a Planck distribution', function tes
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = skewness( lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'lambda: '+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/skewness/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/skewness/test/test.native.js
@@ -22,10 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 
 
 // FIXTURES //
@@ -70,8 +69,6 @@ tape( 'if provided a shape parameter `lambda` which is nonpositive, the function
 tape( 'the function returns the skewness of a Planck distribution', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var y;
 
@@ -79,13 +76,7 @@ tape( 'the function returns the skewness of a Planck distribution', opts, functi
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = skewness( lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'lambda: '+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/planck/skewness` from relative tolerance testing to ULP difference testing, per #11352.

Changes are confined to `test/test.js` and `test/test.native.js`. In each, the fixture loop's `delta`/`tol` computation and the `y === expected[i]` branch are replaced with a single `isAlmostSameValue` assertion, `@stdlib/assert/is-almost-same-value` is added to the module requires, and the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires are removed. No other test cases, loop bounds, or fixtures are touched.

**ULP bound: `1` in both `test/test.js` and `test/test.native.js`.**

This is the measured minimum, not a guess. The JS and native implementations were each evaluated against all 1000 Python fixture cases, and the per-case ULP distance between the returned and expected values was computed directly via `@stdlib/number/float64/base/ulp-difference`. The resulting distribution was identical for both implementations: 891 cases at `0` ULP and 109 cases at exactly `1` ULP, so the maximum over the full fixture set is `1`. The worst case is `lambda = 7.28771354747294`, where the returned `38.265183277421535` differs from the expected `38.26518327742153` by one representable step. Lowering the bound to `0` fails 109 of the 1000 cases, so `1` is the tightest integer bound that holds.

The C and JavaScript implementations return bit-identical results across all 1000 fixture cases, so a single bound is correct for both files.

The previous bound was `1.0 * EPS` in both files (guarded by an exact-equality fast path). A `1` ULP bound is at least as tight everywhere, and strictly tighter for values just above a power of two, where `1.0 * EPS * |expected|` spans nearly two representable steps.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed:

-   `make test TESTS_FILTER=".*/stats/base/dists/planck/skewness/.*"` passes: 1005/1005 in `test/test.js` and 1005/1005 in `test/test.native.js`.
-   The native addon was built locally (`node-gyp rebuild`) so that `test/test.native.js` actually exercised the C implementation rather than being skipped; it passes at the same `1` ULP bound. The build artifacts were removed before committing.
-   The full suite was run twice at the final bound to confirm determinism (no FMA/architecture-dependent variation).
-   The lower bound was confirmed empirically as well as analytically: temporarily setting the bound to `0` produces 109 failures, matching the measured ULP histogram exactly.
-   Both files lint clean under `etc/eslint/.eslintrc.tests.js`, and pass `editorconfig-checker` under both `etc/editorconfig-checker/.editorconfig_checker.json` and `.editorconfig_checker.markdown.json`.
-   Only the two test files are changed; no build artifacts are included.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an automated task. The conversion mirrors the idiom established by previously merged `stats/base/dists/*` conversions (for example `planck/stdev`, `rayleigh/variance`, `negative-binomial/stdev`), and the ULP bound was determined empirically by measuring the per-case ULP distance across the full fixture set for both the JavaScript and C implementations, rather than by trial and error.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01MR5zvc7kvyRSnRnPnN46sn)_