### PR TITLE
test: migrate `math/base/tools/normhermitepoly` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/tools/normhermitepoly/test/test.factory.js
+++ b/lib/node_modules/@stdlib/math/base/tools/normhermitepoly/test/test.factory.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var factory = require( './../lib' ).factory;
 
@@ -30,23 +29,18 @@ var factory = require( './../lib' ).factory;
 // FIXTURES //
 
 var random2 = require( './fixtures/python/random2.json' );
-
 var mediumNegative1 = require( './fixtures/python/medium_negative_1.json' );
 var mediumNegative2 = require( './fixtures/python/medium_negative_2.json' );
 var mediumNegative5 = require( './fixtures/python/medium_negative_5.json' );
-
 var mediumPositive1 = require( './fixtures/python/medium_positive_1.json' );
 var mediumPositive2 = require( './fixtures/python/medium_positive_2.json' );
 var mediumPositive5 = require( './fixtures/python/medium_positive_5.json' );
-
 var smallPositive1 = require( './fixtures/python/small_positive_1.json' );
 var smallPositive2 = require( './fixtures/python/small_positive_2.json' );
 var smallPositive5 = require( './fixtures/python/small_positive_5.json' );
-
 var smallNegative1 = require( './fixtures/python/small_negative_1.json' );
 var smallNegative2 = require( './fixtures/python/small_negative_2.json' );
 var smallNegative5 = require( './fixtures/python/small_negative_5.json' );
-
 var tiny1 = require( './fixtures/python/tiny_1.json' );
 var tiny2 = require( './fixtures/python/tiny_2.json' );
 var tiny5 = require( './fixtures/python/tiny_5.json' );
@@ -67,8 +61,6 @@ tape( 'the function returns a function', function test( t ) {
 
 tape( 'the function returns a function which accurately computes `Hen(x)` for random `n` and `x`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -82,17 +74,13 @@ tape( 'the function returns a function which accurately computes `Hen(x)` for ra
 	for ( i = 0; i < x.length; i++ ) {
 		f = factory( n[ i ] );
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n[ i ] + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He1(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -107,17 +95,13 @@ tape( 'the function returns a function which accurately computes `He1(x)` for sm
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -132,17 +116,13 @@ tape( 'the function accurately computes `He2(x)` for small positive numbers', fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He5(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -157,17 +137,13 @@ tape( 'the function returns a function which accurately computes `He5(x)` for sm
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He1(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -182,17 +158,13 @@ tape( 'the function returns a function which accurately computes `He1(x)` for sm
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He2(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -207,17 +179,13 @@ tape( 'the function returns a function which accurately computes `He2(x)` for sm
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He5(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -232,17 +200,13 @@ tape( 'the function returns a function which accurately computes `He5(x)` for sm
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He1(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -257,17 +221,13 @@ tape( 'the function returns a function which accurately computes `He1(x)` for ti
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He2(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -282,17 +242,13 @@ tape( 'the function returns a function which accurately computes `He2(x)` for ti
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He5(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -307,17 +263,13 @@ tape( 'the function returns a function which accurately computes `He5(x)` for ti
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He1(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -332,17 +284,13 @@ tape( 'the function returns a function which accurately computes `He1(x)` for po
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He2(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -357,17 +305,13 @@ tape( 'the function returns a function which accurately computes `He2(x)` for po
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He5(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -382,17 +326,13 @@ tape( 'the function returns a function which accurately computes `He5(x)` for po
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He1(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -407,17 +347,13 @@ tape( 'the function returns a function which accurately computes `He1(x)` for ne
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He2(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -432,17 +368,13 @@ tape( 'the function returns a function which accurately computes `He2(x)` for ne
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He5(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -457,9 +389,7 @@ tape( 'the function returns a function which accurately computes `He5(x)` for ne
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/tools/normhermitepoly/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/tools/normhermitepoly/test/test.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var normhermitepoly = require( './../lib' );
 
@@ -30,23 +29,18 @@ var normhermitepoly = require( './../lib' );
 // FIXTURES //
 
 var random2 = require( './fixtures/python/random2.json' );
-
 var mediumNegative1 = require( './fixtures/python/medium_negative_1.json' );
 var mediumNegative2 = require( './fixtures/python/medium_negative_2.json' );
 var mediumNegative5 = require( './fixtures/python/medium_negative_5.json' );
-
 var mediumPositive1 = require( './fixtures/python/medium_positive_1.json' );
 var mediumPositive2 = require( './fixtures/python/medium_positive_2.json' );
 var mediumPositive5 = require( './fixtures/python/medium_positive_5.json' );
-
 var smallPositive1 = require( './fixtures/python/small_positive_1.json' );
 var smallPositive2 = require( './fixtures/python/small_positive_2.json' );
 var smallPositive5 = require( './fixtures/python/small_positive_5.json' );
-
 var smallNegative1 = require( './fixtures/python/small_negative_1.json' );
 var smallNegative2 = require( './fixtures/python/small_negative_2.json' );
 var smallNegative5 = require( './fixtures/python/small_negative_5.json' );
-
 var tiny1 = require( './fixtures/python/tiny_1.json' );
 var tiny2 = require( './fixtures/python/tiny_2.json' );
 var tiny5 = require( './fixtures/python/tiny_5.json' );
@@ -67,8 +61,6 @@ tape( 'attached to the main export is a `factory` method', function test( t ) {
 
 tape( 'the function accurately computes `Hen(x)` for random `n` and `x`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -80,17 +72,13 @@ tape( 'the function accurately computes `Hen(x)` for random `n` and `x`', functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n[ i ], x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n[ i ] + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He1(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -102,17 +90,13 @@ tape( 'the function accurately computes `He1(x)` for small positive numbers', fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -124,17 +108,13 @@ tape( 'the function accurately computes `He2(x)` for small positive numbers', fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He5(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -146,17 +126,13 @@ tape( 'the function accurately computes `He5(x)` for small positive numbers', fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He1(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -168,17 +144,13 @@ tape( 'the function accurately computes `He1(x)` for small negative numbers', fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -190,17 +162,13 @@ tape( 'the function accurately computes `He2(x)` for small negative numbers', fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He5(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -212,17 +180,13 @@ tape( 'the function accurately computes `He5(x)` for small negative numbers', fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He1(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -234,17 +198,13 @@ tape( 'the function accurately computes `He1(x)` for tiny numbers', function tes
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -256,17 +216,13 @@ tape( 'the function accurately computes `He2(x)` for tiny numbers', function tes
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He5(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -278,17 +234,13 @@ tape( 'the function accurately computes `He5(x)` for tiny numbers', function tes
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He1(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -300,17 +252,13 @@ tape( 'the function accurately computes `He1(x)` for positive medium numbers', f
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -322,17 +270,13 @@ tape( 'the function accurately computes `He2(x)` for positive medium numbers', f
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He5(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -344,17 +288,13 @@ tape( 'the function accurately computes `He5(x)` for positive medium numbers', f
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He1(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -366,17 +306,13 @@ tape( 'the function accurately computes `He1(x)` for negative medium numbers', f
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -388,17 +324,13 @@ tape( 'the function accurately computes `He2(x)` for negative medium numbers', f
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He5(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -410,9 +342,7 @@ tape( 'the function accurately computes `He5(x)` for negative medium numbers', f
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepoly( n, x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Progresses #11352 (partial).

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.factory.js` for `math/base/tools/normhermitepoly` from the old computed-tolerance (`EPS * abs( expected )`) assertion idiom to ULP-based assertions using `@stdlib/assert/is-almost-same-value`.
-   removes the now-unused `abs` and `EPS` requires and the `delta`/`tol` locals from each test body.
-   determined the tightest ULP bound agentically: computed the exact ULP distance between actual and expected values for every fixture entry (16 fixture blocks × 1,000 samples each, covering both `normhermitepoly` and its `factory` variant). The measured maximum ULP distance was **0** across all blocks (bit-for-bit exact), so a bound of `0` is used throughout. Verified determinism by running the full suite twice (16,010/16,010 assertions passing both times).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Mirrors the idiom already adopted for the sibling package `math/base/tools/hermitepoly` in a prior ULP migration. Only the two test files were changed; no `package.json` changes were needed since `@stdlib/assert/is-almost-same-value` is already available in this context (consistent with the `hermitepoly` precedent).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, run as an unattended scheduled task converting one package's tests per #11352.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRhzJ9hhkqJuvnHF9jwSzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRhzJ9hhkqJuvnHF9jwSzV)_