### PR TITLE
feat: add C implementation for `blas/ext/base/ndarray/dcusum`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/README.md
@@ -113,6 +113,155 @@ console.log( ndarray2array( v ) );
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+<section class="c">
+
+## C APIs
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/blas/ext/base/ndarray/dcusum.h"
+```
+
+#### stdlib_blas_ext_dcusum( sum, arrays )
+
+Computes the cumulative sum of a one-dimensional double-precision floating-point ndarray.
+
+```c
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/dtypes.h"
+#include "stdlib/ndarray/index_modes.h"
+#include "stdlib/ndarray/orders.h"
+#include "stdlib/ndarray/base/bytes_per_element.h"
+#include <stdint.h>
+
+// Create ndarrays:
+const double dataX[] = { 1.0, 2.0, 3.0, 4.0, 5.0 };
+double dataY[] = { 0.0, 0.0, 0.0, 0.0, 0.0 };
+int64_t shape[] = { 5 };
+int64_t strides[] = { STDLIB_NDARRAY_FLOAT64_BYTES_PER_ELEMENT };
+int8_t submodes[] = { STDLIB_NDARRAY_INDEX_ERROR };
+
+struct ndarray *x = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT64, (uint8_t *)dataX, 1, shape, strides, 0, STDLIB_NDARRAY_ROW_MAJOR, STDLIB_NDARRAY_INDEX_ERROR, 1, submodes );
+struct ndarray *y = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT64, (uint8_t *)dataY, 1, shape, strides, 0, STDLIB_NDARRAY_ROW_MAJOR, STDLIB_NDARRAY_INDEX_ERROR, 1, submodes );
+
+// Perform computation:
+const struct ndarray *arrays[] = { x, y };
+stdlib_blas_ext_dcusum( 0.0, arrays );
+
+// Free allocated memory:
+stdlib_ndarray_free( x );
+stdlib_ndarray_free( y );
+```
+
+The function accepts the following arguments:
+
+-   **sum**: `[in] double` initial sum.
+
+-   **arrays**: `[in] struct ndarray**` list containing the following ndarrays:
+
+    -   `[in] struct ndarray*` a one-dimensional input ndarray.
+    -   `[inout] struct ndarray*` a one-dimensional output ndarray.
+
+```c
+void stdlib_blas_ext_dcusum( const double sum, const struct ndarray *arrays[] );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/blas/ext/base/ndarray/dcusum.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/dtypes.h"
+#include "stdlib/ndarray/index_modes.h"
+#include "stdlib/ndarray/orders.h"
+#include "stdlib/ndarray/base/bytes_per_element.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+    // Create data buffers:
+    const double dataX[] = { 1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0 };
+    double dataY[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+
+    // Specify the number of array dimensions:
+    const int64_t ndims = 1;
+
+    // Specify the array shape:
+    int64_t shape[] = { 8 };
+
+    // Specify the array strides:
+    int64_t strides[] = { STDLIB_NDARRAY_FLOAT64_BYTES_PER_ELEMENT };
+
+    // Specify the byte offset:
+    const int64_t offset = 0;
+
+    // Specify the array order:
+    const enum STDLIB_NDARRAY_ORDER order = STDLIB_NDARRAY_ROW_MAJOR;
+
+    // Specify the index mode:
+    const enum STDLIB_NDARRAY_INDEX_MODE imode = STDLIB_NDARRAY_INDEX_ERROR;
+
+    // Specify the subscript index modes:
+    int8_t submodes[] = { STDLIB_NDARRAY_INDEX_ERROR };
+    const int64_t nsubmodes = 1;
+
+    // Create ndarrays:
+    struct ndarray *x = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT64, (uint8_t *)dataX, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+    struct ndarray *y = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT64, (uint8_t *)dataY, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+    if ( x == NULL || y == NULL ) {
+        fprintf( stderr, "Error allocating memory.\n" );
+        exit( 1 );
+    }
+
+    // Define a list of ndarrays:
+    const struct ndarray *arrays[] = { x, y };
+
+    // Perform computation:
+    stdlib_blas_ext_dcusum( 0.0, arrays );
+
+    // Print the result:
+    for ( int i = 0; i < 8; i++ ) {
+        printf( "y[ %i ] = %lf\n", i, dataY[ i ] );
+    }
+
+    // Free allocated memory:
+    stdlib_ndarray_free( x );
+    stdlib_ndarray_free( y );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/binding.gyp
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/examples/c/example.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/examples/c/example.c
@@ -1,0 +1,81 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/blas/ext/base/ndarray/dcusum.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/dtypes.h"
+#include "stdlib/ndarray/index_modes.h"
+#include "stdlib/ndarray/orders.h"
+#include "stdlib/ndarray/base/bytes_per_element.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+	// Create data buffers:
+	const double dataX[] = { 1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0 };
+	double dataY[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+
+	// Specify the number of array dimensions:
+	const int64_t ndims = 1;
+
+	// Specify the array shape:
+	int64_t shape[] = { 8 };
+
+	// Specify the array strides:
+	int64_t strides[] = { STDLIB_NDARRAY_FLOAT64_BYTES_PER_ELEMENT };
+
+	// Specify the byte offset:
+	const int64_t offset = 0;
+
+	// Specify the array order:
+	const enum STDLIB_NDARRAY_ORDER order = STDLIB_NDARRAY_ROW_MAJOR;
+
+	// Specify the index mode:
+	const enum STDLIB_NDARRAY_INDEX_MODE imode = STDLIB_NDARRAY_INDEX_ERROR;
+
+	// Specify the subscript index modes:
+	int8_t submodes[] = { STDLIB_NDARRAY_INDEX_ERROR };
+	const int64_t nsubmodes = 1;
+
+	// Create ndarrays:
+	// cppcheck-suppress invalidPointerCast
+	struct ndarray *x = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT64, (uint8_t *)dataX, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+
+	// cppcheck-suppress invalidPointerCast
+	struct ndarray *y = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT64, (uint8_t *)dataY, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+	if ( x == NULL || y == NULL ) {
+		fprintf( stderr, "Error allocating memory.\n" );
+		exit( 1 );
+	}
+
+	// Define a list of ndarrays:
+	const struct ndarray *arrays[] = { x, y };
+
+	// Perform computation:
+	stdlib_blas_ext_dcusum( 0.0, arrays );
+
+	// Print the result:
+	for ( int i = 0; i < 8; i++ ) {
+		printf( "y[ %i ] = %lf\n", i, dataY[ i ] );
+	}
+
+	// Free allocated memory:
+	stdlib_ndarray_free( x );
+	stdlib_ndarray_free( y );
+}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/include.gypi
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/include/stdlib/blas/ext/base/ndarray/dcusum.h
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/include/stdlib/blas/ext/base/ndarray/dcusum.h
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_BLAS_EXT_BASE_NDARRAY_DCUSUM_H
+#define STDLIB_BLAS_EXT_BASE_NDARRAY_DCUSUM_H
+
+#include "stdlib/ndarray/ctor.h"
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Computes the cumulative sum of a one-dimensional double-precision floating-point ndarray.
+*/
+void stdlib_blas_ext_dcusum( const double sum, const struct ndarray *arrays[] );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_BLAS_EXT_BASE_NDARRAY_DCUSUM_H

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/lib/native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/lib/native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,15 +18,34 @@
 
 'use strict';
 
+// MODULES //
+
+var serialize = require( '@stdlib/ndarray/base/serialize-meta-data' );
+var getData = require( '@stdlib/ndarray/base/data-buffer' );
+var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
 /**
-* Compute the cumulative sum of a one-dimensional double-precision floating-point ndarray.
+* Computes the cumulative sum of a one-dimensional double-precision floating-point ndarray.
 *
-* @module @stdlib/blas/ext/base/ndarray/dcusum
+* ## Notes
+*
+* -   The function expects the following ndarrays:
+*
+*     -   a one-dimensional input ndarray.
+*     -   a one-dimensional output ndarray.
+*     -   a zero-dimensional ndarray containing the initial sum.
+*
+* @private
+* @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
+* @returns {Object} output ndarray
 *
 * @example
 * var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
 * var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
-* var dcusum = require( '@stdlib/blas/ext/base/ndarray/dcusum' );
 *
 * var x = new Float64Vector( [ 1.0, 3.0, 4.0, 2.0 ] );
 * var y = new Float64Vector( [ 0.0, 0.0, 0.0, 0.0 ] );
@@ -41,23 +60,12 @@
 * var bool = ( z === y );
 * // returns true
 */
-
-// MODULES //
-
-var join = require( 'path' ).join;
-var tryRequire = require( '@stdlib/utils/try-require' );
-var isError = require( '@stdlib/assert/is-error' );
-var main = require( './main.js' );
-
-
-// MAIN //
-
-var dcusum;
-var tmp = tryRequire( join( __dirname, './native.js' ) );
-if ( isError( tmp ) ) {
-	dcusum = main;
-} else {
-	dcusum = tmp;
+function dcusum( arrays ) {
+	var x = arrays[ 0 ];
+	var y = arrays[ 1 ];
+	var v = ndarraylike2scalar( arrays[ 2 ] );
+	addon( v, getData( x ), serialize( x ), getData( y ), serialize( y ) );
+	return y;
 }
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/manifest.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/manifest.json
@@ -1,0 +1,110 @@
+{
+  "options": {
+    "task": "build",
+    "wasm": false
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/blas/ext/base/dcusum",
+        "@stdlib/ndarray/ctor",
+        "@stdlib/ndarray/base/napi/addon-arguments",
+        "@stdlib/napi/export",
+        "@stdlib/napi/argv",
+        "@stdlib/napi/argv-double"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/blas/ext/base/dcusum",
+        "@stdlib/ndarray/ctor",
+        "@stdlib/ndarray/dtypes",
+        "@stdlib/ndarray/index-modes",
+        "@stdlib/ndarray/orders",
+        "@stdlib/ndarray/base/bytes-per-element"
+      ]
+    },
+    {
+      "task": "examples",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/blas/ext/base/dcusum",
+        "@stdlib/ndarray/ctor",
+        "@stdlib/ndarray/dtypes",
+        "@stdlib/ndarray/index-modes",
+        "@stdlib/ndarray/orders",
+        "@stdlib/ndarray/base/bytes-per-element"
+      ]
+    },
+    {
+      "task": "",
+      "wasm": true,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/blas/ext/base/dcusum",
+        "@stdlib/ndarray/ctor"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/package.json
@@ -14,6 +14,7 @@
     }
   ],
   "main": "./lib",
+  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/src/Makefile
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/src/addon.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/src/addon.c
@@ -1,0 +1,66 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/blas/ext/base/ndarray/dcusum.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/base/napi/addon_arguments.h"
+#include "stdlib/napi/export.h"
+#include "stdlib/napi/argv.h"
+#include "stdlib/napi/argv_double.h"
+#include <node_api.h>
+#include <assert.h>
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon( napi_env env, napi_callback_info info ) {
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 5 );
+	STDLIB_NAPI_ARGV_DOUBLE( env, sum, argv, 0 );
+
+	// Process provided ndarray arguments (x: argv[1:3], y: argv[3:5]):
+	struct ndarray *arrays[ 2 ];
+	napi_value err;
+	napi_status status = stdlib_ndarray_napi_addon_arguments( env, &argv[ 1 ], 4, 2, arrays, &err );
+	assert( status == napi_ok );
+	if ( err != NULL ) {
+		status = napi_throw( env, err );
+		assert( status == napi_ok );
+		return NULL;
+	}
+	// Create a const-qualified view of the argument pointer list:
+	const struct ndarray *arr[ 2 ] = {
+		arrays[ 0 ],
+		arrays[ 1 ]
+	};
+	// Perform computation:
+	stdlib_blas_ext_dcusum( sum, arr );
+
+	// Free allocated memory:
+	stdlib_ndarray_free( arrays[ 0 ] );
+	stdlib_ndarray_free( arrays[ 1 ] );
+	arrays[ 0 ] = NULL;
+	arrays[ 1 ] = NULL;
+
+	return NULL;
+}
+
+STDLIB_NAPI_MODULE_EXPORT_FCN( addon )

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/src/main.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/src/main.c
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/blas/ext/base/ndarray/dcusum.h"
+#include "stdlib/blas/ext/base/dcusum.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/blas/base/shared.h"
+
+/**
+* Computes the cumulative sum of a one-dimensional double-precision floating-point ndarray.
+*
+* ## Notes
+*
+* -   The function expects the following ndarrays:
+*
+*     -   a one-dimensional input ndarray.
+*     -   a one-dimensional output ndarray.
+*
+* @param sum       initial sum
+* @param arrays    list containing ndarrays
+*/
+void stdlib_blas_ext_dcusum( const double sum, const struct ndarray *arrays[] ) {
+	const struct ndarray *x = arrays[ 0 ];
+	const struct ndarray *y = arrays[ 1 ];
+
+	const CBLAS_INT N = stdlib_ndarray_dimension( x, 0 );
+
+	const CBLAS_INT strideX = stdlib_ndarray_stride_elements( x, 0 );
+	const CBLAS_INT offsetX = stdlib_ndarray_offset_elements( x );
+	const CBLAS_INT strideY = stdlib_ndarray_stride_elements( y, 0 );
+	const CBLAS_INT offsetY = stdlib_ndarray_offset_elements( y );
+
+	const double *dataX = (const double *)stdlib_ndarray_data( x );
+	double *dataY = (double *)stdlib_ndarray_data( y );
+	API_SUFFIX(stdlib_strided_dcusum_ndarray)( N, sum, dataX, strideX, offsetX, dataY, strideY, offsetY );
+}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/test/test.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/test/test.native.js
@@ -1,0 +1,320 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isSameFloat64Array = require( '@stdlib/assert/is-same-float64array' );
+var Float64Array = require( '@stdlib/array/float64' );
+var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var scalar2ndarrayLike = require( '@stdlib/ndarray/base/from-scalar-like' );
+var zerosLike = require( '@stdlib/ndarray/zeros-like' );
+var getData = require( '@stdlib/ndarray/data-buffer' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var dcusum = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( dcusum instanceof Error )
+};
+
+
+// FUNCTIONS //
+
+/**
+* Returns a one-dimensional ndarray.
+*
+* @private
+* @param {Float64Array} buffer - underlying data buffer
+* @param {NonNegativeInteger} length - number of indexed elements
+* @param {integer} stride - stride length
+* @param {NonNegativeInteger} offset - index offset
+* @returns {ndarray} one-dimensional ndarray
+*/
+function vector( buffer, length, stride, offset ) {
+	return new ndarray( 'float64', buffer, [ length ], [ stride ], offset, 'row-major' );
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof dcusum, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 1', opts, function test( t ) {
+	t.strictEqual( dcusum.length, 1, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function computes the cumulative sum of a one-dimensional ndarray', opts, function test( t ) {
+	var expected;
+	var initial;
+	var xbuf;
+	var x;
+	var y;
+	var v;
+
+	xbuf = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0 ] );
+	x = vector( xbuf, 6, 1, 0 );
+	y = zerosLike( x );
+	initial = scalar2ndarrayLike( x, 0.0 );
+	v = dcusum( [ x, y, initial ] );
+
+	expected = new Float64Array( [ 1.0, -1.0, -5.0, 0.0, 0.0, 3.0 ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat64Array( getData( v ), expected ), true, 'returns expected value' );
+
+	xbuf = new Float64Array( [ -4.0, -5.0 ] );
+	x = vector( xbuf, 2, 1, 0 );
+	y = zerosLike( x );
+	initial = scalar2ndarrayLike( x, 10.0 );
+	v = dcusum( [ x, y, initial ] );
+
+	expected = new Float64Array( [ 6.0, 1.0 ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat64Array( getData( v ), expected ), true, 'returns expected value' );
+
+	xbuf = new Float64Array( [ -0.0, 0.0, -0.0 ] );
+	x = vector( xbuf, 3, 1, 0 );
+	y = zerosLike( x );
+	initial = scalar2ndarrayLike( x, -0.0 );
+	v = dcusum( [ x, y, initial ] );
+
+	expected = new Float64Array( [ -0.0, 0.0, 0.0 ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat64Array( getData( v ), expected ), true, 'returns expected value' );
+
+	xbuf = new Float64Array( [ -0.0, -0.0, -0.0 ] );
+	x = vector( xbuf, 3, 1, 0 );
+	y = zerosLike( x );
+	initial = scalar2ndarrayLike( x, -0.0 );
+	v = dcusum( [ x, y, initial ] );
+
+	expected = new Float64Array( [ -0.0, -0.0, -0.0 ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat64Array( getData( v ), expected ), true, 'returns expected value' );
+
+	xbuf = new Float64Array( [ -0.0, -0.0, -0.0 ] );
+	x = vector( xbuf, 3, 1, 0 );
+	y = zerosLike( x );
+	initial = scalar2ndarrayLike( x, 0.0 );
+	v = dcusum( [ x, y, initial ] );
+
+	expected = new Float64Array( [ 0.0, 0.0, 0.0 ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat64Array( getData( v ), expected ), true, 'returns expected value' );
+
+	xbuf = new Float64Array( [ NaN ] );
+	x = vector( xbuf, 1, 1, 0 );
+	y = zerosLike( x );
+	initial = scalar2ndarrayLike( x, 0.0 );
+	v = dcusum( [ x, y, initial ] );
+
+	expected = new Float64Array( [ NaN ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat64Array( getData( v ), expected ), true, 'returns expected value' );
+
+	xbuf = new Float64Array( [ NaN, NaN ] );
+	x = vector( xbuf, 2, 1, 0 );
+	y = zerosLike( x );
+	initial = scalar2ndarrayLike( x, NaN );
+	v = dcusum( [ x, y, initial ] );
+
+	expected = new Float64Array( [ NaN, NaN ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat64Array( getData( v ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an empty vector, the function returns the output array unchanged', opts, function test( t ) {
+	var expected;
+	var initial;
+	var xbuf;
+	var x;
+	var y;
+	var v;
+
+	xbuf = new Float64Array( [] );
+	x = vector( xbuf, 0, 1, 0 );
+	y = zerosLike( x );
+	initial = scalar2ndarrayLike( x, 100.0 );
+
+	v = dcusum( [ x, y, initial ] );
+
+	expected = new Float64Array( [] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat64Array( getData( v ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports one-dimensional ndarrays having non-unit strides', opts, function test( t ) {
+	var expected;
+	var initial;
+	var xbuf;
+	var ybuf;
+	var x;
+	var y;
+	var v;
+
+	xbuf = new Float64Array([
+		1.0,  // 0
+		2.0,
+		2.0,  // 1
+		-7.0,
+		-2.0, // 2
+		3.0,
+		4.0,  // 3
+		2.0
+	]);
+	x = vector( xbuf, 4, 2, 0 );
+
+	ybuf = new Float64Array([
+		0.0,  // 0
+		0.0,
+		0.0,  // 1
+		0.0,
+		0.0,  // 2
+		0.0,
+		0.0,  // 3
+		0.0
+	]);
+	y = vector( ybuf, 4, 2, 0 );
+
+	initial = scalar2ndarrayLike( x, 5.0 );
+
+	v = dcusum( [ x, y, initial ] );
+
+	expected = new Float64Array([
+		6.0,  // 0
+		0.0,
+		8.0,  // 1
+		0.0,
+		6.0,  // 2
+		0.0,
+		10.0, // 3
+		0.0
+	]);
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat64Array( getData( v ), expected ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports one-dimensional ndarrays having negative strides', opts, function test( t ) {
+	var expected;
+	var initial;
+	var xbuf;
+	var ybuf;
+	var x;
+	var y;
+	var v;
+
+	xbuf = new Float64Array([
+		1.0,  // 2
+		-2.0,
+		3.0,  // 1
+		4.0,
+		-5.0  // 0
+	]);
+	x = vector( xbuf, 3, -2, 4 );
+
+	ybuf = new Float64Array([
+		0.0, // 2
+		0.0, // 1
+		0.0, // 0
+		0.0,
+		0.0
+	]);
+	y = vector( ybuf, 3, -1, 2 );
+
+	initial = scalar2ndarrayLike( x, 0.0 );
+
+	v = dcusum( [ x, y, initial ] );
+
+	expected = new Float64Array([
+		-1.0, // 2
+		-2.0, // 1
+		-5.0, // 0
+		0.0,
+		0.0
+	]);
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat64Array( getData( v ), expected ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports one-dimensional ndarrays having non-zero offsets', opts, function test( t ) {
+	var expected;
+	var initial;
+	var xbuf;
+	var ybuf;
+	var x;
+	var y;
+	var v;
+
+	xbuf = new Float64Array([
+		2.0,
+		1.0,  // 0
+		2.0,
+		-2.0, // 1
+		-2.0,
+		2.0,  // 2
+		3.0,
+		4.0   // 3
+	]);
+	x = vector( xbuf, 4, 2, 1 );
+
+	ybuf = new Float64Array([
+		0.0,
+		0.0,
+		0.0,  // 0
+		0.0,  // 1
+		0.0,  // 2
+		0.0,  // 3
+		0.0,
+		0.0
+	]);
+	y = vector( ybuf, 4, 1, 2 );
+
+	initial = scalar2ndarrayLike( x, 0.0 );
+
+	v = dcusum( [ x, y, initial ] );
+
+	expected = new Float64Array([
+		0.0,
+		0.0,
+		1.0,  // 0
+		-1.0, // 1
+		1.0,  // 2
+		5.0,  // 3
+		0.0,
+		0.0
+	]);
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat64Array( getData( v ), expected ), true, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves part of #14819.

## Description
> What is the purpose of this pull request?

This pull request:
- adds a native C implementation for `blas/ext/base/ndarray/dcusum`, computing the cumulative sum of a one-dimensional double-precision floating-point ndarray
- adds `src/main.c`, `src/addon.c`, `include/stdlib/blas/ext/base/ndarray/dcusum.h`, `binding.gyp`, `include.gypi`, `manifest.json`, `src/Makefile`, `examples/c/Makefile`, and `examples/c/example.c`
- updates `lib/index.js` to prefer the native addon, falling back to the existing pure JavaScript implementation when the addon is unavailable, and adds `lib/native.js` to load it
- adds tests for the native binding (`test/test.native.js`), mirroring the existing JavaScript test suite
- verifies that both the native addon and the JavaScript fallback independently pass the full test suite (25/25), that `test.native.js` correctly skips rather than fails when the addon is unavailable, and that the C example's output matches a manually computed cumulative sum

## Related Issues
> Does this pull request have any related issues?

This pull request has the following related issues:
- **Open** [[RFC]: add C implementations for `blas/ext/base/ndarray` packages #14819](https://github.com/stdlib-js/stdlib/issues/14819)

## Questions
> Any questions for reviewers of this pull request?

No.

## Other
> Any other information relevant to this pull request?

`lint_c_src` and `lint_c_examples` show `missing_dependencies` in the static analysis report because `cppcheck` is not installed in my local dev environment; CI should run this check properly.

## Checklist
> Please ensure the following tasks are completed before submitting this pull request.
-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

### AI Assistance
> When authoring the changes proposed in this PR, did you use any kind of AI assistance?
-   [x] Yes
-   [ ] No

If yes:
-   [ ] Code generation
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure
I used Claude to help debug local build/tooling issues (a missing `src/Makefile` and `examples/c/Makefile` required for the native-addon build pipeline, and a stale build cache that silently prevented the compiled addon from being copied to `src/addon.node`), and to independently verify the C example's cumulative-sum output against manual calculation. The implementation itself was authored by me; AI tools were used for debugging and verification only.