### PR TITLE
docs: remove unnecessary require statements

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/wasm/dasumpw/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/wasm/dasumpw/lib/main.js
@@ -35,7 +35,6 @@ var Module = require( './module.js' );
 *
 * @example
 * var Float64Array = require( '@stdlib/array/float64' );
-* var dasumpw = require( '@stdlib/blas/ext/base/wasm/dasumpw' );
 *
 * // Define a strided array:
 * var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
@@ -46,7 +45,6 @@ var Module = require( './module.js' );
 *
 * @example
 * var Float64Array = require( '@stdlib/array/float64' );
-* var dasumpw = require( '@stdlib/blas/ext/base/wasm/dasumpw' );
 *
 * // Define a strided array:
 * var x = new Float64Array( [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0 ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/wasm/dnansumkbn2/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/wasm/dnansumkbn2/lib/main.js
@@ -35,7 +35,6 @@ var Module = require( './module.js' );
 *
 * @example
 * var Float64Array = require( '@stdlib/array/float64' );
-* var dnansumkbn2 = require( '@stdlib/blas/ext/base/wasm/dnansumkbn2' );
 *
 * // Define a strided array:
 * var x = new Float64Array( [ 1.0, -2.0, NaN, 2.0 ] );
@@ -46,7 +45,6 @@ var Module = require( './module.js' );
 *
 * @example
 * var Float64Array = require( '@stdlib/array/float64' );
-* var dnansumkbn2 = require( '@stdlib/blas/ext/base/wasm/dnansumkbn2' );
 *
 * // Define a strided array:
 * var x = new Float64Array( [ 2.0, 1.0, -2.0, NaN, -2.0, 2.0, 3.0, 4.0 ] );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request removes a redundant `require` statement from the JSDoc `@example` blocks in two `@stdlib/blas/ext/base/wasm` packages so their documentation matches the established namespace convention.

Both packages document the exported routine via `@name`/`@type {Routine}` and reference the symbol directly in each `@example`, yet also re-`require` themselves — a line absent from every other package in the namespace and from all packages in the mature `@stdlib/blas/base/wasm` sibling namespace. The examples now require only `@stdlib/array/float64`. Conformance to the majority convention: 8 of 10 namespace packages; 33 of 33 `blas/base/wasm` packages.

### `blas/ext/base/wasm/dasumpw`

Removed the `require( '@stdlib/blas/ext/base/wasm/dasumpw' )` line from both `@example` blocks in `lib/main.js`. The routine symbol is already documented via `@name`/`@type`, so the self-require was redundant and inconsistent with the namespace.

### `blas/ext/base/wasm/dnansumkbn2`

Removed the `require( '@stdlib/blas/ext/base/wasm/dnansumkbn2' )` line from both `@example` blocks in `lib/main.js`. Documentation-only; the exported API and behavior are unchanged.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

The change is documentation-only and confined to JSDoc `@example` comments; no source behavior, signatures, tests, or benchmarks are affected. These two packages were the only deviators in the namespace on this feature; the deviation was validated against sibling packages before applying the fix.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This pull request was produced by Claude Code running an automated cross-package documentation drift-detection routine. Claude extracted structural and semantic documentation features across the `blas/ext/base/wasm` namespace, identified the majority `@example` convention, validated the two deviating packages against their siblings, and applied the mechanical removal. A maintainer reviews before merge.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_017DqmiF5tPbLTz3vVwv9DWg)_