### PR TITLE
test: migrate `stats/base/dists/cosine/variance` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/variance/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var variance = require( './../lib' );
 
 
@@ -76,8 +75,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', function test
 
 tape( 'the function returns the variance of a raised cosine distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var s;
 	var y;
@@ -89,13 +86,7 @@ tape( 'the function returns the variance of a raised cosine distribution', funct
 	for ( i = 0; i < mu.length; i++ ) {
 		y = variance( mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/variance/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/variance/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -88,8 +87,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', opts, functio
 
 tape( 'the function returns the variance of a raised cosine distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var s;
 	var y;
@@ -101,13 +98,7 @@ tape( 'the function returns the variance of a raised cosine distribution', opts,
 	for ( i = 0; i < mu.length; i++ ) {
 		y = variance( mu[i], s[i] );
 		if ( expected[i] !== null) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/cosine/variance` from relative tolerance testing to ULP difference testing, per #11352.

The computed-tolerance idiom (`delta = abs( y - expected[i] )`, `tol = 2.0 * EPS * abs( expected[i] )`, `t.ok( delta <= tol, ... )`) is replaced with `isAlmostSameValue` from [`@stdlib/assert/is-almost-same-value`][is-almost-same-value], and the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires are dropped. Only `test/test.js` and `test/test.native.js` are changed.

**Final ULP constant: `0` (both `test/test.js` and `test/test.native.js`).**

This is the measured minimum. Before editing, the JavaScript and C implementations were both run against the full Julia fixture set (100 cases, no `null` entries) and the ULP difference was computed for every case with `@stdlib/number/float64/base/ulp-difference`:

| implementation | cases | max ULP difference | minimum passing `N` |
| -------------- | ----- | ------------------ | ------------------- |
| JavaScript (`lib/main.js`) | 100 | 0 | 0 |
| C (`src/main.c`, addon built locally) | 100 | 0 | 0 |

Both implementations are bit-exact against the fixtures, so `0` is the tightest bound available and no lower value exists. This is expected from the implementations themselves: both compute `( s * s ) * SCALAR` — two IEEE-754 double multiplications, each correctly rounded, with no addition for a compiler to contract into an FMA. There is therefore no JS-vs-C divergence of the kind described in the [FAQ][faq], and no architecture-dependent rounding to absorb.

The suite was run twice at `N = 0` with the native addon built, and both `test/test.js` (110 assertions) and `test/test.native.js` (111 assertions) passed identically on both runs. `isAlmostSameValue( x, y, 0 )` was also checked to be non-vacuous: it returns `false` for a one-ULP deviation, so the assertions remain meaningful rather than trivially satisfied.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Opened as a draft.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task. It selected the package, studied prior converted packages in the same family to match the established idiom, measured the ULP difference for every fixture case against both the JavaScript and C implementations to determine the minimum bound, and applied the edits.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value
[faq]: https://github.com/stdlib-js/stdlib/blob/develop/docs/contributing/FAQ.md#js-vs-c-return-values


---
_Generated by [Claude Code](https://claude.ai/code/session_012ZqCiQvWvdXEbdwj8pkVTn)_