### PR TITLE
test: migrate `stats/base/dists/gumbel/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/stdev/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -76,9 +75,7 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', function t
 
 tape( 'the function returns the standard deviation of a Gumbel distribution', function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -89,13 +86,7 @@ tape( 'the function returns the standard deviation of a Gumbel distribution', fu
 	for ( i = 0; i < mu.length; i++ ) {
 		y = stdev( mu[i], beta[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/stdev/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -88,9 +87,7 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', opts, func
 
 tape( 'the function returns the standard deviation of a Gumbel distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -100,14 +97,8 @@ tape( 'the function returns the standard deviation of a Gumbel distribution', op
 	beta = data.beta;
 	for ( i = 0; i < mu.length; i++ ) {
 		y = stdev( mu[i], beta[i] );
-		if ( expected[i] !== null) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+		if ( expected[i] !== null ) {
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/gumbel/stdev` from relative tolerance testing to ULP difference testing, per #11352.

The computed-tolerance idiom (`delta = abs( y - expected[i] )`, `tol = 1.0 * EPS * abs( expected[i] )`, `t.ok( delta <= tol, ... )`) is replaced with `isAlmostSameValue` from [`@stdlib/assert/is-almost-same-value`][is-almost-same-value], and the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires are dropped. The existing `expected[i] !== null` guard is preserved. Only `test/test.js` and `test/test.native.js` are changed.

**Final ULP constant: `1` (both `test/test.js` and `test/test.native.js`).**

This is the measured minimum. Before editing, the JavaScript and C implementations were both run against the full Julia fixture set (100 cases, no `null` entries) and the minimum passing ULP bound was computed for every individual case:

| implementation | cases | max ULP difference | minimum passing `N` |
| -------------- | ----- | ------------------ | ------------------- |
| JavaScript (`lib/main.js`) | 100 | 1 | 1 |
| C (`src/main.c`, addon built locally) | 100 | 1 | 1 |

Both implementations agree bit-for-bit with each other, which is expected from the sources: each computes `PI_OVER_SQRT6 * beta` — a single correctly rounded IEEE-754 double multiplication, with no addition for a compiler to contract into an FMA. There is therefore no JS-vs-C divergence of the kind described in the [FAQ][faq], and no architecture-dependent rounding to absorb.

`1` is the tightest bound that passes. The worst case is `mu = -3.3192170148182183`, `beta = 0.9006151006176755`, where the returned `1.1550837443384099` is one ULP above the fixture value `1.1550837443384097`. Running the suite at `N = 0` fails 18 of the 100 fixture assertions, so the bound is not merely conservative and the assertions are non-vacuous.

The suite was run twice at `N = 1` with the native addon built, and both `test/test.js` (110 assertions) and `test/test.native.js` (111 assertions) passed identically on both runs. `test/test.native.js` was confirmed to be actually executing rather than skipping.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Opened as a draft.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task. It selected the package, studied prior converted packages in the same family to match the established idiom, measured the minimum passing ULP bound for every fixture case against both the JavaScript and C implementations, and applied the edits.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value
[faq]: https://github.com/stdlib-js/stdlib/blob/develop/docs/contributing/FAQ.md#js-vs-c-return-values

---
_Generated by [Claude Code](https://claude.ai/code/session_016kmKfBAZdQvaPw24Mnw9cH)_