### PR TITLE
docs: add output-mutation notes to six `blas/ext/base/ndarray` packages

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cwxsa/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cwxsa/README.md
@@ -70,6 +70,10 @@ The function has the following parameters:
 
 <section class="notes">
 
+## Notes
+
+-   The output ndarray is modified **in-place** (i.e., the output ndarray is **mutated**).
+
 </section>
 
 <!-- /.notes -->

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dwxsa/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dwxsa/README.md
@@ -69,6 +69,10 @@ The function has the following parameters:
 
 <section class="notes">
 
+## Notes
+
+-   The output ndarray is modified **in-place** (i.e., the output ndarray is **mutated**).
+
 </section>
 
 <!-- /.notes -->

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gwxpy/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gwxpy/README.md
@@ -80,6 +80,10 @@ The function has the following parameters:
 
 <section class="notes">
 
+## Notes
+
+-   The output ndarray is modified **in-place** (i.e., the output ndarray is **mutated**).
+
 </section>
 
 <!-- /.notes -->

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gwxsa/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gwxsa/README.md
@@ -69,6 +69,10 @@ The function has the following parameters:
 
 <section class="notes">
 
+## Notes
+
+-   The output ndarray is modified **in-place** (i.e., the output ndarray is **mutated**).
+
 </section>
 
 <!-- /.notes -->

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/swxsa/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/swxsa/README.md
@@ -69,6 +69,10 @@ The function has the following parameters:
 
 <section class="notes">
 
+## Notes
+
+-   The output ndarray is modified **in-place** (i.e., the output ndarray is **mutated**).
+
 </section>
 
 <!-- /.notes -->

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/zwxsa/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/zwxsa/README.md
@@ -70,6 +70,10 @@ The function has the following parameters:
 
 <section class="notes">
 
+## Notes
+
+-   The output ndarray is modified **in-place** (i.e., the output ndarray is **mutated**).
+
 </section>
 
 <!-- /.notes -->


### PR DESCRIPTION
## Description

This pull request populates the empty README `Notes` section in six `@stdlib/blas/ext/base/ndarray` packages with the standard output-mutation caveat, matching the documented convention for output-writing operations in the namespace.

### Namespace summary

-   **Namespace:** `blas/ext/base/ndarray`
-   **Members analyzed:** 216 packages (all direct children with a `package.json`; none carry autogeneration markers).
-   **Features analyzed:** file tree; `package.json`, `stdlib`, and `directories` key sets; README section list and order; public signature and JSDoc shape; error construction; validation prologue; return kind; source dependencies.
-   **Features with a clear majority (≥75%):** standard file set (100%), `package.json` key set, `@param`/single-argument signature (216/216 identical), and README `Notes` section presence (210/216 = 97%).
-   **Features without a clear majority (excluded):** README `References` (27/216) and `C APIs` (10/216) sections, present only where a citation or native addon applies; return type and dependency sets, which vary by operation semantics.

### `cwxsa`, `dwxsa`, `gwxsa`, `swxsa`, `zwxsa`, `gwxpy`

Each of these packages writes its result to a separate output ndarray and returns it, yet shipped an empty `<section class="notes">` scaffold with no `## Notes` heading or bullet. Every one of the 24 output-writing siblings in the namespace (e.g. `gxpy`, `dxsy`, `gxmy`) documents this behavior with an identical bullet; these six were the only output-writing members missing it. The change adds the verbatim `The output ndarray is modified in-place` note to each. It is documentation only and touches no source, tests, or examples.

## Related Issues

None.

## Questions

No.

## Other

### Validation

Structural features were extracted directly from the filesystem and package sources; semantic features (signatures, validation prologues, error construction, JSDoc shape) were confirmed uniform across the namespace — no package throws, validates, or constructs errors, and `@param`/signature shape is identical in all 216 members. The single surviving drift finding was cross-checked by independent review: confirmed as unintentional documentation drift, with the corrective note verified factually correct for all six packages (each returns its output array) and verbatim-consistent with the 24 sibling precedents.

Deliberately excluded: the native-addon file subset (`binding.gyp`, `manifest.json`, C sources) present in only 10 packages (legitimate, not drift); the `References`/`C APIs` sections without a namespace majority; and return-type and dependency variation reflecting genuine per-operation semantics.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was generated by Claude Code as part of an automated cross-package documentation-consistency (drift detection) routine. Structural and semantic features were extracted across the `blas/ext/base/ndarray` namespace, a per-feature majority pattern was computed, deviations were validated by independent review agents, and the resulting mechanical documentation fix was applied and verified against existing sibling packages.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qiq3RWNEXWZ9YFoE3eJs8N)_