### PR TITLE
test: migrate `stats/incr/rmse` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/rmse/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/rmse/test/test.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var incrrmse = require( './../lib' );
 
 
@@ -49,11 +48,9 @@ tape( 'the initial accumulated value is `null`', function test( t ) {
 tape( 'the accumulator function incrementally computes the root mean squared error', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
 	var acc;
 	var sum;
-	var tol;
 	var N;
 	var r;
 	var x;
@@ -80,13 +77,7 @@ tape( 'the accumulator function incrementally computes the root mean squared err
 		sum += r * r;
 		expected = sqrt( sum/(i+1) );
 		actual = acc( x, y );
-		if ( actual === expected ) {
-			t.strictEqual( actual, expected, 'returns expected value' );
-		} else {
-			delta = abs( expected - actual );
-			tol = 1.0 * EPS * abs( expected );
-			t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+actual+'. Expected: '+expected+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual, expected, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -94,10 +85,8 @@ tape( 'the accumulator function incrementally computes the root mean squared err
 tape( 'if not provided an input value, the accumulator function returns the current root mean squared error', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
 	var acc;
-	var tol;
 	var i;
 
 	data = [
@@ -111,8 +100,6 @@ tape( 'if not provided an input value, the accumulator function returns the curr
 	}
 	actual = acc();
 	expected = sqrt( ( 1.0+64.0+81.0 ) / 3.0 );
-	delta = abs( expected - actual );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+actual+'. Expected: '+expected+'. Delta: '+delta+'. Tol: '+tol+'.' );
+	t.strictEqual( isAlmostSameValue( actual, expected, 0 ), true, 'returns expected value' );
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/incr/rmse` from relative tolerance comparisons to ULP-based assertions.
-   replaces the `abs`/`EPS` computed-tolerance idiom (`delta = abs( expected - actual ); tol = 1.0 * EPS * abs( expected ); t.strictEqual( delta <= tol, true, ... )`) with `t.strictEqual( isAlmostSameValue( actual, expected, 0 ), true, 'returns expected value' )`, adding the `@stdlib/assert/is-almost-same-value` require and removing the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.
-   only modifies `test/test.js`. The package has no `test/test.native.js`.

**Final ULP bound: `0` (both assertions).**

Starting from a high bound and tightening, `0` is the measured minimum which still passes over the full set of test cases: the accumulator results are bit-for-bit identical to the expected values for these fixtures. The suite was run twice at the final bound to confirm determinism. A ULP value of `0` is consistent with existing converted packages in the repository (e.g., `math/base/special/coversin`, `math/base/special/asecf`).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code, which identified the package, performed the migration, and empirically determined the minimum ULP bound by running the test suite.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1MQc2dSEYA7jfHwE2Gm3d


---
_Generated by [Claude Code](https://claude.ai/code/session_01T1MQc2dSEYA7jfHwE2Gm3d)_