### PR TITLE
test: migrate `blas/base/dzasum` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dzasum/test/test.dzasum.js
+++ b/lib/node_modules/@stdlib/blas/base/dzasum/test/test.dzasum.js
@@ -22,8 +22,7 @@
 
 var tape = require( 'tape' );
 var Complex128Array = require( '@stdlib/array/complex128' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var dzasum = require( './../lib/dzasum.js' );
 
 
@@ -36,19 +35,10 @@ var dzasum = require( './../lib/dzasum.js' );
 * @param {Object} t - test object
 * @param {number} actual - actual value
 * @param {number} expected - expected value
-* @param {number} rtol - relative tolerance
+* @param {NonNegativeInteger} ulp - maximum allowed ULP difference
 */
-function isApprox( t, actual, expected, rtol ) {
-	var delta;
-	var tol;
-
-	if ( actual === expected ) {
-		t.strictEqual( actual, expected, 'returns expected value' );
-	} else {
-		delta = abs( actual - expected );
-		tol = rtol * EPS * abs( expected );
-		t.ok( delta <= tol, 'within tolerance. actual: '+actual+'. expected: '+expected+'. delta: '+delta+'. tol: '+tol+'.' );
-	}
+function isApprox( t, actual, expected, ulp ) {
+	t.strictEqual( isAlmostSameValue( actual, expected, ulp ), true, 'returns expected value' );
 }
 
 
@@ -68,7 +58,10 @@ tape( 'the function has an arity of 3', function test( t ) {
 tape( 'the function computes the sum of the absolute values of the real and imaginary components of a double-precision complex floating-point strided array', function test( t ) {
 	var expected;
 	var actual;
+	var ULP;
 	var x;
+
+	ULP = 1;
 
 	x = new Complex128Array([
 		0.3, // 1
@@ -85,7 +78,7 @@ tape( 'the function computes the sum of the absolute values of the real and imag
 	expected = 1.6;
 
 	actual = dzasum( 4, x, 1 );
-	isApprox( t, actual, expected, 2.0 );
+	isApprox( t, actual, expected, ULP );
 
 	x = new Complex128Array([
 		0.1,  // 1
@@ -100,7 +93,7 @@ tape( 'the function computes the sum of the absolute values of the real and imag
 	expected = 1.3;
 
 	actual = dzasum( 3, x, 1 );
-	isApprox( t, actual, expected, 2.0 );
+	isApprox( t, actual, expected, ULP );
 	t.end();
 });
 
@@ -137,7 +130,10 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function retu
 tape( 'the function supports specifying a stride', function test( t ) {
 	var expected;
 	var actual;
+	var ULP;
 	var x;
+
+	ULP = 1;
 
 	x = new Complex128Array([
 		0.3, // 1
@@ -160,14 +156,17 @@ tape( 'the function supports specifying a stride', function test( t ) {
 	expected = 1.6;
 
 	actual = dzasum( 4, x, 2 );
-	isApprox( t, actual, expected, 2.0 );
+	isApprox( t, actual, expected, ULP );
 	t.end();
 });
 
 tape( 'the function supports specifying a negative stride', function test( t ) {
 	var expected;
 	var actual;
+	var ULP;
 	var x;
+
+	ULP = 0;
 
 	x = new Complex128Array([
 		0.3, // 4
@@ -182,7 +181,7 @@ tape( 'the function supports specifying a negative stride', function test( t ) {
 	expected = 28.9;
 
 	actual = dzasum( 4, x, -1 );
-	isApprox( t, actual, expected, 2.0 );
+	isApprox( t, actual, expected, ULP );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/blas/base/dzasum/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dzasum/test/test.ndarray.js
@@ -22,8 +22,7 @@
 
 var tape = require( 'tape' );
 var Complex128Array = require( '@stdlib/array/complex128' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var dzasum = require( './../lib/ndarray.js' );
 
 
@@ -36,19 +35,10 @@ var dzasum = require( './../lib/ndarray.js' );
 * @param {Object} t - test object
 * @param {number} actual - actual value
 * @param {number} expected - expected value
-* @param {number} rtol - relative tolerance
+* @param {NonNegativeInteger} ulp - maximum allowed ULP difference
 */
-function isApprox( t, actual, expected, rtol ) {
-	var delta;
-	var tol;
-
-	if ( actual === expected ) {
-		t.strictEqual( actual, expected, 'returns expected value' );
-	} else {
-		delta = abs( actual - expected );
-		tol = rtol * EPS * abs( expected );
-		t.ok( delta <= tol, 'within tolerance. actual: '+actual+'. expected: '+expected+'. delta: '+delta+'. tol: '+tol+'.' );
-	}
+function isApprox( t, actual, expected, ulp ) {
+	t.strictEqual( isAlmostSameValue( actual, expected, ulp ), true, 'returns expected value' );
 }
 
 
@@ -68,7 +58,10 @@ tape( 'the function has an arity of 4', function test( t ) {
 tape( 'the function computes the sum of the absolute values of the real and imaginary components of a double-precision complex floating-point strided array', function test( t ) {
 	var expected;
 	var actual;
+	var ULP;
 	var x;
+
+	ULP = 1;
 
 	x = new Complex128Array([
 		0.3, // 1
@@ -85,7 +78,7 @@ tape( 'the function computes the sum of the absolute values of the real and imag
 	expected = 1.6;
 
 	actual = dzasum( 4, x, 1, 0 );
-	isApprox( t, actual, expected, 2.0 );
+	isApprox( t, actual, expected, ULP );
 
 	x = new Complex128Array([
 		0.1,  // 1
@@ -100,7 +93,7 @@ tape( 'the function computes the sum of the absolute values of the real and imag
 	expected = 1.3;
 
 	actual = dzasum( 3, x, 1, 0 );
-	isApprox( t, actual, expected, 2.0 );
+	isApprox( t, actual, expected, ULP );
 	t.end();
 });
 
@@ -137,7 +130,10 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function retu
 tape( 'the function supports specifying a stride', function test( t ) {
 	var expected;
 	var actual;
+	var ULP;
 	var x;
+
+	ULP = 1;
 
 	x = new Complex128Array([
 		0.3, // 1
@@ -160,14 +156,17 @@ tape( 'the function supports specifying a stride', function test( t ) {
 	expected = 1.6;
 
 	actual = dzasum( 4, x, 2, 0 );
-	isApprox( t, actual, expected, 2.0 );
+	isApprox( t, actual, expected, ULP );
 	t.end();
 });
 
 tape( 'the function supports specifying a negative stride', function test( t ) {
 	var expected;
 	var actual;
+	var ULP;
 	var x;
+
+	ULP = 0;
 
 	x = new Complex128Array([
 		0.3, // 4
@@ -190,7 +189,7 @@ tape( 'the function supports specifying a negative stride', function test( t ) {
 	expected = 28.9;
 
 	actual = dzasum( 4, x, -1, 3 );
-	isApprox( t, actual, expected, 2.0 );
+	isApprox( t, actual, expected, ULP );
 	t.end();
 });
 
@@ -221,7 +220,10 @@ tape( 'the function supports specifying an offset', function test( t ) {
 tape( 'the function supports specifying complex access patterns', function test( t ) {
 	var expected;
 	var actual;
+	var ULP;
 	var x;
+
+	ULP = 0;
 
 	x = new Complex128Array([
 		0.3, // 4
@@ -244,6 +246,6 @@ tape( 'the function supports specifying complex access patterns', function test(
 	expected = 1.6;
 
 	actual = dzasum( 4, x, -2, 6 );
-	isApprox( t, actual, expected, 2.0 );
+	isApprox( t, actual, expected, ULP );
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `blas/base/dzasum` from relative-tolerance assertions to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to both `test/test.dzasum.js` and `test/test.ndarray.js`. The package has no `test/test.native.js` (no native implementation has landed yet), and `test/test.js` contains no tolerance-based assertions and is unchanged.
-   converts the shared private `isApprox( t, actual, expected, rtol )` helper in each file to `isApprox( t, actual, expected, ulp )`, replacing the `delta`/`tol` computation with a single `t.strictEqual( isAlmostSameValue( actual, expected, ulp ), true, 'returns expected value' )`, mirroring the same-family conversion in `blas/base/drotm` (#14869).
-   introduces a per-test `ULP` constant, as in `blas/base/drotm`, and drops the now-unused `abs` and `EPS` requires.
-   preserves all existing test cases and every non-tolerance assertion (`N <= 0`, view offsets, offset support, arity, main export) exactly as-is.

### ULP bounds

| File                   | Test                                | ULP |
| ---------------------- | ----------------------------------- | :-: |
| `test/test.dzasum.js`  | computes the sum of absolute values |  1  |
| `test/test.dzasum.js`  | supports specifying a stride        |  1  |
| `test/test.dzasum.js`  | supports specifying a negative stride |  0  |
| `test/test.ndarray.js` | computes the sum of absolute values |  1  |
| `test/test.ndarray.js` | supports specifying a stride        |  1  |
| `test/test.ndarray.js` | supports specifying a negative stride |  0  |
| `test/test.ndarray.js` | supports specifying complex access patterns |  0  |

Each value is the **measured minimum**. Starting from a loose bound and tightening, every assertion site was measured directly with `@stdlib/number/float64/base/ulp-difference`, and the result was confirmed by re-running the suite with the bounds tightened one step further:

-   The six sites carrying `ULP = 1` have an exact measured ULP difference of `1` (e.g. `dzasum( 4, x, 1 )` returns `1.5999999999999999` against an expected `1.6`, and `dzasum( 3, x, 1 )` returns `1.2999999999999998` against an expected `1.3`). Lowering those blocks to `ULP = 0` fails 3 assertions in `test/test.dzasum.js` and 3 assertions in `test/test.ndarray.js`, so `1` cannot be reduced.
-   The remaining sites are bit-for-bit exact and therefore use `ULP = 0`, which delegates to the SameValue algorithm. `0` is the tightest bound expressible.

Bounds this small are what one expects here: `dzasum` is a plain summation of `abs( real )` and `abs( imag )` over a short strided array, so the only error is the accumulated rounding of a handful of additions, and it never exceeds one ULP on these fixtures. The previous relative tolerance of `2.0 * EPS` corresponds to roughly 2–4 ULP depending on where the expected value falls within its binade, so the new bounds are strictly tighter than the tolerances they replace.

The full package suite was run twice at the final bounds to confirm deterministic passing (26 assertions across the 3 test files, all passing on both runs, no FMA/architecture-dependent variation). Linting is clean: `make eslint-tests TESTS_FILTER=".*/blas/base/dzasum/.*"` reports no errors for either changed file. The only files changed are the two test files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code: the assistant mechanically converted the tolerance-based assertions to `isAlmostSameValue`, agentically searched for the minimum ULP bound at every assertion site, verified minimality by re-running the suite one step tighter, confirmed determinism across repeated full runs, and ran the local lint and test suites before submitting.

* * *

@stdlib-js/reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfbAgTVeRuwnmFGvUZETog

---
_Generated by [Claude Code](https://claude.ai/code/session_01CfbAgTVeRuwnmFGvUZETog)_