### PR TITLE
docs: add Git note

### DIFF
--- a/docs/git-notes/69174e098bbc05ec4d00c0c3fabd96e9b9317770.txt
+++ b/docs/git-notes/69174e098bbc05ec4d00c0c3fabd96e9b9317770.txt
@@ -1,0 +1,8 @@
+---
+type: amend-message
+---
+test: migrate `stats/base/dists/bernoulli/mean` to ULP-based assertions
+
+PR-URL: https://github.com/stdlib-js/stdlib/pull/14832
+Reviewed-by: Athan Reines <kgryte@gmail.com>
+Ref: https://github.com/stdlib-js/stdlib/issues/11352


### PR DESCRIPTION
Audit of commits merged to `develop` in the last 24 hours found one commit message with a clear typo. This PR adds a corrected-message note under `docs/git-notes/` per the routine's convention; no existing history is rewritten.

- `69174e09`: subject typo — "ULP-base assertions" should read "ULP-based assertions" (every sibling commit in the same #11352 migration series uses "ULP-based"). PR-URL, Reviewed-by, and Ref trailers were verified against #14832 and #11352 and are correct as-is.

All other commits from the last 24 hours were checked (PR-URL/Closes/Ref numbers verified via the GitHub API, trailers checked for malformation, subjects checked for typos and style) and found to be correct.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)