### PR TITLE
build: scope affected benchmarks to the changed package

### DIFF
--- a/.github/workflows/scripts/run_affected_benchmarks/run
+++ b/.github/workflows/scripts/run_affected_benchmarks/run
@@ -129,11 +129,11 @@ main() {
 		fi
 	done
 
-	# Find all benchmark files in package directories:
+	# Find all benchmark files in package directories. Note that benchmark discovery is intentionally scoped to each package's own `benchmark` directory so that changes to a namespace package do not trigger benchmarks for that namespace's sub-packages:
 	js_bench_files=""
 	for dir in ${directories}; do
-		if [ -d "${dir}" ]; then
-			files=$(find "${dir}" -maxdepth 3 -wholename '**/benchmark/benchmark*.js' | grep -v '/fixtures/' | sort -u | tr '\n' ' ') || true
+		if [ -d "${dir}/benchmark" ]; then
+			files=$(find "${dir}/benchmark" -name 'benchmark*.js' | grep -v '/fixtures/' | sort -u | tr '\n' ' ') || true
 			js_bench_files="${js_bench_files} ${files}"
 		fi
 	done
@@ -151,8 +151,8 @@ main() {
 	echo "Finding C benchmark files in ${directories}..."
 	c_bench_files=""
 	for dir in ${directories}; do
-		if [ -d "${dir}" ]; then
-			files=$(find "${dir}" -maxdepth 5 \( -wholename '**/benchmark/c/benchmark*.c' -or -wholename '**/benchmark/c/**/benchmark*.c' \) -exec realpath {} \; | grep -v '/fixtures/' | sort -u | tr '\n' ' ') || true
+		if [ -d "${dir}/benchmark/c" ]; then
+			files=$(find "${dir}/benchmark/c" -name 'benchmark*.c' -exec realpath {} \; | grep -v '/fixtures/' | sort -u | tr '\n' ' ') || true
 			c_bench_files="${c_bench_files} ${files}"
 		fi
 	done
@@ -161,8 +161,8 @@ main() {
 	# If benchmarks requiring Cephes are found, install the Cephes library:
 	c_cephes_makefiles=""
 	for dir in ${directories}; do
-		if [ -d "${dir}" ]; then
-			files=$(find "${dir}" -maxdepth 5 -wholename '**/benchmark/c/**/Makefile' -exec grep -l 'CEPHES' {} + || true)
+		if [ -d "${dir}/benchmark/c" ]; then
+			files=$(find "${dir}/benchmark/c" -name 'Makefile' -exec grep -l 'CEPHES' {} + || true)
 			c_cephes_makefiles="${c_cephes_makefiles} ${files}"
 		fi
 	done

--- a/.github/workflows/scripts/run_affected_benchmarks/run
+++ b/.github/workflows/scripts/run_affected_benchmarks/run
@@ -129,8 +129,8 @@ main() {
 		fi
 	done
 
-	# Note that benchmark discovery is intentionally scoped to each package's own `benchmark` directory so that changes to a namespace package do not trigger benchmarks for that namespace's sub-packages.
-	# Find all benchmark files in package directories:
+	# Find all benchmark files in package directories. Note that benchmark discovery is intentionally scoped to each package's own
+	# `benchmark` directory so that changes to a namespace package do not trigger benchmarks for that namespace's sub-packages:
 	js_bench_files=""
 	for dir in ${directories}; do
 		if [ -d "${dir}/benchmark" ]; then

--- a/.github/workflows/scripts/run_affected_benchmarks/run
+++ b/.github/workflows/scripts/run_affected_benchmarks/run
@@ -129,7 +129,8 @@ main() {
 		fi
 	done
 
-	# Find all benchmark files in package directories. Note that benchmark discovery is intentionally scoped to each package's own `benchmark` directory so that changes to a namespace package do not trigger benchmarks for that namespace's sub-packages:
+	# Note that benchmark discovery is intentionally scoped to each package's own `benchmark` directory so that changes to a namespace package do not trigger benchmarks for that namespace's sub-packages.
+	# Find all benchmark files in package directories:
 	js_bench_files=""
 	for dir in ${directories}; do
 		if [ -d "${dir}/benchmark" ]; then

--- a/.github/workflows/scripts/run_affected_benchmarks/run
+++ b/.github/workflows/scripts/run_affected_benchmarks/run
@@ -129,8 +129,7 @@ main() {
 		fi
 	done
 
-	# Find all benchmark files in package directories. Note that benchmark discovery is intentionally scoped to each package's own
-	# `benchmark` directory so that changes to a namespace package do not trigger benchmarks for that namespace's sub-packages:
+	# Find all benchmark files in package directories (note: benchmark discovery is intentionally scoped to each package's own `benchmark` directory so that changes to a namespace package do not trigger benchmarks for that namespace's sub-packages):
 	js_bench_files=""
 	for dir in ${directories}; do
 		if [ -d "${dir}/benchmark" ]; then


### PR DESCRIPTION
Resolves stdlib-js/metr-issue-tracker#659.

## Description

> What is the purpose of this pull request?

This pull request:

-   scopes affected-benchmark discovery in `.github/workflows/scripts/run_affected_benchmarks/run` to each changed package's own `benchmark` directory. Previously, the script recursively searched the changed package directory, so a change to a namespace package file (e.g., `@stdlib/ndarray/lib/index.js`) ran benchmarks for every sub-package in the namespace (294 JavaScript benchmark files for `ndarray`, 732 for `math/base/special`), clogging the workflow queue and causing timeouts. With this change, only the changed package's own benchmarks run. Leaf package behavior is unchanged.

Notes:

-   The affected-tests workflow needs no equivalent change: its per-package test discovery is already scoped to the package's own `test` directory, and its dependents scan matches exact `require( '@stdlib/<pkg>' )` calls, of which none exist for namespace packages.
-   Since benchmark directories never contain sub-packages, the `find` invocations no longer need `-maxdepth` caps and now also accommodate benchmark files in subdirectories of `benchmark`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   stdlib-js/metr-issue-tracker#659

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verified locally by running the script with a stubbed `make` for both a namespace change (`ndarray/lib`: no benchmarks run) and a leaf change (`math/base/special/sin/lib`: same JS/C/Cephes benchmarks as before).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, with the approach reviewed and directed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
