### PR TITLE
test: migrate `stats/base/dists/hypergeometric/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/stdev/test/test.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -119,8 +118,6 @@ tape( 'if provided an `n` which is not a nonnegative integer, the function retur
 
 tape( 'the function returns the standard deviation of a hypergeometric distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var N;
 	var K;
 	var n;
@@ -133,13 +130,7 @@ tape( 'the function returns the standard deviation of a hypergeometric distribut
 	n = data.n;
 	for ( i = 0; i < n.length; i++ ) {
 		y = stdev( N[i], K[i], n[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'N: '+N[i]+', K: '+K[i]+', n: '+n[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. N: '+N[i]+'. K: '+K[i]+'. n: '+n[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/stdev/test/test.native.js
@@ -22,10 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -87,8 +86,6 @@ tape( 'if provided an `n` which is not a nonnegative integer, the function retur
 
 tape( 'the function returns the standard deviation of a hypergeometric distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var N;
 	var K;
 	var n;
@@ -101,13 +98,7 @@ tape( 'the function returns the standard deviation of a hypergeometric distribut
 	n = data.n;
 	for ( i = 0; i < n.length; i++ ) {
 		y = stdev( N[i], K[i], n[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'N: '+N[i]+', K: '+K[i]+', n: '+n[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. N: '+N[i]+'. K: '+K[i]+'. n: '+n[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/hypergeometric/stdev` from relative tolerance testing (`delta <= EPS * abs( expected )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].

The following files are updated:

-   `test/test.js`: ULP bound of **2**.
-   `test/test.native.js`: ULP bound of **1**.

Each bound is the measured minimum over the full 100-case Julia fixture set (`test/fixtures/julia/data.json`); lowering `test/test.js` to `1` yields 4 failures, and lowering `test/test.native.js` to `0` yields 19 failures. The test suite was run twice at the final bounds to confirm the results are deterministic, and the native add-on was additionally compiled with `CFLAGS="-ffp-contract=off"` to confirm the C bound is not sensitive to FMA contraction.

Only the two test files are changed; no implementation, documentation, or fixture files are touched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

The JavaScript and C implementations require different bounds (2 vs. 1) for the same fixtures. Per the [FAQ][faq], the bounds are reported as measured rather than unified. Happy to use a single bound of `2` in both files if that is preferred.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed locally:

```
make test TESTS_FILTER=".*/stats/base/dists/hypergeometric/stdev/.*"
  test.js         120 passing
  test.native.js  108 passing

make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/hypergeometric/stdev/.*"
  clean
```

The native add-on was built locally so that `test/test.native.js` actually executed rather than being skipped.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. The agent studied previously merged conversions under this tracking issue to match the established idiom, applied the migration, and determined the minimum ULP bounds empirically by bisecting on the fixture set and re-running the suite.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

[faq]: https://github.com/stdlib-js/stdlib/blob/develop/docs/contributing/FAQ.md#js-vs-c-return-values


---
_Generated by [Claude Code](https://claude.ai/code/session_01L7AExAGAeNN4gnd4Ukbw6k)_