### PR TITLE
test: migrate `stats/base/dists/chi/variance` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chi/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/variance/test/test.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var variance = require( './../lib' );
 
 
@@ -61,8 +60,6 @@ tape( 'if provided a degrees of freedom parameter `k` that is not a nonnegative 
 
 tape( 'the function returns the variance of a chi distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -71,13 +68,7 @@ tape( 'the function returns the variance of a chi distribution', function test( 
 	k = data.k;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = variance( k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 150.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 288 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/variance/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/variance/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -70,8 +69,6 @@ tape( 'if provided a degrees of freedom parameter `k` that is not a nonnegative 
 
 tape( 'the function returns the variance of a chi distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -80,13 +77,7 @@ tape( 'the function returns the variance of a chi distribution', opts, function 
 	k = data.k;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = variance( k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 150.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 288 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/chi/variance` from relative-tolerance assertions (`delta <= tol`, with `delta = abs( y - expected[ i ] )` and `tol = 150.0 * EPS * abs( expected[ i ] )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the same migration to both `test/test.js` and `test/test.native.js`.
-   preserves all existing test cases and non-tolerance assertions (`NaN` input, negative `k`, `-infinity`), and drops the now-unused `abs` and `EPS` requires.

### ULP bound

| File                  | ULP |
| --------------------- | :-: |
| `test/test.js`        | 288 |
| `test/test.native.js` | 288 |

`288` is the **measured minimum**: it is the smallest integer `N` for which `isAlmostSameValue( actual, expected[ i ], N )` holds for every one of the 50 entries in `test/fixtures/julia/data.json`. Starting from `N = 64` and tightening agentically, `N = 288` passes all 55 assertions while `N = 287` fails one (the worst case is `k = 14.059155590431867`, where the implementation returns `0.4908090238471683` against an expected `0.4908090238471523`).

A bound of this magnitude is expected for this package rather than indicative of a regression: `variance( k )` is computed as `k - mu*mu`, where `mu = mean( k )` is a ratio of gamma functions. For larger `k`, `mu*mu` approaches `k`, so the subtraction is subject to catastrophic cancellation, and the relative error of `mu` is amplified in the difference. The previous relative tolerance of `150.0 * EPS` corresponds to roughly 150–300 ULP depending on where the expected value falls within its binade, so the new bound is consistent with, and no looser than, the tolerance it replaces.

The tests were run twice at the final `N` to confirm deterministic passing (55 assertions, all passing on both runs, no FMA/architecture-dependent variation). `test/test.native.js` uses the same bound as `test/test.js`; the native add-on is not built in this environment, so those tests are skipped locally, and both the JavaScript and C implementations evaluate the identical expression (`k - mu*mu`) in double precision.

Linting was checked before and after the change and is unchanged: both files report the same four pre-existing `no-restricted-syntax` (`FunctionExpression`) errors before and after, identical to those reported for the already-migrated sibling package `stats/base/dists/chi/stdev`. The only files changed are the two test files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code: the assistant mechanically converted the tolerance-based assertions to `isAlmostSameValue`, agentically searched for the minimum ULP bound over the full fixture set, verified determinism across two full runs, and ran the local lint and test suites before submitting.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ee1MqwuwK7koQdLHrvzote)_