### PR TITLE
test: migrate `stats/base/dists/weibull/pdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/pdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -200,9 +199,7 @@ tape( 'if provided a positive `lambda` and `k` not equal to one, the  created fu
 tape( 'the created function evaluates the pdf for `x` given large `lambda` and `k`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var pdf;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -215,13 +212,7 @@ tape( 'the created function evaluates the pdf for `x` given large `lambda` and `
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( k[i], lambda[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -229,9 +220,7 @@ tape( 'the created function evaluates the pdf for `x` given large `lambda` and `
 tape( 'the created function evaluates the pdf for `x` given a large shape parameter `k`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var pdf;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -244,13 +233,7 @@ tape( 'the created function evaluates the pdf for `x` given a large shape parame
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( k[i], lambda[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -258,9 +241,7 @@ tape( 'the created function evaluates the pdf for `x` given a large shape parame
 tape( 'the created function evaluates the pdf for `x` given a large scale parameter `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var pdf;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -273,13 +254,7 @@ tape( 'the created function evaluates the pdf for `x` given a large scale parame
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( k[i], lambda[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/pdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -150,8 +149,6 @@ tape( 'if provided `0.0` for `x`, a positive `lambda` and `k` not equal to one, 
 tape( 'the function evaluates the pdf for `x` given large `lambda` and `k`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -163,13 +160,7 @@ tape( 'the function evaluates the pdf for `x` given large `lambda` and `k`', opt
 	k = bothLarge.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -177,8 +168,6 @@ tape( 'the function evaluates the pdf for `x` given large `lambda` and `k`', opt
 tape( 'the function evaluates the pdf for `x` given large scale parameter `lambda`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -190,13 +179,7 @@ tape( 'the function evaluates the pdf for `x` given large scale parameter `lambd
 	k = largeScale.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -204,8 +187,6 @@ tape( 'the function evaluates the pdf for `x` given large scale parameter `lambd
 tape( 'the function evaluates the pdf for `x` given large shape parameter `k`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -217,13 +198,7 @@ tape( 'the function evaluates the pdf for `x` given large shape parameter `k`', 
 	k = largeShape.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/pdf/test/test.pdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( './../lib' );
 
 
@@ -141,8 +140,6 @@ tape( 'if provided `0.0` for `x`, a positive `lambda` and `k` not equal to one, 
 tape( 'the function evaluates the pdf for `x` given large `lambda` and `k`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -154,13 +151,7 @@ tape( 'the function evaluates the pdf for `x` given large `lambda` and `k`', fun
 	k = bothLarge.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -168,8 +159,6 @@ tape( 'the function evaluates the pdf for `x` given large `lambda` and `k`', fun
 tape( 'the function evaluates the pdf for `x` given large scale parameter `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -181,13 +170,7 @@ tape( 'the function evaluates the pdf for `x` given large scale parameter `lambd
 	k = largeScale.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -195,8 +178,6 @@ tape( 'the function evaluates the pdf for `x` given large scale parameter `lambd
 tape( 'the function evaluates the pdf for `x` given large shape parameter `k`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -208,13 +189,7 @@ tape( 'the function evaluates the pdf for `x` given large shape parameter `k`', 
 	k = largeShape.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/weibull/pdf` from relative tolerance testing (`delta <= N * EPS * abs( expected )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].

The following files are updated, each containing the same three Julia fixture loops:

| File | `both_large.json` | `large_scale.json` | `large_shape.json` |
| ---- | ----------------- | ------------------ | ------------------ |
| `test/test.pdf.js` | **0** | **0** | **0** |
| `test/test.factory.js` | **0** | **0** | **0** |
| `test/test.native.js` | **0** | **0** | **0** |

Each bound is the measured minimum over the full fixture set (1000 cases per fixture, 3000 cases per file). `0` is the tightest bound the assertion admits: at `0`, `isAlmostSameValue` reduces to the SameValue algorithm, so every returned value matches its Julia-generated expected value bit-for-bit, and no case relies on any tolerance. The previous relative tolerances (`1.0 * EPS`, and `2.0 * EPS` for one loop in `test/test.native.js`) were therefore never exercised.

The JavaScript, factory, and C implementations were each measured independently and agree exactly on all three bounds, so a single set of values is used across the three files.

Only the three test files are changed; no implementation, documentation, or fixture files are touched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed locally:

```
test.js          3 passing
test.pdf.js      3023 passing
test.factory.js  3028 passing
test.native.js   3023 passing

eslint --config etc/eslint/.eslintrc.tests.js (all four test files)
  clean
```

The native add-on was built locally so that `test/test.native.js` actually executed rather than being skipped. The full suite was run twice at the final bounds to confirm the results are deterministic, and the add-on was additionally rebuilt with `CFLAGS="-ffp-contract=off"` to confirm the C bounds are not sensitive to FMA contraction (identical bounds in both builds).

Note on the local environment: `make install-node-modules` could not complete in the sandbox used to author this change, because a transitive development dependency resolves to `es-object-atoms@^1.1.2`, which is not published on the registry. The test runner, ESLint (with the project's `.eslintrc.tests.js` configuration and the stdlib plugin), and `node-gyp` were installed separately so that the checks above could be run; the `editorconfig-checker` and production license pre-commit/pre-push hooks could not run, since both fetch artifacts that are unreachable from the sandbox. EditorConfig conformance for the three changed files (LF endings, UTF-8, tab indentation, no trailing whitespace, final newline) was verified manually instead.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. The agent studied previously merged conversions under this tracking issue (in particular the sibling package `stats/base/dists/weibull/cdf`) to match the established idiom, applied the migration, and determined the minimum ULP bounds empirically by computing the exact per-element ULP distance across the fixture set for the JavaScript, factory, and native implementations.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdStKqNtBndEmFNZSLgFJW)_