### PR TITLE
test: migrate `stats/base/dists/frechet/logpdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/logpdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/logpdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -143,8 +142,6 @@ tape( 'the created function evaluates the logPDF for `x` given large `alpha`', f
 	var expected;
 	var logpdf;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -157,13 +154,7 @@ tape( 'the created function evaluates the logPDF for `x` given large `alpha`', f
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( alpha[i], s[i], 0.0 );
 		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 5.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. m: 0. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -172,8 +163,6 @@ tape( 'the created function evaluates the logPDF for `x` given large `s`', funct
 	var expected;
 	var logpdf;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -186,13 +175,7 @@ tape( 'the created function evaluates the logPDF for `x` given large `s`', funct
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( alpha[i], s[i], 0.0 );
 		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 5.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -201,8 +184,6 @@ tape( 'the created function evaluates the logPDF for `x` given large `alpha` and
 	var expected;
 	var logpdf;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -215,13 +196,7 @@ tape( 'the created function evaluates the logPDF for `x` given large `alpha` and
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( alpha[i], s[i], 0.0 );
 		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 25 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/logpdf/test/test.logpdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/logpdf/test/test.logpdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logpdf = require( './../lib' );
 
 
@@ -129,8 +128,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', function test
 tape( 'the function evaluates the logPDF for `x` given large `alpha`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -142,13 +139,7 @@ tape( 'the function evaluates the logPDF for `x` given large `alpha`', function 
 	s = largeShape.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], alpha[i], s[i], 0.0 );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 5.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -156,8 +147,6 @@ tape( 'the function evaluates the logPDF for `x` given large `alpha`', function 
 tape( 'the function evaluates the logPDF for `x` given large `s`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -169,13 +158,7 @@ tape( 'the function evaluates the logPDF for `x` given large `s`', function test
 	s = largeScale.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], alpha[i], s[i], 0.0 );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 5.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -183,8 +166,6 @@ tape( 'the function evaluates the logPDF for `x` given large `s`', function test
 tape( 'the function evaluates the logPDF for `x` given large `alpha` and `s`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -196,13 +177,7 @@ tape( 'the function evaluates the logPDF for `x` given large `alpha` and `s`', f
 	s = bothLarge.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], alpha[i], s[i], 0.0 );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. m: 0. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 25 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/logpdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/logpdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -138,8 +137,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', opts, functio
 tape( 'the function evaluates the logPDF for `x` given large `alpha`', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -151,13 +148,7 @@ tape( 'the function evaluates the logPDF for `x` given large `alpha`', opts, fun
 	s = largeShape.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], alpha[i], s[i], 0.0 );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 5.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -165,8 +156,6 @@ tape( 'the function evaluates the logPDF for `x` given large `alpha`', opts, fun
 tape( 'the function evaluates the logPDF for `x` given large `s`', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -178,13 +167,7 @@ tape( 'the function evaluates the logPDF for `x` given large `s`', opts, functio
 	s = largeScale.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], alpha[i], s[i], 0.0 );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 5.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -192,8 +175,6 @@ tape( 'the function evaluates the logPDF for `x` given large `s`', opts, functio
 tape( 'the function evaluates the logPDF for `x` given large `alpha` and `s`', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -205,13 +186,7 @@ tape( 'the function evaluates the logPDF for `x` given large `alpha` and `s`', o
 	s = bothLarge.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], alpha[i], s[i], 0.0 );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. m: 0. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 25 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/frechet/logpdf` from relative tolerance testing (`delta <= N * EPS * abs( expected )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].

The following files are updated, each containing the same three Julia fixture loops:

| File | `large_shape.json` | `large_scale.json` | `both_large.json` |
| ---- | ------------------ | ------------------ | ----------------- |
| `test/test.logpdf.js` | **2** | **2** | **25** |
| `test/test.factory.js` | **2** | **2** | **25** |
| `test/test.native.js` | **2** | **2** | **25** |

Each bound is the measured minimum over the full fixture set (1000 cases per fixture, 3000 cases per file). Lowering the bounds by one ULP fails: `large_shape` yields 34 failures at `1`, `large_scale` yields 30 failures at `1`, and `both_large` yields 1 failure at `24`.

The JavaScript, factory, and C implementations were each measured independently and agree exactly on all three bounds, so a single set of values is used across the three files.

Only the three test files are changed; no implementation, documentation, or fixture files are touched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed locally:

```
test.js          3 passing
test.logpdf.js   3024 passing
test.factory.js  3021 passing
test.native.js   3024 passing

eslint --config etc/eslint/.eslintrc.tests.js (all four test files)
  clean
```

The native add-on was built locally so that `test/test.native.js` actually executed rather than being skipped. The full suite was run twice at the final bounds to confirm the results are deterministic, and the add-on was additionally rebuilt with `CFLAGS="-ffp-contract=off"` to confirm the C bounds are not sensitive to FMA contraction (identical bounds in both builds).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. The agent studied previously merged conversions under this tracking issue (in particular the sibling package `stats/base/dists/frechet/logcdf`) to match the established idiom, applied the migration, and determined the minimum ULP bounds empirically by computing the exact per-element ULP distance across the fixture set and confirming failures one ULP below each bound.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value