### PR TITLE
test: migrate `stats/base/dists/normal/kurtosis` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var kurtosis = require( './../lib' );
 
 
@@ -76,9 +75,7 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', function 
 
 tape( 'the function returns the excess kurtosis of a normal distribution', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -89,13 +86,7 @@ tape( 'the function returns the excess kurtosis of a normal distribution', funct
 	for ( i = 0; i < mu.length; i++ ) {
 		y = kurtosis( mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -88,9 +87,7 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', opts, fun
 
 tape( 'the function returns the excess kurtosis of a normal distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -101,13 +98,7 @@ tape( 'the function returns the excess kurtosis of a normal distribution', opts,
 	for ( i = 0; i < mu.length; i++ ) {
 		y = kurtosis( mu[i], sigma[i] );
 		if ( expected[i] !== null) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `@stdlib/stats/base/dists/normal/kurtosis` from relative tolerance testing to ULP difference testing, per #11352.

In both `test/test.js` and `test/test.native.js`, the fixture loop's `delta`/`tol` comparison is replaced with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );`, adding the `@stdlib/assert/is-almost-same-value` require and dropping the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**Final ULP constant: `0` (both `test/test.js` and `test/test.native.js`).**

How the bound was measured: starting from `64`, the bound was lowered over the full fixture set (`64 → 32 → 16 → 8 → 4 → 2 → 1 → 0`) and every value passed, so `0` is the measured minimum. The suite was run twice at the final value to confirm determinism (20/20 assertions passing on both runs).

`0` is the correct bound because the excess kurtosis of a normal distribution is identically zero: both `lib/main.js` and `src/main.c` return the constant `0.0` for any non-`NaN` input with `sigma > 0`, and all ten fixture expected values are `0.0`. There is no floating-point arithmetic on either path, so the results are bit-exact. Note that `isAlmostSameValue` falls back to `isSameValue` when `maxULP` is `0`, which distinguishes `+0` from `-0`; both implementations and the fixtures use `+0`, so the assertion holds.

Because `test/test.native.js` is skipped without a compiled add-on, the C path was verified separately by compiling `src/main.c` against the fixture inputs and comparing the raw bit patterns of the results to the expected values. There were no mismatches under `-O0`, `-O2`, `-O3 -ffp-contract=fast`, and `-O2 -march=native`, confirming that `0` is also correct for the native path and is not sensitive to FMA contraction.

Only the two test files are changed; no source, fixture, or documentation files were touched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The full development environment could not be provisioned in this session: `make install-node-modules` fails because a transitive dependency requests `es-object-atoms@^1.1.2`, which is not published on the registry (`1.1.1` is the latest available), so `npm` exits with `ETARGET`. This is an upstream registry issue and is unrelated to the changes in this pull request. To validate the change anyway, `tape` and the ESLint stack were installed in isolation. The package's tests were run directly with `node` (20/20 passing, twice), and both files were linted with the repository's own `etc/eslint/.eslintrc.tests.js` configuration and the in-repo `eslint-plugin-stdlib`, reporting 0 errors and 0 warnings.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. It selected the package, mirrored the conversion idiom from previously merged PRs for this tracking issue, measured the minimum ULP bound empirically, and verified the tests and linting.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_0185s11dUcdqJRrCwR8qsbL5)_