### PR TITLE
test: migrate `stats/base/dists/triangular/logcdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/logcdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/logcdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -157,8 +156,6 @@ tape( 'if provided parameters not satisfying `a <= c <= b`, the created function
 tape( 'the created function evaluates the logcdf for `x` given a small range `b - a`', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -174,13 +171,7 @@ tape( 'the created function evaluates the logcdf for `x` given a small range `b 
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( a[i], b[i], c[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 6 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -188,8 +179,6 @@ tape( 'the created function evaluates the logcdf for `x` given a small range `b 
 tape( 'the created function evaluates the logcdf for `x` given a medium range `b - a`', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -205,13 +194,7 @@ tape( 'the created function evaluates the logcdf for `x` given a medium range `b
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( a[i], b[i], c[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -219,8 +202,6 @@ tape( 'the created function evaluates the logcdf for `x` given a medium range `b
 tape( 'the created function evaluates the logcdf for `x` given a large range `b - a`', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -236,13 +217,7 @@ tape( 'the created function evaluates the logcdf for `x` given a large range `b 
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( a[i], b[i], c[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 11 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/logcdf/test/test.logcdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/logcdf/test/test.logcdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logcdf = require( './../lib' );
 
 
@@ -92,8 +91,6 @@ tape( 'if provided parameters not satisfying `a <= c <= b`, the function returns
 
 tape( 'the function evaluates the logcdf for `x` given a small range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -108,21 +105,13 @@ tape( 'the function evaluates the logcdf for `x` given a small range `b - a`', f
 	c = smallRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 6 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given a medium range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -137,21 +126,13 @@ tape( 'the function evaluates the logcdf for `x` given a medium range `b - a`', 
 	c = mediumRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given a large range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -166,13 +147,7 @@ tape( 'the function evaluates the logcdf for `x` given a large range `b - a`', f
 	c = largeRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 11 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/logcdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/logcdf/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -101,8 +100,6 @@ tape( 'if provided parameters not satisfying `a <= c <= b`, the function returns
 
 tape( 'the function evaluates the logcdf for `x` given a small range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -117,21 +114,13 @@ tape( 'the function evaluates the logcdf for `x` given a small range `b - a`', o
 	c = smallRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 6 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given a medium range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -146,21 +135,13 @@ tape( 'the function evaluates the logcdf for `x` given a medium range `b - a`', 
 	c = mediumRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given a large range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -175,13 +156,7 @@ tape( 'the function evaluates the logcdf for `x` given a large range `b - a`', o
 	c = largeRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 11 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/triangular/logcdf` from relative tolerance assertions to ULP-based assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   replaces the `if ( y === expected[i] ) { ... } else { delta/tol ... }` branches in the fixture-driven test cases with `t.strictEqual( isAlmostSameValue( y, expected[ i ], N ), true, 'returns expected value' );`.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires, along with the `delta` and `tol` declarations.

The previous assertions used a `10.0 * EPS * abs( expected[ i ] )` relative tolerance. The ULP bounds below are the **minimum** values which pass over the full set of fixture values (1000 values per fixture) and are applied consistently in `test/test.logcdf.js`, `test/test.factory.js`, and `test/test.native.js`:

| Fixture | Test case | ULP |
| --- | --- | --- |
| `small_range.json` | evaluates the logcdf for `x` given a small range `b - a` | 6 |
| `medium_range.json` | evaluates the logcdf for `x` given a medium range `b - a` | 0 |
| `large_range.json` | evaluates the logcdf for `x` given a large range `b - a` | 11 |

Minimality was verified by lowering the bounds by one ULP and confirming test failures (`6` → `5` and `11` → `10` both fail; the medium range bound is already exact). The measured maximum ULP differences over each fixture are `6`, `0`, and `11`, respectively, and are identical for the JavaScript and C implementations, so the same bounds are used in `test/test.native.js`.

The suite was run twice at the final bounds, with all assertions passing in both runs (`make test TESTS_FILTER=".*/stats/base/dists/triangular/logcdf/.*"`): 3012 (`test.logcdf.js`), 3022 (`test.factory.js`), 3 (`test.js`), and 3012 (`test.native.js`, run against a locally built add-on). Only test files are changed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, which performed the test migration and empirically determined the minimum ULP bounds.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value


---
_Generated by [Claude Code](https://claude.ai/code/session_018QvLfRiV8mNh5Kvr1h3NLF)_