### PR TITLE
test: migrate `stats/base/dists/lognormal/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/stdev/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -76,9 +75,7 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', function 
 
 tape( 'the function returns the standard deviation of a lognormal distribution', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -89,13 +86,7 @@ tape( 'the function returns the standard deviation of a lognormal distribution',
 	for ( i = 0; i < mu.length; i++ ) {
 		y = stdev( mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/stdev/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -88,9 +87,7 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', opts, fun
 
 tape( 'the function returns the standard deviation of a lognormal distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -100,14 +97,8 @@ tape( 'the function returns the standard deviation of a lognormal distribution',
 	sigma = data.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
 		y = stdev( mu[i], sigma[i] );
-		if ( expected[i] !== null) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+		if ( expected[i] !== null ) {
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/lognormal/stdev` from relative tolerance testing to ULP difference testing, per #11352.

The computed-tolerance idiom (`delta = abs( y - expected[i] )`, `tol = 1.0 * EPS * abs( expected[i] )`, `t.ok( delta &lt;= tol, ... )`, together with its `y === expected[i]` exact-match branch) is replaced with `isAlmostSameValue` from [`@stdlib/assert/is-almost-same-value`][is-almost-same-value], and the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires are dropped. The existing `expected[i] !== null` fixture guard is preserved. Only `test/test.js` and `test/test.native.js` are changed.

**Final ULP constant: `0` (both `test/test.js` and `test/test.native.js`).**

This is the measured minimum. Both the JavaScript and C implementations were run against the full Julia fixture set and the ULP difference was computed for every case with `@stdlib/number/float64/base/ulp-difference`:

| implementation | cases | max ULP difference | minimum passing `N` |
| -------------- | ----- | ------------------ | ------------------- |
| JavaScript (`lib/main.js`) | 100 | 0 | 0 |
| C (`src/main.c`, addon built locally) | 100 | 0 | 0 |

Both implementations are bit-exact against the fixtures, so `0` is the tightest bound available and no lower value exists. The maximum JS-vs-C divergence over the same inputs is also `0`, so there is no divergence of the kind described in the [FAQ][faq] and a single bound serves both test files. This is consistent with the implementations: `stdev` is `sqrt( variance( mu, sigma ) )` in both languages, `variance` is `( exp( s2 ) - 1.0 ) * exp( ( 2.0*mu ) + s2 )` in both, the exponential is stdlib's own `exp` (not the platform libm) in both, and `sqrt` is correctly rounded per IEEE 754. The sibling package `stats/base/dists/lognormal/variance`, which this package delegates to, is already converted at `0` for both its JavaScript and native tests.

The suite was run twice at `N = 0` with the native addon built, and both `test/test.js` (110 assertions) and `test/test.native.js` (111 assertions) passed identically on both runs. `isAlmostSameValue( x, y, 0 )` was also checked to be non-vacuous: it returns `false` for a one-ULP deviation, so the assertions remain meaningful rather than trivially satisfied. `make eslint-tests TESTS_FILTER=".*/stats/base/dists/lognormal/stdev/.*"` is clean.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Opened as a draft.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task. It selected the package, studied prior converted packages in the same family to match the established idiom, built the native add-on and measured the ULP difference for every fixture case against both the JavaScript and C implementations to determine the minimum bound, and applied the edits.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value
[faq]: https://github.com/stdlib-js/stdlib/blob/develop/docs/contributing/FAQ.md#js-vs-c-return-values

---
_Generated by [Claude Code](https://claude.ai/code/session_011sKJZToddCjQBSr5zvoDvb)_