### PR TITLE
test: migrate `stats/base/dists/beta/variance` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/beta/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/variance/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var variance = require( './../lib' );
 
 
@@ -96,10 +95,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the variance of a beta distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -108,13 +105,7 @@ tape( 'the function returns the variance of a beta distribution', function test(
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = variance( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/variance/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/variance/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -105,10 +104,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 
 tape( 'the function returns the variance of a beta distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -117,13 +114,7 @@ tape( 'the function returns the variance of a beta distribution', opts, function
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = variance( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/beta/variance` from relative-tolerance assertions (`delta <= tol`, with `delta = abs( y - expected[ i ] )` and `tol = 1.0 * EPS * abs( expected[ i ] )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the same migration to both `test/test.js` and `test/test.native.js`.
-   preserves all existing test cases and non-tolerance assertions (`NaN` input, `alpha <= 0`, `beta <= 0`), and drops the now-unused `abs` and `EPS` requires.

### ULP bound

| File                  | ULP |
| --------------------- | :-: |
| `test/test.js`        |  0  |
| `test/test.native.js` |  0  |

`0` is the **measured minimum**, and is the tightest bound possible. Starting from `N = 64` and tightening agentically, `N = 0` still holds for every one of the 1000 entries in `test/fixtures/julia/data.json`: both implementations reproduce every expected value exactly, so `isAlmostSameValue( actual, expected[ i ], 0 )` (same-value equality) is satisfied throughout.

This is expected for this package rather than surprising. `variance( alpha, beta )` is computed as `(alpha*beta) / (apb*apb*(apb+1))` with `apb = alpha + beta`, i.e. a short chain of exactly-rounded multiplications, one addition, and one division, with no cancellation and no series expansion. The previous `1.0 * EPS` relative tolerance was already effectively an exactness check for this fixture set.

Both `test/test.js` and `test/test.native.js` were run twice at the final `N` to confirm deterministic passing (1014 assertions each, all passing on both runs, no FMA/architecture-dependent variation). The native add-on was built locally for this package so that `test/test.native.js` executes rather than skips. As an additional check against FMA contraction, `src/main.c` was compiled and evaluated over the full fixture set under `-O0`, `-O2`, `-O3 -ffp-contract=off`, and `-O3 -ffp-contract=fast`; all four configurations reproduce all 1000 expected values exactly, so the `0` ULP bound is not dependent on compiler flags.

Linting is clean: both files pass `etc/eslint/.eslintrc.tests.js` with no errors, and the repository's pre-commit lint stages (JavaScript test lint, filename lint, commit-message lint) pass. The only files changed are the two test files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The `editorconfig` pre-commit stage could not run in this environment because downloading the `editorconfig-checker` binary is blocked by the sandbox network policy. Both files were instead verified manually against `.editorconfig` (LF endings, UTF-8, tab indentation, no trailing whitespace, final newline present); all other pre-commit lint stages ran normally.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code: the assistant mechanically converted the tolerance-based assertions to `isAlmostSameValue`, agentically searched for the minimum ULP bound over the full fixture set, built the native add-on and cross-checked the C implementation under several compiler flag sets, verified determinism across two full runs of each test file, and ran the local lint and test suites before submitting.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_018FFKUiwfPegcvcqXWuAaH6)_