### PR TITLE
docs: fix broken Markdown link (issue #14863)

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/cdf/README.md
@@ -245,7 +245,7 @@ int main( void ) {
 
 [cdf]: https://en.wikipedia.org/wiki/Cumulative_distribution_function
 
-[anglit-distribution]: https://en.wikipedia.org/wiki/Anglit_distribution
+[anglit-distribution]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.anglit.html
 
 </section>
 

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/entropy/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/entropy/README.md
@@ -229,7 +229,7 @@ int main( void ) {
 
 [entropy]: https://en.wikipedia.org/wiki/Entropy_%28information_theory%29
 
-[anglit-distribution]: https://en.wikipedia.org/wiki/Anglit_distribution
+[anglit-distribution]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.anglit.html
 
 [nats]: https://en.wikipedia.org/wiki/Nat_%28unit%29
 

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/README.md
@@ -243,7 +243,7 @@ int main( void ) {
 
 <section class="links">
 
-[anglit-distribution]: https://en.wikipedia.org/wiki/Anglit_distribution
+[anglit-distribution]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.anglit.html
 
 [mean]: https://en.wikipedia.org/wiki/Mean
 

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/median/README.md
@@ -235,7 +235,7 @@ int main( void ) {
 
 <section class="links">
 
-[anglit-distribution]: https://en.wikipedia.org/wiki/Anglit_distribution
+[anglit-distribution]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.anglit.html
 
 [median]: https://en.wikipedia.org/wiki/Median
 

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/mode/README.md
@@ -235,7 +235,7 @@ int main( void ) {
 
 <section class="links">
 
-[anglit-distribution]: https://en.wikipedia.org/wiki/Anglit_distribution
+[anglit-distribution]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.anglit.html
 
 [mode]: https://en.wikipedia.org/wiki/Mode_%28statistics%29
 

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/pdf/README.md
@@ -245,7 +245,7 @@ int main( void ) {
 
 [pdf]: https://en.wikipedia.org/wiki/Probability_density_function
 
-[anglit-distribution]: https://en.wikipedia.org/wiki/Anglit_distribution
+[anglit-distribution]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.anglit.html
 
 </section>
 

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/README.md
@@ -256,7 +256,7 @@ int main( void ) {
 
 [quantile-function]: https://en.wikipedia.org/wiki/Quantile_function
 
-[anglit-distribution]: https://en.wikipedia.org/wiki/Anglit_distribution
+[anglit-distribution]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.anglit.html
 
 </section>
 

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/skewness/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/skewness/README.md
@@ -230,7 +230,7 @@ int main( void ) {
 
 <section class="links">
 
-[anglit-distribution]: https://en.wikipedia.org/wiki/Anglit_distribution
+[anglit-distribution]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.anglit.html
 
 [skewness]: https://en.wikipedia.org/wiki/Skewness
 

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/stdev/README.md
@@ -232,7 +232,7 @@ int main( void ) {
 
 <section class="links">
 
-[anglit-distribution]: https://en.wikipedia.org/wiki/Anglit_distribution
+[anglit-distribution]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.anglit.html
 
 [stdev]: https://en.wikipedia.org/wiki/Standard_deviation
 


### PR DESCRIPTION
## Description

The Markdown link check flagged the Wikipedia URL for the Anglit distribution in the anglit READMEs. There is no Wikipedia article for this distribution, so the link returns 404.

The nine affected READMEs (mean, mode, median, quantile, pdf, cdf, stdev, entropy, skewness) now point to the scipy documentation for `scipy.stats.anglit`, which documents the same distribution with the same parametrization (`sin(2x + π/2)` on the `[-π/4, π/4]` support).

## Related Issues

resolves #14863

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
-   [x] Verified that the new link resolves (HTTP 200)
-   [x] All occurrences across the anglit package updated consistently (9 files)
