### PR TITLE
test: migrate `stats/base/dists/chi/entropy` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chi/entropy/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/entropy/test/test.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var entropy = require( './../lib' );
 
 
@@ -64,8 +63,6 @@ tape( 'if provided a degrees of freedom parameter `k` that is not a positive num
 
 tape( 'the function returns the differential entropy of a chi distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -74,13 +71,7 @@ tape( 'the function returns the differential entropy of a chi distribution', fun
 	k = data.k;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 40 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/entropy/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/entropy/test/test.native.js
@@ -22,10 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 
 
@@ -73,8 +72,6 @@ tape( 'if provided a degrees of freedom parameter `k` that is not a positive num
 
 tape( 'the function returns the differential entropy of a chi distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -83,13 +80,7 @@ tape( 'the function returns the differential entropy of a chi distribution', opt
 	k = data.k;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 40 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/chi/entropy` from relative-tolerance assertions (`delta <= tol`, with `delta = abs( y - expected[ i ] )` and `tol = 40.0 * EPS * abs( expected[ i ] )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the same migration to both `test/test.js` and `test/test.native.js`.
-   preserves all existing test cases and non-tolerance assertions (`NaN` input, `k = 0`, negative `k`, `-infinity`), and drops the now-unused `abs` and `EPS` requires.

### ULP bound

| File                  | ULP |
| --------------------- | :-: |
| `test/test.js`        | 40  |
| `test/test.native.js` | 40  |

`40` is the **measured minimum**: it is the smallest integer `N` for which `isAlmostSameValue( actual, expected[ i ], N )` holds for every one of the 50 entries in `test/fixtures/julia/data.json`. Starting from a loose bound and tightening, `N = 40` passes all 56 assertions, while `N = 39` fails one. The worst case is `k = 12.15523701785568`, where the implementation returns `1.0574794791499498` against an expected `1.057479479149941`.

A bound of this magnitude is expected for this package rather than indicative of a regression. `entropy( k )` is computed as `gammaln( k/2 ) + ( 0.5 * ( k - LN2 - ( (k-1)*digamma( k/2 ) ) ) )`, so the result is a difference of two comparatively large quantities (the log-gamma term and the `(k-1)*digamma( k/2 )` term) whose leading digits cancel as `k` grows. The relative errors of `gammaln` and `digamma` are therefore amplified in the difference. The previous relative tolerance of `40.0 * EPS` corresponds to roughly 40–80 ULP depending on where the expected value falls within its binade, so the new bound is no looser than, and at the worst case slightly tighter than, the tolerance it replaces.

The tests were run repeatedly at the final `N` to confirm deterministic passing (56 assertions, all passing on every run, no FMA/architecture-dependent variation). `test/test.native.js` uses the same bound as `test/test.js`; the native add-on is not built in this environment, so those tests are skipped locally, and both the JavaScript and C implementations evaluate the identical expression in double precision and in the same order of operations.

Linting was checked before and after the change and is unchanged: both files report the same eight pre-existing `no-restricted-syntax` (`FunctionExpression`) errors before and after, with only line numbers shifted. The only files changed are the two test files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code: the assistant mechanically converted the tolerance-based assertions to `isAlmostSameValue`, agentically searched for the minimum ULP bound over the full fixture set, verified determinism across repeated full runs, and ran the local lint and test suites before submitting.

* * *

@stdlib-js/reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdTF9JMjg8TUp9feR48EDh

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdTF9JMjg8TUp9feR48EDh)_