### PR TITLE
test: migrate `stats/incr/pcorrmat` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/pcorrmat/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/pcorrmat/test/test.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var ndarray = require( '@stdlib/ndarray/ctor' );
 var Float64Array = require( '@stdlib/array/float64' );
 var incrpcorrmat = require( './../lib' );
@@ -591,9 +590,7 @@ tape( 'the accumulator function incrementally computes a sample Pearson product-
 	var strides;
 	var actual;
 	var shape;
-	var delta;
 	var order;
-	var tol;
 	var acc;
 	var n;
 	var v;
@@ -636,13 +633,7 @@ tape( 'the accumulator function incrementally computes a sample Pearson product-
 			for ( k = 0; k < n; k++ ) {
 				v = actual.get( j, k );
 				e = expected[ i ][ (j*n)+k ];
-				if ( v === e ) {
-					t.strictEqual( v, e, 'returns expected result. i: '+i+'. j: '+j+'. k: '+k+'.' );
-				} else {
-					delta = abs( e - v );
-					tol = 3.0 * EPS * abs( e );
-					t.strictEqual( delta <= tol, true, 'i: '+i+'. j: '+j+'. k: '+k+'. expected: '+e+'. actual: '+v+'. tol: '+tol+'. delta: '+delta+'.' );
-				}
+				t.strictEqual( isAlmostSameValue( v, e, 3 ), true, 'returns expected value' );
 			}
 		}
 	}
@@ -655,10 +646,8 @@ tape( 'the accumulator function incrementally computes a sample Pearson product-
 	var actual;
 	var buffer;
 	var shape;
-	var delta;
 	var order;
 	var corr;
-	var tol;
 	var acc;
 	var n;
 	var v;
@@ -707,13 +696,7 @@ tape( 'the accumulator function incrementally computes a sample Pearson product-
 			for ( k = 0; k < n; k++ ) {
 				v = actual.get( j, k );
 				e = expected[ i ][ (j*n)+k ];
-				if ( v === e ) {
-					t.strictEqual( v, e, 'returns expected result. i: '+i+'. j: '+j+'. k: '+k+'.' );
-				} else {
-					delta = abs( e - v );
-					tol = 3.0 * EPS * abs( e );
-					t.strictEqual( delta <= tol, true, 'i: '+i+'. j: '+j+'. k: '+k+'. expected: '+e+'. actual: '+v+'. tol: '+tol+'. delta: '+delta+'.' );
-				}
+				t.strictEqual( isAlmostSameValue( v, e, 3 ), true, 'returns expected value' );
 			}
 		}
 	}
@@ -727,9 +710,7 @@ tape( 'the accumulator function incrementally computes a sample Pearson product-
 	var buffer;
 	var means;
 	var shape;
-	var delta;
 	var order;
-	var tol;
 	var acc;
 	var n;
 	var v;
@@ -775,13 +756,7 @@ tape( 'the accumulator function incrementally computes a sample Pearson product-
 			for ( k = 0; k < n; k++ ) {
 				v = actual.get( j, k );
 				e = expected[ i ][ (j*n)+k ];
-				if ( v === e ) {
-					t.strictEqual( v, e, 'returns expected result. i: '+i+'. j: '+j+'. k: '+k+'.' );
-				} else {
-					delta = abs( e - v );
-					tol = 3.0 * EPS * abs( e );
-					t.strictEqual( delta <= tol, true, 'i: '+i+'. j: '+j+'. k: '+k+'. expected: '+e+'. actual: '+v+'. tol: '+tol+'. delta: '+delta+'.' );
-				}
+				t.strictEqual( isAlmostSameValue( v, e, 1 ), true, 'returns expected value' );
 			}
 		}
 	}
@@ -795,10 +770,8 @@ tape( 'the accumulator function incrementally computes a sample Pearson product-
 	var buffer;
 	var means;
 	var shape;
-	var delta;
 	var order;
 	var corr;
-	var tol;
 	var acc;
 	var n;
 	var v;
@@ -850,13 +823,7 @@ tape( 'the accumulator function incrementally computes a sample Pearson product-
 			for ( k = 0; k < n; k++ ) {
 				v = actual.get( j, k );
 				e = expected[ i ][ (j*n)+k ];
-				if ( v === e ) {
-					t.strictEqual( v, e, 'returns expected result. i: '+i+'. j: '+j+'. k: '+k+'.' );
-				} else {
-					delta = abs( e - v );
-					tol = 3.0 * EPS * abs( e );
-					t.strictEqual( delta <= tol, true, 'i: '+i+'. j: '+j+'. k: '+k+'. expected: '+e+'. actual: '+v+'. tol: '+tol+'. delta: '+delta+'.' );
-				}
+				t.strictEqual( isAlmostSameValue( v, e, 1 ), true, 'returns expected value' );
 			}
 		}
 	}


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/incr/pcorrmat` from relative tolerance assertions to ULP-based assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   replaces the `if ( v === e ) { ... } else { delta/tol ... }` branches in the four accumulator test cases with `t.strictEqual( isAlmostSameValue( v, e, N ), true, 'returns expected value' );`.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires, along with the `delta` and `tol` declarations.

The previous assertions used a `3.0 * EPS * abs( e )` relative tolerance. The ULP bounds below are the **minimum** values which pass over the full set of fixture values:

| Test case | ULP |
| --- | --- |
| incrementally computes a sample Pearson product-moment correlation matrix (order) | 3 |
| incrementally computes a sample Pearson product-moment correlation matrix (correlation matrix) | 3 |
| incrementally computes a sample Pearson product-moment correlation matrix (order, means) | 1 |
| incrementally computes a sample Pearson product-moment correlation matrix (correlation matrix, means) | 1 |

Minimality was verified by lowering each bound by one ULP and confirming test failures (`3` &rarr; `2` fails; `1` &rarr; `0` fails). The suite was run twice at the final bounds, with all 212 assertions passing in both runs (`make test TESTS_FILTER=".*/stats/incr/pcorrmat/.*"`). Only the test file is changed; the package has no `test.native.js`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, which performed the test migration and empirically determined the minimum ULP bounds.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value
