### PR TITLE
test: migrate `stats/base/dists/planck/logpmf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/planck/logpmf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/logpmf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -139,8 +138,6 @@ tape( 'the returned function evaluates the logpmf for `x` given small `lambda`',
 	var expected;
 	var logpmf;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -151,13 +148,7 @@ tape( 'the returned function evaluates the logpmf for `x` given small `lambda`',
 	for ( i = 0; i < x.length; i++ ) {
 		logpmf = factory( lambda[ i ] );
 		y = logpmf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[ i ]+'. lambda: '+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -166,8 +157,6 @@ tape( 'the returned function evaluates the logpmf for `x` given large `lambda`',
 	var expected;
 	var logpmf;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -178,13 +167,7 @@ tape( 'the returned function evaluates the logpmf for `x` given large `lambda`',
 	for ( i = 0; i < x.length; i++ ) {
 		logpmf = factory( lambda[ i ] );
 		y = logpmf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[ i ]+'. lambda: '+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/logpmf/test/test.logpmf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/logpmf/test/test.logpmf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logpmf = require( './../lib' );
 
 
@@ -92,8 +91,6 @@ tape( 'if provided a shape parameter `lambda` which is nonpositive, the function
 tape( 'the function evaluates the logpmf for `x` given small parameter `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -103,13 +100,7 @@ tape( 'the function evaluates the logpmf for `x` given small parameter `lambda`'
 	lambda = smallLambda.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpmf( x[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. lambda:'+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -117,8 +108,6 @@ tape( 'the function evaluates the logpmf for `x` given small parameter `lambda`'
 tape( 'the function evaluates the logpmf for `x` given large parameter `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -128,13 +117,7 @@ tape( 'the function evaluates the logpmf for `x` given large parameter `lambda`'
 	lambda = largeLambda.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpmf( x[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. lambda:'+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/logpmf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/logpmf/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -101,8 +100,6 @@ tape( 'if provided a shape parameter `lambda` which is nonpositive, the function
 tape( 'the function evaluates the logpmf for `x` given small parameter `lambda`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -112,13 +109,7 @@ tape( 'the function evaluates the logpmf for `x` given small parameter `lambda`'
 	lambda = smallLambda.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpmf( x[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. lambda:'+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -126,8 +117,6 @@ tape( 'the function evaluates the logpmf for `x` given small parameter `lambda`'
 tape( 'the function evaluates the logpmf for `x` given large parameter `lambda`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -137,13 +126,7 @@ tape( 'the function evaluates the logpmf for `x` given large parameter `lambda`'
 	lambda = largeLambda.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpmf( x[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. lambda:'+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/planck/logpmf` from relative tolerance testing (`delta <= N * EPS * abs( expected )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].

The following files are updated, each containing the same two Python fixture loops:

| File | `small_lambda.json` | `large_lambda.json` |
| ---- | ------------------- | ------------------- |
| `test/test.logpmf.js` | **1** | **1** |
| `test/test.factory.js` | **1** | **1** |
| `test/test.native.js` | **1** | **1** |

Each bound is the measured minimum over the full fixture set (1000 cases per fixture, 2000 cases per file). Lowering the bounds by one ULP fails: at `0`, each of the three files reports 242 failing assertions.

The JavaScript, factory, and C implementations were each measured independently and agree exactly on both bounds, so a single value is used across the three files.

Only the three test files are changed; no implementation, documentation, or fixture files are touched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed locally:

```
test.js          3 passing
test.logpmf.js   2011 passing
test.factory.js  2017 passing
test.native.js   2011 passing

eslint --config etc/eslint/.eslintrc.tests.js (all four test files)
  clean
```

The native add-on was built locally so that `test/test.native.js` actually executed rather than being skipped. The full suite was run twice at the final bounds to confirm the results are deterministic, and the add-on was additionally rebuilt with `CFLAGS="-ffp-contract=off"` to confirm the C bounds are not sensitive to FMA contraction (identical bounds in both builds).

Note: `editorconfig-checker` could not run in the sandbox used to author this change (its binary is fetched from GitHub releases, which was unreachable), so EditorConfig conformance for the three changed files was verified by hand instead: LF endings, UTF-8, tab indentation, no trailing whitespace, and a final newline.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. The agent studied previously merged conversions under this tracking issue (in particular the sibling packages `stats/base/dists/frechet/logpdf` and `stats/base/dists/weibull/pdf`) to match the established idiom, applied the migration, and determined the minimum ULP bounds empirically by computing the exact per-element ULP distance across the fixture set and confirming failures one ULP below each bound.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01THyYEuVJMxBagJLkSy64QQ)_