### PR TITLE
feat: add C implementation for `stats/base/ndarray/dnanmskmax`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/README.md
@@ -118,6 +118,173 @@ console.log( v );
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/stats/base/ndarray/dnanmskmax.h"
+```
+
+#### stdlib_stats_dnanmskmax( arrays )
+
+Computes the maximum value of a one-dimensional double-precision floating-point ndarray according to a mask, ignoring `NaN` values.
+
+```c
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/dtypes.h"
+#include "stdlib/ndarray/index_modes.h"
+#include "stdlib/ndarray/orders.h"
+#include "stdlib/ndarray/base/bytes_per_element.h"
+#include <stdint.h>
+
+// Create an ndarray:
+const double data[] = { 1.0, -2.0, 0.0/0.0, 2.0 };
+int64_t shape[] = { 4 };
+int64_t strides[] = { STDLIB_NDARRAY_FLOAT64_BYTES_PER_ELEMENT };
+int8_t submodes[] = { STDLIB_NDARRAY_INDEX_ERROR };
+
+struct ndarray *x = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT64, (uint8_t *)data, 1, shape, strides, 0, STDLIB_NDARRAY_ROW_MAJOR, STDLIB_NDARRAY_INDEX_ERROR, 1, submodes );
+
+// Create a mask ndarray:
+const uint8_t mdata[] = { 0, 0, 0, 0 };
+int64_t mstrides[] = { STDLIB_NDARRAY_UINT8_BYTES_PER_ELEMENT };
+
+struct ndarray *mask = stdlib_ndarray_allocate( STDLIB_NDARRAY_UINT8, mdata, 1, shape, mstrides, 0, STDLIB_NDARRAY_ROW_MAJOR, STDLIB_NDARRAY_INDEX_ERROR, 1, submodes );
+
+// Compute the maximum value:
+const struct ndarray *arrays[] = { x, mask };
+double v = stdlib_stats_dnanmskmax( arrays );
+// returns 2.0
+
+// Free allocated memory:
+stdlib_ndarray_free( x );
+stdlib_ndarray_free( mask );
+```
+
+The function accepts the following arguments:
+
+-   **arrays**: `[in] struct ndarray**` list containing the following ndarrays:
+
+    -   `[in] struct ndarray*` a one-dimensional input ndarray.
+    -   `[in] struct ndarray*` a one-dimensional mask ndarray.
+
+```c
+double stdlib_stats_dnanmskmax( const struct ndarray *arrays[] );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/stats/base/ndarray/dnanmskmax.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/dtypes.h"
+#include "stdlib/ndarray/index_modes.h"
+#include "stdlib/ndarray/orders.h"
+#include "stdlib/ndarray/base/bytes_per_element.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+   // Create a data buffer:
+   const double data[] = { 1.0, -2.0, 3.0, -4.0, 5.0, 0.0/0.0, 7.0, -8.0 };
+
+   // Specify the number of array dimensions:
+   const int64_t ndims = 1;
+
+   // Specify the array shape:
+   int64_t shape[] = { 4 };
+
+   // Specify the array strides:
+   int64_t strides[] = { 2*STDLIB_NDARRAY_FLOAT64_BYTES_PER_ELEMENT };
+
+   // Specify the byte offset:
+   const int64_t offset = 0;
+
+   // Specify the array order:
+   const enum STDLIB_NDARRAY_ORDER order = STDLIB_NDARRAY_ROW_MAJOR;
+
+   // Specify the index mode:
+   const enum STDLIB_NDARRAY_INDEX_MODE imode = STDLIB_NDARRAY_INDEX_ERROR;
+
+   // Specify the subscript index modes:
+   int8_t submodes[] = { STDLIB_NDARRAY_INDEX_ERROR };
+   const int64_t nsubmodes = 1;
+
+   // Create an ndarray:
+   struct ndarray *x = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT64, (uint8_t *)data, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+   if ( x == NULL ) {
+      fprintf( stderr, "Error allocating memory.\n" );
+      exit( 1 );
+   }
+
+   // Create a mask ndarray:
+   const uint8_t mdata[] = { 0, 0, 1, 0 };
+   int64_t mstrides[] = { STDLIB_NDARRAY_UINT8_BYTES_PER_ELEMENT };
+   struct ndarray *mask = stdlib_ndarray_allocate( STDLIB_NDARRAY_UINT8, mdata, ndims, shape, mstrides, offset, order, imode, nsubmodes, submodes );
+   if ( mask == NULL ) {
+      fprintf( stderr, "Error allocating memory.\n" );
+      exit( 1 );
+   }
+
+   // Define a list of ndarrays:
+   const struct ndarray *arrays[] = { x, mask };
+
+   // Compute the maximum value:
+   double v = stdlib_stats_dnanmskmax( arrays );
+
+   // Print the result:
+   printf( "max: %lf\n", v );
+
+   // Free allocated memory:
+   stdlib_ndarray_free( x );
+   stdlib_ndarray_free( mask );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/benchmark/benchmark.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,52 +20,29 @@
 
 // MODULES //
 
+var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
-var bernoulli = require( '@stdlib/random/base/bernoulli' );
-var fillBy = require( '@stdlib/ndarray/fill-by' );
-var zeros = require( '@stdlib/ndarray/zeros' );
+var uniform = require( '@stdlib/random/uniform' );
+var bernoulli = require( '@stdlib/random/bernoulli' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
+var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
-var dnanmskmax = require( './../lib/main.js' );
 
 
 // VARIABLES //
 
+var dnanmskmax = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( dnanmskmax instanceof Error )
+};
 var options = {
 	'dtype': 'float64'
-};
-var moptions = {
-	'dtype': 'uint8'
 };
 
 
 // FUNCTIONS //
-
-/**
-* Returns a random number.
-*
-* @private
-* @returns {number} random number
-*/
-function rand() {
-	if ( bernoulli( 0.8 ) < 1 ) {
-		return NaN;
-	}
-	return uniform( -10.0, 10.0 );
-}
-
-/**
-* Returns a random mask value.
-*
-* @private
-* @returns {integer} random mask value
-*/
-function mrand() {
-	return bernoulli( 0.2 );
-}
 
 /**
 * Creates a benchmark function.
@@ -78,9 +55,10 @@ function createBenchmark( len ) {
 	var mask;
 	var x;
 
-	x = fillBy( zeros( [ len ], options ), rand );
-	mask = fillBy( zeros( [ len ], moptions ), mrand );
-
+	x = uniform( [ len ], -100.0, 100.0, options );
+	mask = bernoulli( [ len ], 0.2, {
+		'dtype': 'uint8'
+	});
 	return benchmark;
 
 	/**
@@ -95,6 +73,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
+			x.set( i%len, i );
 			v = dnanmskmax( [ x, mask ] );
 			if ( isnan( v ) ) {
 				b.fail( 'should not return NaN' );
@@ -130,7 +109,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		bench( format( '%s::native:len=%d', pkg, len ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/benchmark/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.length.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/benchmark/c/benchmark.length.c
@@ -1,0 +1,197 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/ndarray/dnanmskmax.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/dtypes.h"
+#include "stdlib/ndarray/index_modes.h"
+#include "stdlib/ndarray/orders.h"
+#include "stdlib/ndarray/base/bytes_per_element.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "dnanmskmax"
+#define ITERATIONS 1000000
+#define REPEATS 3
+#define MIN 1
+#define MAX 6
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param iterations  number of iterations
+* @param elapsed     elapsed time in seconds
+*/
+static void print_results( int iterations, double elapsed ) {
+	double rate = (double)iterations / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", iterations );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1).
+*
+* @return random number
+*/
+static double rand_double( void ) {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @param iterations   number of iterations
+* @param len          array length
+* @return             elapsed time in seconds
+*/
+static double benchmark( int iterations, int len ) {
+	enum STDLIB_NDARRAY_INDEX_MODE imode;
+	const struct ndarray *arrays[ 2 ];
+	enum STDLIB_NDARRAY_ORDER order;
+	struct ndarray *mask;
+	int8_t submodes[ 1 ];
+	int64_t strides[ 1 ];
+	int64_t shape[ 1 ];
+	int64_t nsubmodes;
+	struct ndarray *x;
+	int64_t offset;
+	double elapsed;
+	uint8_t *mdata;
+	int64_t ndims;
+	double *xdata;
+	double v;
+	double t;
+	int i;
+
+	ndims = 1;
+	shape[ 0 ] = len;
+	strides[ 0 ] = STDLIB_NDARRAY_FLOAT64_BYTES_PER_ELEMENT;
+	offset = 0;
+	order = STDLIB_NDARRAY_ROW_MAJOR;
+	imode = STDLIB_NDARRAY_INDEX_ERROR;
+	submodes[ 0 ] = imode;
+	nsubmodes = 1;
+
+	xdata = (double *) malloc( len * sizeof( double ) );
+	mdata = (uint8_t *) malloc( len * sizeof( uint8_t ) );
+	for ( i = 0; i < len; i++ ) {
+		xdata[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
+		mdata[ i ] = 0;
+	}
+	// cppcheck-suppress invalidPointerCast
+	x = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT64, (uint8_t *)xdata, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+
+	strides[ 0 ] = STDLIB_NDARRAY_UINT8_BYTES_PER_ELEMENT;
+	mask = stdlib_ndarray_allocate( STDLIB_NDARRAY_UINT8, mdata, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+
+	arrays[ 0 ] = x;
+	arrays[ 1 ] = mask;
+
+	v = 0.0;
+	t = tic();
+	for ( i = 0; i < iterations; i++ ) {
+		v = stdlib_stats_dnanmskmax( arrays );
+		if ( v != v ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( v != v ) {
+		printf( "should not return NaN\n" );
+	}
+	stdlib_ndarray_free( x );
+	stdlib_ndarray_free( mask );
+	free( xdata );
+	free( mdata );
+	arrays[ 0 ] = NULL;
+	arrays[ 1 ] = NULL;
+
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int count;
+	int iter;
+	int len;
+	int i;
+	int j;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	count = 0;
+	for ( i = MIN; i <= MAX; i++ ) {
+		len = pow( 10, i );
+		iter = ITERATIONS / pow( 10, i-1 );
+		for ( j = 0; j < REPEATS; j++ ) {
+			count += 1;
+			printf( "# c::%s:len=%d\n", NAME, len );
+			elapsed = benchmark( iter, len );
+			print_results( iter, elapsed );
+			printf( "ok %d benchmark finished\n", count );
+		}
+	}
+	print_summary( count, count );
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/examples/c/example.c
@@ -1,0 +1,84 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/ndarray/dnanmskmax.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/dtypes.h"
+#include "stdlib/ndarray/index_modes.h"
+#include "stdlib/ndarray/orders.h"
+#include "stdlib/ndarray/base/bytes_per_element.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+	// Create a data buffer:
+	const double data[] = { 1.0, -2.0, 3.0, -4.0, 5.0, 0.0/0.0, 7.0, -8.0 };
+
+	// Specify the number of array dimensions:
+	const int64_t ndims = 1;
+
+	// Specify the array shape:
+	int64_t shape[] = { 4 };
+
+	// Specify the array strides:
+	int64_t strides[] = { 2*STDLIB_NDARRAY_FLOAT64_BYTES_PER_ELEMENT };
+
+	// Specify the byte offset:
+	const int64_t offset = 0;
+
+	// Specify the array order:
+	const enum STDLIB_NDARRAY_ORDER order = STDLIB_NDARRAY_ROW_MAJOR;
+
+	// Specify the index mode:
+	const enum STDLIB_NDARRAY_INDEX_MODE imode = STDLIB_NDARRAY_INDEX_ERROR;
+
+	// Specify the subscript index modes:
+	int8_t submodes[] = { STDLIB_NDARRAY_INDEX_ERROR };
+	const int64_t nsubmodes = 1;
+
+	// Create an ndarray:
+	// cppcheck-suppress invalidPointerCast
+	struct ndarray *x = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT64, (uint8_t *)data, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+	if ( x == NULL ) {
+		fprintf( stderr, "Error allocating memory.\n" );
+		exit( 1 );
+	}
+
+	// Create a mask ndarray:
+	const uint8_t mdata[] = { 0, 0, 1, 0 };
+	int64_t mstrides[] = { STDLIB_NDARRAY_UINT8_BYTES_PER_ELEMENT };
+	struct ndarray *mask = stdlib_ndarray_allocate( STDLIB_NDARRAY_UINT8, mdata, ndims, shape, mstrides, offset, order, imode, nsubmodes, submodes );
+	if ( mask == NULL ) {
+		fprintf( stderr, "Error allocating memory.\n" );
+		exit( 1 );
+	}
+
+	// Define a list of ndarrays:
+	const struct ndarray *arrays[] = { x, mask };
+
+	// Compute the maximum value:
+	double v = stdlib_stats_dnanmskmax( arrays );
+
+	// Print the result:
+	printf( "max: %lf\n", v );
+
+	// Free allocated memory:
+	stdlib_ndarray_free( x );
+	stdlib_ndarray_free( mask );
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/include/stdlib/stats/base/ndarray/dnanmskmax.h
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/include/stdlib/stats/base/ndarray/dnanmskmax.h
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_STATS_BASE_NDARRAY_DNANMSKMAX_H
+#define STDLIB_STATS_BASE_NDARRAY_DNANMSKMAX_H
+
+#include "stdlib/ndarray/ctor.h"
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Computes the maximum value of a one-dimensional double-precision floating-point ndarray according to a mask, ignoring `NaN` values.
+*/
+double stdlib_stats_dnanmskmax( const struct ndarray *arrays[] );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_STATS_BASE_NDARRAY_DNANMSKMAX_H

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/lib/native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,15 +18,32 @@
 
 'use strict';
 
+// MODULES //
+
+var serialize = require( '@stdlib/ndarray/base/serialize-meta-data' );
+var getData = require( '@stdlib/ndarray/base/data-buffer' );
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
 /**
-* Compute the maximum value of a double-precision floating-point ndarray according to a mask, ignoring `NaN` values.
+* Computes the maximum value of a one-dimensional double-precision floating-point ndarray according to a mask, ignoring `NaN` values.
 *
-* @module @stdlib/stats/base/ndarray/dnanmskmax
+* ## Notes
+*
+* -   The function expects the following ndarrays:
+*
+*     -   a one-dimensional input ndarray.
+*     -   a one-dimensional mask ndarray.
+*
+* @private
+* @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
+* @returns {number} maximum value
 *
 * @example
 * var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
 * var Uint8Vector = require( '@stdlib/ndarray/vector/uint8' );
-* var dnanmskmax = require( '@stdlib/stats/base/ndarray/dnanmskmax' );
 *
 * var x = new Float64Vector( [ 1.0, -2.0, NaN, 2.0 ] );
 * var mask = new Uint8Vector( [ 0, 0, 0, 0 ] );
@@ -34,23 +51,10 @@
 * var v = dnanmskmax( [ x, mask ] );
 * // returns 2.0
 */
-
-// MODULES //
-
-var join = require( 'path' ).join;
-var tryRequire = require( '@stdlib/utils/try-require' );
-var isError = require( '@stdlib/assert/is-error' );
-var main = require( './main.js' );
-
-
-// MAIN //
-
-var dnanmskmax;
-var tmp = tryRequire( join( __dirname, './native.js' ) );
-if ( isError( tmp ) ) {
-	dnanmskmax = main;
-} else {
-	dnanmskmax = tmp;
+function dnanmskmax( arrays ) {
+	var mask = arrays[ 1 ];
+	var x = arrays[ 0 ];
+	return addon( getData( x ), serialize( x ), getData( mask ), serialize( mask ) ); // eslint-disable-line max-len
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/manifest.json
@@ -1,0 +1,110 @@
+{
+  "options": {
+    "task": "build",
+    "wasm": false
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/stats/strided/dnanmskmax",
+        "@stdlib/ndarray/ctor",
+        "@stdlib/ndarray/base/napi/addon-arguments",
+        "@stdlib/napi/export",
+        "@stdlib/napi/argv",
+        "@stdlib/napi/create-double"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/stats/strided/dnanmskmax",
+        "@stdlib/ndarray/ctor",
+        "@stdlib/ndarray/dtypes",
+        "@stdlib/ndarray/index-modes",
+        "@stdlib/ndarray/orders",
+        "@stdlib/ndarray/base/bytes-per-element"
+      ]
+    },
+    {
+      "task": "examples",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/stats/strided/dnanmskmax",
+        "@stdlib/ndarray/ctor",
+        "@stdlib/ndarray/dtypes",
+        "@stdlib/ndarray/index-modes",
+        "@stdlib/ndarray/orders",
+        "@stdlib/ndarray/base/bytes-per-element"
+      ]
+    },
+    {
+      "task": "",
+      "wasm": true,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/stats/strided/dnanmskmax",
+        "@stdlib/ndarray/ctor"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/package.json
@@ -14,11 +14,15 @@
     }
   ],
   "main": "./lib",
+  "browser": "./lib/main.js",
+  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
+    "include": "./include",
     "lib": "./lib",
+    "src": "./src",
     "test": "./test"
   },
   "types": "./docs/types",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/src/addon.c
@@ -1,0 +1,65 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/ndarray/dnanmskmax.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/base/napi/addon_arguments.h"
+#include "stdlib/napi/export.h"
+#include "stdlib/napi/argv.h"
+#include "stdlib/napi/create_double.h"
+#include <node_api.h>
+#include <assert.h>
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon( napi_env env, napi_callback_info info ) {
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 4 );
+
+	// Process provided arguments:
+	struct ndarray *arrays[ 2 ];
+	napi_value err;
+	napi_status status = stdlib_ndarray_napi_addon_arguments( env, argv, 4, 2, arrays, &err );
+	assert( status == napi_ok );
+	if ( err != NULL ) {
+		status = napi_throw( env, err );
+		assert( status == napi_ok );
+		return NULL;
+	}
+	// Create a const-qualified view of the argument pointer list:
+	const struct ndarray *arr[ 2 ] = {
+		arrays[ 0 ],
+		arrays[ 1 ]
+	};
+	// Perform computation:
+	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_stats_dnanmskmax( arr ), v );
+
+	// Free allocated memory:
+	stdlib_ndarray_free( arrays[ 0 ] );
+	stdlib_ndarray_free( arrays[ 1 ] );
+	arrays[ 0 ] = NULL;
+	arrays[ 1 ] = NULL;
+
+	return v;
+}
+
+STDLIB_NAPI_MODULE_EXPORT_FCN( addon )

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/src/main.c
@@ -1,0 +1,41 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/ndarray/dnanmskmax.h"
+#include "stdlib/stats/strided/dnanmskmax.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/blas/base/shared.h"
+
+/**
+* Computes the maximum value of a one-dimensional double-precision floating-point ndarray according to a mask, ignoring `NaN` values.
+*
+* ## Notes
+*
+* -   The function expects the following ndarrays:
+*
+*     -   a one-dimensional input ndarray.
+*     -   a one-dimensional mask ndarray.
+*
+* @param arrays    list containing ndarrays
+* @return          maximum value
+*/
+double stdlib_stats_dnanmskmax( const struct ndarray *arrays[] ) {
+	const struct ndarray *x = arrays[ 0 ];
+	const struct ndarray *mask = arrays[ 1 ];
+	return API_SUFFIX(stdlib_strided_dnanmskmax_ndarray)( stdlib_ndarray_dimension( x, 0 ), (const double *)stdlib_ndarray_data( x ), stdlib_ndarray_stride_elements( x, 0 ), stdlib_ndarray_offset_elements( x ), (const uint8_t *)stdlib_ndarray_data( mask ), stdlib_ndarray_stride_elements( mask, 0 ), stdlib_ndarray_offset_elements( mask ) );
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/test/test.js
@@ -21,30 +21,16 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
-var Float64Array = require( '@stdlib/array/float64' );
-var Uint8Array = require( '@stdlib/array/uint8' );
-var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var proxyquire = require( 'proxyquire' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
 var dnanmskmax = require( './../lib' );
 
 
-// FUNCTIONS //
+// VARIABLES //
 
-/**
-* Returns a one-dimensional ndarray.
-*
-* @private
-* @param {string} dtype - data type
-* @param {Collection} buffer - underlying data buffer
-* @param {NonNegativeInteger} length - number of indexed elements
-* @param {integer} stride - stride length
-* @param {NonNegativeInteger} offset - index offset
-* @returns {ndarray} one-dimensional ndarray
-*/
-function vector( dtype, buffer, length, stride, offset ) {
-	return new ndarray( dtype, buffer, [ length ], [ stride ], offset, 'row-major' );
-}
+var opts = {
+	'skip': IS_BROWSER
+};
 
 
 // TESTS //
@@ -55,178 +41,37 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'the function has an arity of 1', function test( t ) {
-	t.strictEqual( dnanmskmax.length, 1, 'has expected arity' );
+tape( 'if a native implementation is available, the main export is the native implementation', opts, function test( t ) {
+	var dnanmskmax = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
+
+	t.strictEqual( dnanmskmax, mock, 'returns expected value' );
 	t.end();
+
+	function tryRequire() {
+		return mock;
+	}
+
+	function mock() {
+		// Mock...
+	}
 });
 
-tape( 'the function calculates the maximum value of a one-dimensional ndarray according to a mask, ignoring `NaN` values', function test( t ) {
-	var mask;
-	var x;
-	var v;
+tape( 'if a native implementation is not available, the main export is a JavaScript implementation', opts, function test( t ) {
+	var dnanmskmax;
+	var main;
 
-	x = new Float64Array( [ 1.0, -2.0, -4.0, NaN, 5.0, 0.0, 3.0 ] );
-	mask = new Uint8Array( [ 0, 0, 0, 0, 1, 0, 0 ] );
-	v = dnanmskmax( [ vector( 'float64', x, x.length, 1, 0 ), vector( 'uint8', mask, mask.length, 1, 0 ) ] );
-	t.strictEqual( v, 3.0, 'returns expected value' );
+	main = require( './../lib/main.js' );
 
-	x = new Float64Array( [ -4.0, NaN, -5.0 ] );
-	mask = new Uint8Array( [ 0, 0, 0 ] );
-	v = dnanmskmax( [ vector( 'float64', x, x.length, 1, 0 ), vector( 'uint8', mask, mask.length, 1, 0 ) ] );
-	t.strictEqual( v, -4.0, 'returns expected value' );
+	dnanmskmax = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
 
-	x = new Float64Array( [-0.0, 0.0, NaN, -0.0 ] );
-	mask = new Uint8Array( [ 0, 0, 0, 0 ] );
-	v = dnanmskmax( [ vector( 'float64', x, x.length, 1, 0 ), vector( 'uint8', mask, mask.length, 1, 0 ) ] );
-	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
-
-	x = new Float64Array( [ NaN ] );
-	mask = new Uint8Array( [ 0 ] );
-	v = dnanmskmax( [ vector( 'float64', x, x.length, 1, 0 ), vector( 'uint8', mask, mask.length, 1, 0 ) ] );
-	t.strictEqual( isnan( v ), true, 'returns expected value' );
-
-	x = new Float64Array( [ NaN, NaN ] );
-	mask = new Uint8Array( [ 0, 0 ] );
-	v = dnanmskmax( [ vector( 'float64', x, x.length, 1, 0 ), vector( 'uint8', mask, mask.length, 1, 0 ) ] );
-	t.strictEqual( isnan( v ), true, 'returns expected value' );
-
+	t.strictEqual( dnanmskmax, main, 'returns expected value' );
 	t.end();
-});
 
-tape( 'if provided an empty ndarray, the function returns `NaN`', function test( t ) {
-	var mask;
-	var x;
-	var v;
-
-	x = new Float64Array( [] );
-	mask = new Uint8Array( [] );
-
-	v = dnanmskmax( [ vector( 'float64', x, 0, 1, 0 ), vector( 'uint8', mask, 0, 1, 0 ) ] );
-	t.strictEqual( isnan( v ), true, 'returns expected value' );
-
-	t.end();
-});
-
-tape( 'if provided an ndarray containing a single element, the function returns that element', function test( t ) {
-	var mask;
-	var x;
-	var v;
-
-	x = new Float64Array( [ 1.0 ] );
-	mask = new Uint8Array( [ 0 ] );
-
-	v = dnanmskmax( [ vector( 'float64', x, 1, 1, 0 ), vector( 'uint8', mask, 1, 1, 0 ) ] );
-	t.strictEqual( v, 1.0, 'returns expected value' );
-
-	t.end();
-});
-
-tape( 'the function supports one-dimensional ndarrays having non-unit strides', function test( t ) {
-	var mask;
-	var x;
-	var v;
-
-	x = new Float64Array([
-		1.0,  // 0
-		2.0,
-		2.0,  // 1
-		-7.0,
-		-2.0, // 2
-		3.0,
-		4.0,  // 3
-		2.0,
-		NaN,  // 4
-		NaN
-	]);
-	mask = new Uint8Array([
-		0,  // 0
-		0,
-		0,  // 1
-		0,
-		0,  // 2
-		0,
-		0,  // 3
-		0,
-		0,  // 4
-		0
-	]);
-
-	v = dnanmskmax( [ vector( 'float64', x, 5, 2, 0 ), vector( 'uint8', mask, 5, 2, 0 ) ] );
-
-	t.strictEqual( v, 4.0, 'returns expected value' );
-	t.end();
-});
-
-tape( 'the function supports one-dimensional ndarrays having negative strides', function test( t ) {
-	var mask;
-	var x;
-	var v;
-
-	x = new Float64Array([
-		NaN,  // 4
-		NaN,
-		1.0,  // 3
-		2.0,
-		2.0,  // 2
-		-7.0,
-		-2.0, // 1
-		3.0,
-		4.0,  // 0
-		2.0
-	]);
-	mask = new Uint8Array([
-		0,  // 4
-		0,
-		0,  // 3
-		0,
-		0,  // 2
-		0,
-		0,  // 1
-		0,
-		0,  // 0
-		0
-	]);
-
-	v = dnanmskmax( [ vector( 'float64', x, 5, -2, 8 ), vector( 'uint8', mask, 5, -2, 8 ) ] );
-
-	t.strictEqual( v, 4.0, 'returns expected value' );
-	t.end();
-});
-
-tape( 'the function supports one-dimensional ndarrays having non-zero offsets', function test( t ) {
-	var mask;
-	var x;
-	var v;
-
-	x = new Float64Array([
-		2.0,
-		1.0,  // 0
-		2.0,
-		-2.0, // 1
-		-2.0,
-		2.0,  // 2
-		3.0,
-		4.0,  // 3
-		6.0,
-		NaN,  // 4
-		NaN
-	]);
-	mask = new Uint8Array([
-		0,
-		0,  // 0
-		0,
-		0,  // 1
-		0,
-		0,  // 2
-		0,
-		0,  // 3
-		0,
-		0,  // 4
-		0
-	]);
-
-	v = dnanmskmax( [ vector( 'float64', x, 5, 2, 1 ), vector( 'uint8', mask, 5, 2, 1 ) ] );
-	t.strictEqual( v, 4.0, 'returns expected value' );
-
-	t.end();
+	function tryRequire() {
+		return new Error( 'Cannot find module' );
+	}
 });

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/test/test.main.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/test/test.main.js
@@ -1,0 +1,232 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var Float64Array = require( '@stdlib/array/float64' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var dnanmskmax = require( './../lib/main.js' );
+
+
+// FUNCTIONS //
+
+/**
+* Returns a one-dimensional ndarray.
+*
+* @private
+* @param {string} dtype - data type
+* @param {Collection} buffer - underlying data buffer
+* @param {NonNegativeInteger} length - number of indexed elements
+* @param {integer} stride - stride length
+* @param {NonNegativeInteger} offset - index offset
+* @returns {ndarray} one-dimensional ndarray
+*/
+function vector( dtype, buffer, length, stride, offset ) {
+	return new ndarray( dtype, buffer, [ length ], [ stride ], offset, 'row-major' );
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof dnanmskmax, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 1', function test( t ) {
+	t.strictEqual( dnanmskmax.length, 1, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the maximum value of a one-dimensional ndarray according to a mask, ignoring `NaN` values', function test( t ) {
+	var mask;
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, NaN, 5.0, 0.0, 3.0 ] );
+	mask = new Uint8Array( [ 0, 0, 0, 0, 1, 0, 0 ] );
+	v = dnanmskmax( [ vector( 'float64', x, x.length, 1, 0 ), vector( 'uint8', mask, mask.length, 1, 0 ) ] );
+	t.strictEqual( v, 3.0, 'returns expected value' );
+
+	x = new Float64Array( [ -4.0, NaN, -5.0 ] );
+	mask = new Uint8Array( [ 0, 0, 0 ] );
+	v = dnanmskmax( [ vector( 'float64', x, x.length, 1, 0 ), vector( 'uint8', mask, mask.length, 1, 0 ) ] );
+	t.strictEqual( v, -4.0, 'returns expected value' );
+
+	x = new Float64Array( [ -0.0, 0.0, NaN, -0.0 ] );
+	mask = new Uint8Array( [ 0, 0, 0, 0 ] );
+	v = dnanmskmax( [ vector( 'float64', x, x.length, 1, 0 ), vector( 'uint8', mask, mask.length, 1, 0 ) ] );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
+
+	x = new Float64Array( [ NaN ] );
+	mask = new Uint8Array( [ 0 ] );
+	v = dnanmskmax( [ vector( 'float64', x, x.length, 1, 0 ), vector( 'uint8', mask, mask.length, 1, 0 ) ] );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	x = new Float64Array( [ NaN, NaN ] );
+	mask = new Uint8Array( [ 0, 0 ] );
+	v = dnanmskmax( [ vector( 'float64', x, x.length, 1, 0 ), vector( 'uint8', mask, mask.length, 1, 0 ) ] );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an empty ndarray, the function returns `NaN`', function test( t ) {
+	var mask;
+	var x;
+	var v;
+
+	x = new Float64Array( [] );
+	mask = new Uint8Array( [] );
+
+	v = dnanmskmax( [ vector( 'float64', x, 0, 1, 0 ), vector( 'uint8', mask, 0, 1, 0 ) ] );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an ndarray containing a single element, the function returns that element', function test( t ) {
+	var mask;
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0 ] );
+	mask = new Uint8Array( [ 0 ] );
+
+	v = dnanmskmax( [ vector( 'float64', x, 1, 1, 0 ), vector( 'uint8', mask, 1, 1, 0 ) ] );
+	t.strictEqual( v, 1.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports one-dimensional ndarrays having non-unit strides', function test( t ) {
+	var mask;
+	var x;
+	var v;
+
+	x = new Float64Array([
+		1.0,  // 0
+		2.0,
+		2.0,  // 1
+		-7.0,
+		-2.0, // 2
+		3.0,
+		4.0,  // 3
+		2.0,
+		NaN,  // 4
+		NaN
+	]);
+	mask = new Uint8Array([
+		0,  // 0
+		0,
+		0,  // 1
+		0,
+		0,  // 2
+		0,
+		0,  // 3
+		0,
+		0,  // 4
+		0
+	]);
+
+	v = dnanmskmax( [ vector( 'float64', x, 5, 2, 0 ), vector( 'uint8', mask, 5, 2, 0 ) ] );
+
+	t.strictEqual( v, 4.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports one-dimensional ndarrays having negative strides', function test( t ) {
+	var mask;
+	var x;
+	var v;
+
+	x = new Float64Array([
+		NaN,  // 4
+		NaN,
+		1.0,  // 3
+		2.0,
+		2.0,  // 2
+		-7.0,
+		-2.0, // 1
+		3.0,
+		4.0,  // 0
+		2.0
+	]);
+	mask = new Uint8Array([
+		0,  // 4
+		0,
+		0,  // 3
+		0,
+		0,  // 2
+		0,
+		0,  // 1
+		0,
+		0,  // 0
+		0
+	]);
+
+	v = dnanmskmax( [ vector( 'float64', x, 5, -2, 8 ), vector( 'uint8', mask, 5, -2, 8 ) ] );
+
+	t.strictEqual( v, 4.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports one-dimensional ndarrays having non-zero offsets', function test( t ) {
+	var mask;
+	var x;
+	var v;
+
+	x = new Float64Array([
+		2.0,
+		1.0,  // 0
+		2.0,
+		-2.0, // 1
+		-2.0,
+		2.0,  // 2
+		3.0,
+		4.0,  // 3
+		6.0,
+		NaN,  // 4
+		NaN
+	]);
+	mask = new Uint8Array([
+		0,
+		0,  // 0
+		0,
+		0,  // 1
+		0,
+		0,  // 2
+		0,
+		0,  // 3
+		0,
+		0,  // 4
+		0
+	]);
+
+	v = dnanmskmax( [ vector( 'float64', x, 5, 2, 1 ), vector( 'uint8', mask, 5, 2, 1 ) ] );
+	t.strictEqual( v, 4.0, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/test/test.native.js
@@ -1,0 +1,241 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var Float64Array = require( '@stdlib/array/float64' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var dnanmskmax = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( dnanmskmax instanceof Error )
+};
+
+
+// FUNCTIONS //
+
+/**
+* Returns a one-dimensional ndarray.
+*
+* @private
+* @param {string} dtype - data type
+* @param {Collection} buffer - underlying data buffer
+* @param {NonNegativeInteger} length - number of indexed elements
+* @param {integer} stride - stride length
+* @param {NonNegativeInteger} offset - index offset
+* @returns {ndarray} one-dimensional ndarray
+*/
+function vector( dtype, buffer, length, stride, offset ) {
+	return new ndarray( dtype, buffer, [ length ], [ stride ], offset, 'row-major' );
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof dnanmskmax, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 1', opts, function test( t ) {
+	t.strictEqual( dnanmskmax.length, 1, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the maximum value of a one-dimensional ndarray according to a mask, ignoring `NaN` values', opts, function test( t ) {
+	var mask;
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, NaN, 5.0, 0.0, 3.0 ] );
+	mask = new Uint8Array( [ 0, 0, 0, 0, 1, 0, 0 ] );
+	v = dnanmskmax( [ vector( 'float64', x, x.length, 1, 0 ), vector( 'uint8', mask, mask.length, 1, 0 ) ] );
+	t.strictEqual( v, 3.0, 'returns expected value' );
+
+	x = new Float64Array( [ -4.0, NaN, -5.0 ] );
+	mask = new Uint8Array( [ 0, 0, 0 ] );
+	v = dnanmskmax( [ vector( 'float64', x, x.length, 1, 0 ), vector( 'uint8', mask, mask.length, 1, 0 ) ] );
+	t.strictEqual( v, -4.0, 'returns expected value' );
+
+	x = new Float64Array( [ -0.0, 0.0, NaN, -0.0 ] );
+	mask = new Uint8Array( [ 0, 0, 0, 0 ] );
+	v = dnanmskmax( [ vector( 'float64', x, x.length, 1, 0 ), vector( 'uint8', mask, mask.length, 1, 0 ) ] );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
+
+	x = new Float64Array( [ NaN ] );
+	mask = new Uint8Array( [ 0 ] );
+	v = dnanmskmax( [ vector( 'float64', x, x.length, 1, 0 ), vector( 'uint8', mask, mask.length, 1, 0 ) ] );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	x = new Float64Array( [ NaN, NaN ] );
+	mask = new Uint8Array( [ 0, 0 ] );
+	v = dnanmskmax( [ vector( 'float64', x, x.length, 1, 0 ), vector( 'uint8', mask, mask.length, 1, 0 ) ] );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an empty ndarray, the function returns `NaN`', opts, function test( t ) {
+	var mask;
+	var x;
+	var v;
+
+	x = new Float64Array( [] );
+	mask = new Uint8Array( [] );
+
+	v = dnanmskmax( [ vector( 'float64', x, 0, 1, 0 ), vector( 'uint8', mask, 0, 1, 0 ) ] );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an ndarray containing a single element, the function returns that element', opts, function test( t ) {
+	var mask;
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0 ] );
+	mask = new Uint8Array( [ 0 ] );
+
+	v = dnanmskmax( [ vector( 'float64', x, 1, 1, 0 ), vector( 'uint8', mask, 1, 1, 0 ) ] );
+	t.strictEqual( v, 1.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports one-dimensional ndarrays having non-unit strides', opts, function test( t ) {
+	var mask;
+	var x;
+	var v;
+
+	x = new Float64Array([
+		1.0,  // 0
+		2.0,
+		2.0,  // 1
+		-7.0,
+		-2.0, // 2
+		3.0,
+		4.0,  // 3
+		2.0,
+		NaN,  // 4
+		NaN
+	]);
+	mask = new Uint8Array([
+		0,  // 0
+		0,
+		0,  // 1
+		0,
+		0,  // 2
+		0,
+		0,  // 3
+		0,
+		0,  // 4
+		0
+	]);
+
+	v = dnanmskmax( [ vector( 'float64', x, 5, 2, 0 ), vector( 'uint8', mask, 5, 2, 0 ) ] );
+
+	t.strictEqual( v, 4.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports one-dimensional ndarrays having negative strides', opts, function test( t ) {
+	var mask;
+	var x;
+	var v;
+
+	x = new Float64Array([
+		NaN,  // 4
+		NaN,
+		1.0,  // 3
+		2.0,
+		2.0,  // 2
+		-7.0,
+		-2.0, // 1
+		3.0,
+		4.0,  // 0
+		2.0
+	]);
+	mask = new Uint8Array([
+		0,  // 4
+		0,
+		0,  // 3
+		0,
+		0,  // 2
+		0,
+		0,  // 1
+		0,
+		0,  // 0
+		0
+	]);
+
+	v = dnanmskmax( [ vector( 'float64', x, 5, -2, 8 ), vector( 'uint8', mask, 5, -2, 8 ) ] );
+
+	t.strictEqual( v, 4.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports one-dimensional ndarrays having non-zero offsets', opts, function test( t ) {
+	var mask;
+	var x;
+	var v;
+
+	x = new Float64Array([
+		2.0,
+		1.0,  // 0
+		2.0,
+		-2.0, // 1
+		-2.0,
+		2.0,  // 2
+		3.0,
+		4.0,  // 3
+		6.0,
+		NaN,  // 4
+		NaN
+	]);
+	mask = new Uint8Array([
+		0,
+		0,  // 0
+		0,
+		0,  // 1
+		0,
+		0,  // 2
+		0,
+		0,  // 3
+		0,
+		0,  // 4
+		0
+	]);
+
+	v = dnanmskmax( [ vector( 'float64', x, 5, 2, 1 ), vector( 'uint8', mask, 5, 2, 1 ) ] );
+	t.strictEqual( v, 4.0, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
Resolves a part of #14034 

## Description

> What is the purpose of this pull request?

This pull request:

-   adds a native C implementation for computing the maximum value of a one-dimensional double-precision floating-point ndarray according to a mask, ignoring `NaN` values (`dnanmskmax`).
-   updates the test suite (`test.js`, `test.main.js`, `test.native.js`) and benchmarks to cover and utilize the new native C addon.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #14034 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I consulted an AI assistant to help research the `stdlib` N-API architecture, understand the `ndarray` masking logic, and to structure and generate the test files (`test.main.js`, `test.native.js`) and benchmark files required to test the native C addon. The core logic and implementation were authored manually by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
