### PR TITLE
test: migrate `stats/base/dists/gumbel/cdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/cdf/test/test.cdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( './../lib' );
 
 
@@ -98,9 +97,7 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', function t
 
 tape( 'the function evaluates the cdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -112,22 +109,14 @@ tape( 'the function evaluates the cdf for `x` given positive `mu`', function tes
 	beta = positiveMean.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -139,22 +128,14 @@ tape( 'the function evaluates the cdf for `x` given negative `mu`', function tes
 	beta = negativeMean.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given large variance ( = large `beta` )', function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -166,13 +147,7 @@ tape( 'the function evaluates the cdf for `x` given large variance ( = large `be
 	beta = largeVariance.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/cdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -140,10 +139,8 @@ tape( 'if provided a nonpositive `beta`, the created function always returns `Na
 
 tape( 'the created function evaluates the cdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var beta;
 	var cdf;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -156,23 +153,15 @@ tape( 'the created function evaluates the cdf for `x` given positive `mu`', func
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( mu[i], beta[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var beta;
 	var cdf;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -185,23 +174,15 @@ tape( 'the created function evaluates the cdf for `x` given negative `mu`', func
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( mu[i], beta[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given large variance ( = large `beta`)', function test( t ) {
 	var expected;
-	var delta;
 	var beta;
 	var cdf;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -214,13 +195,7 @@ tape( 'the created function evaluates the cdf for `x` given large variance ( = l
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( mu[i], beta[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/cdf/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -107,9 +106,7 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', opts, func
 
 tape( 'the function evaluates the cdf for `x` given positive `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -121,22 +118,14 @@ tape( 'the function evaluates the cdf for `x` given positive `mu`', opts, functi
 	beta = positiveMean.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given negative `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -148,22 +137,14 @@ tape( 'the function evaluates the cdf for `x` given negative `mu`', opts, functi
 	beta = negativeMean.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given large variance ( = large `beta` )', opts, function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -175,13 +156,7 @@ tape( 'the function evaluates the cdf for `x` given large variance ( = large `be
 	beta = largeVariance.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates `stats/base/dists/gumbel/cdf` test cases from relative-tolerance testing (`EPS`-scaled `delta`/`tol` comparisons) to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per the tracking issue #11352.
-   Updates `test/test.cdf.js`, `test/test.factory.js`, and `test/test.native.js` (the three files containing the fixture-based tolerance idiom); `test/test.js` was untouched, as it contains no fixture-based tolerance checks.
-   Measured the minimum required ULP bound empirically against the full Julia fixture set (`positive_mean`, `negative_mean`, `large_variance`; 1000 cases each): the JS implementation returns values bit-for-bit identical to the fixtures (0 ULP difference) across all 3000 cases, so `isAlmostSameValue( y, expected[ i ], 0 )` is used throughout. The suite was run twice to confirm determinism.
-   No source or fixture changes; only test files were modified.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

- Final ULP bound: `0` for all three fixture groups (`positive_mean`, `negative_mean`, `large_variance`), in `test.cdf.js`, `test.factory.js`, and `test.native.js`.
- `test.native.js` mirrors the same ULP bound as the JS tests, consistent with the convention in prior conversions in this package family (e.g. `stats/base/dists/cosine/cdf`); the native addon is not built in the environment this PR was prepared in, so those assertions run but are skipped locally (as `tryRequire` fails to resolve the compiled addon) and were not empirically re-verified against a native binary.
- `npx eslint` reports no issues on the changed files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, as part of an automated, unattended conversion run targeting issue #11352. Claude Code discovered the candidate package, studied prior-art commits for the exact idiom, computed the minimum ULP bound empirically from the fixtures, applied the edits, and ran the local test/lint suite before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeV22WPpWxd7fFqj1B1fhE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeV22WPpWxd7fFqj1B1fhE)_