### PR TITLE
test: migrate `stats/base/dists/discrete-uniform/variance` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/variance/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var variance = require( './../lib' );
 
 
@@ -76,8 +75,6 @@ tape( 'if provided `a > b`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function returns the variance of a discrete uniform distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -88,13 +85,7 @@ tape( 'the function returns the variance of a discrete uniform distribution', fu
 	b = data.b;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = variance( a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/variance/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/variance/test/test.native.js
@@ -22,9 +22,8 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -60,8 +59,6 @@ tape( 'if provided `a > b`, the function returns `NaN`', opts, function test( t 
 
 tape( 'the function returns the variance of a discrete uniform distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -72,13 +69,7 @@ tape( 'the function returns the variance of a discrete uniform distribution', op
 	b = data.b;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = variance( a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/discrete-uniform/variance` from relative tolerance testing to ULP difference testing, replacing the `delta`/`tol` comparison against `EPS * abs( expected[ i ] )` with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' )`.
-   adds the `@stdlib/assert/is-almost-same-value` require and removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires in `test/test.js` and `test/test.native.js`.

The ULP bound was tightened to the measured minimum:

-   `test/test.js`: **0 ULP** (measured maximum ULP difference over the full 1000-value Julia fixture set: 0)
-   `test/test.native.js`: **0 ULP** (measured maximum ULP difference over the same fixture set using the compiled native add-on: 0)

Both implementations return bit-for-bit identical results to the fixture values for every fixture case, so `0` is the tightest possible bound. Each suite was run twice at the final bound to confirm determinism (`test.js`: 1008/1008 passing; `test.native.js`: 1003/1003 passing with the add-on built locally). Only the two test files are changed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated pass over the packages tracked by #11352. The migration mirrors the idiom established in previously merged conversions, and the ULP bound was determined empirically by computing the maximum ULP difference across the full fixture set for both the JavaScript and native implementations.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpeKFsXEhstEFppJh5YPeT)_