### PR TITLE
docs: fix JSDoc types

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/lib/factory.js
@@ -34,7 +34,7 @@ var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 * Returns a function for evaluating the probability density function (PDF) for a Wald distribution.
 *
 * @param {PositiveNumber} mu - mean
-* @param {PositiveNumber} lambda - shape parameter
+* @param {NonNegativeNumber} lambda - shape parameter
 * @returns {Function} function to evaluate the probability density function
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/lib/main.js
@@ -34,7 +34,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 *
 * @param {number} x - input value
 * @param {PositiveNumber} mu - mean
-* @param {PositiveNumber} lambda - shape parameter
+* @param {NonNegativeNumber} lambda - shape parameter
 * @returns {number} evaluated probability density function
 *
 * @example


### PR DESCRIPTION
This pull request corrects a JSDoc parameter-type annotation in `@stdlib/stats/base/dists/wald/pdf` that had drifted from its sibling packages and from the package's own implementation. There is no associated issue.

## Description

> What is the purpose of this pull request?

This pull request normalizes the JSDoc type of the `lambda` shape parameter in `@stdlib/stats/base/dists/wald/pdf`.

### `stats/base/dists/wald/pdf`

`pdf` documented `lambda` as `{PositiveNumber}` in both `lib/main.js` and `lib/factory.js`, yet the implementation accepts `lambda === 0` via a dedicated degenerate-limit branch and returns `NaN` only for `lambda < 0`. Its four measure-family siblings — `cdf`, `logcdf`, `logpdf`, and `quantile` — document the parameter as `{NonNegativeNumber}` (4/5 = 80% conformance), and the package's own type declaration already states that only `lambda < 0` yields `NaN`. Both JSDoc annotations are updated to `{NonNegativeNumber}`. The change is documentation-only: runtime behavior, the public signature, and all tests are unchanged.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

This correction came out of a cross-package consistency sweep of the `stats/base/dists/wald` namespace (12 members). The `lambda` JSDoc type in `pdf` was the only high-signal, mechanical, non-behavioral divergence found; `package.json`/`manifest.json` shape, README sections, error handling, validation guards, and signatures were otherwise uniform or reflected intentional measure-vs-moment differences.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code. The tool analyzed the `wald` namespace for cross-package drift, identified the `lambda` JSDoc type inconsistency in `pdf`, verified it against the sibling packages and the implementation, and applied the two-line documentation fix.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_019fr64Z2THEMY8SC1wqcuDz)_