### PR TITLE
test: migrate `stats/base/dists/chi/logpdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chi/logpdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/logpdf/test/test.factory.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var randu = require( '@stdlib/random/base/randu' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
@@ -146,8 +146,6 @@ tape( 'the returned function returns `-Infinity` for all `x < 0`', function test
 tape( 'the created function evaluates the logpdf for `x` given degrees of freedom `k`', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
-	var tol;
 	var k;
 	var x;
 	var y;
@@ -159,13 +157,7 @@ tape( 'the created function evaluates the logpdf for `x` given degrees of freedo
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( k[i] );
 		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/logpdf/test/test.logpdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/logpdf/test/test.logpdf.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var randu = require( '@stdlib/random/base/randu' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
@@ -117,8 +117,6 @@ tape( 'the function returns `-Infinity` for all `x < 0`', function test( t ) {
 
 tape( 'the function evaluates the logpdf for `x` given degrees of freedom `k`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var k;
 	var y;
@@ -129,13 +127,7 @@ tape( 'the function evaluates the logpdf for `x` given degrees of freedom `k`', 
 	k = decimalDecimal.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/logpdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/logpdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -97,8 +96,6 @@ tape( 'if provided `-infinity` for `x` and a valid `k`, the function returns `-i
 
 tape( 'the function evaluates the logpdf for given `x` and `k`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var k;
 	var y;
@@ -109,13 +106,7 @@ tape( 'the function evaluates the logpdf for given `x` and `k`', opts, function 
 	k = data.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[ i ], k[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + ', k: ' + k[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] ); // Higher tolerance needed due to accumulated floating-point precision differences between JS and C implementations
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. k: ' + k[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/chi/logpdf` from relative tolerance comparisons to ULP difference assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].

The following files are updated:

-   `test/test.logpdf.js` (was `2.0 * EPS * abs( expected[ i ] )`) → **2 ULP**
-   `test/test.factory.js` (was `2.0 * EPS * abs( expected[ i ] )`) → **2 ULP**
-   `test/test.native.js` (was `40.0 * EPS * abs( expected[ i ] )`) → **2 ULP**

### ULP bounds

Each bound is the **measured minimum**. Over the full `decimal_decimal.json` fixture set (5000 cases), the maximum observed ULP difference against the expected values is `2` for each of the main, `factory`, and native implementations, attained at `x = 0.048002235420554484`, `k = 2.39848473901088`. At `1` ULP, all three implementations fail on that same case; at `0` ULP, six cases fail. The bounds were tightened downward from an initial value of `64` and the suite was run twice at the final value to confirm determinism.

The native add-on was compiled locally (`node-gyp rebuild`) so that `test/test.native.js` executes rather than skips; the previous `40.0 * EPS` native tolerance turned out to be considerably looser than required, as the C implementation agrees with the JavaScript implementation on this fixture set.

Only test files are touched; no implementation or fixture changes are included.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

While measuring, I noticed that the native results for this function are sensitive to floating-point contraction: compiling `src/main.c` with FMA contraction enabled (e.g., `-march=native -ffp-contract=fast`) raises the maximum observed difference from `2` to `48` ULP. stdlib's `binding.gyp` builds with `-O3 -std=c99` and no `-march` override, so the `2` ULP bound holds for the add-on as actually built here (verified against the compiled `.node`), but reviewers may want to confirm on an architecture where FMA contraction is the compiler default (e.g., arm64).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, running unattended as a scheduled task. It studied previously merged ULP migrations to mirror the established idiom, applied the edits, and searched for the minimum passing ULP bound empirically.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYyqUPEukY4soPWzpgy8RV)_