### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/logcdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/logcdf/src/main.c
@@ -53,5 +53,5 @@ double stdlib_base_dists_arcsine_logcdf( const double x, const double a, const d
 		return 0.0;
 	}
 
-	return STDLIB_CONSTANT_FLOAT64_LN2  - STDLIB_CONSTANT_FLOAT64_LN_PI + ( stdlib_base_ln( stdlib_base_asin ( stdlib_base_sqrt ( ( x-a ) / ( b-a ) ) ) ) ) ;
+	return STDLIB_CONSTANT_FLOAT64_LN2 - STDLIB_CONSTANT_FLOAT64_LN_PI + stdlib_base_ln( stdlib_base_asin( stdlib_base_sqrt( ( x-a ) / ( b-a ) ) ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/pdf/README.md
@@ -186,7 +186,7 @@ logEachMap( 'x: %0.4f, k: %d, λ: %0.4f, f(x;k,λ): %0.4f', x, k, lambda, pdf );
 Evaluates the [probability density function][pdf] (PDF) for an [Erlang][erlang-distribution] distribution with parameters `k` (shape parameter) and `lambda` (rate parameter).
 
 ```c
-double y = stdlib_base_dists_erlang_pdf( 0.1, 1.0, 1.0 );
+double y = stdlib_base_dists_erlang_pdf( 0.1, 1, 1.0 );
 // returns ~0.905
 ```
 

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/pdf/README.md
@@ -186,7 +186,7 @@ logEachMap( 'x: %0.4f, k: %d, λ: %0.4f, f(x;k,λ): %0.4f', x, k, lambda, pdf );
 Evaluates the [probability density function][pdf] (PDF) for an [Erlang][erlang-distribution] distribution with parameters `k` (shape parameter) and `lambda` (rate parameter).
 
 ```c
-double y = stdlib_base_dists_erlang_pdf( 0.1, 1, 1.0 );
+double y = stdlib_base_dists_erlang_pdf( 0.1, 1.0, 1.0 );
 // returns ~0.905
 ```
 

--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/README.md
@@ -188,7 +188,6 @@ The function accepts the following arguments:
 -   **mu**: `[in] double` location parameter.
 -   **sigma**: `[in] double` scale parameter.
 
-
 ```c
 double stdlib_base_dists_truncated_normal_pdf( const double x, const double a, const double b, const double mu, const double sigma );
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/include/stdlib/stats/base/dists/truncated-normal/pdf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/include/stdlib/stats/base/dists/truncated-normal/pdf.h
@@ -27,9 +27,7 @@ extern "C" {
 #endif
 
 /**
-* Evaluates the probability density function (PDF) for a truncated normal
-* distribution with lower limit `a`, upper limit `b`, location parameter `mu`,
-* and scale parameter `sigma`.
+* Evaluates the probability density function (PDF) for a truncated normal distribution with lower limit `a`, upper limit `b`, location parameter `mu`, and scale parameter `sigma`.
 */
 double stdlib_base_dists_truncated_normal_pdf( const double x, const double a, const double b, const double mu, const double sigma );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/manifest.json
@@ -1,91 +1,91 @@
 {
-    "options": {
-        "task": "build",
-        "wasm": false
+  "options": {
+    "task": "build",
+    "wasm": false
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
     },
-    "fields": [
-        {
-            "field": "src",
-            "resolve": true,
-            "relative": true
-        },
-        {
-            "field": "include",
-            "resolve": true,
-            "relative": true
-        },
-        {
-            "field": "libraries",
-            "resolve": false,
-            "relative": false
-        },
-        {
-            "field": "libpath",
-            "resolve": true,
-            "relative": false
-        }
-    ],
-    "confs": [
-        {
-            "task": "build",
-            "wasm": false,
-            "src": [
-                "./src/main.c"
-            ],
-            "include": [
-                "./include"
-            ],
-            "libraries": [],
-            "libpath": [],
-            "dependencies": [
-                "@stdlib/math/base/napi/quinary",
-                "@stdlib/math/base/assert/is-nan",
-                "@stdlib/math/base/special/exp",
-                "@stdlib/math/base/special/abs2",
-                "@stdlib/constants/float64/pi",
-                "@stdlib/math/base/special/sqrt",
-                "@stdlib/stats/base/dists/normal/cdf"
-            ]
-        },
-        {
-            "task": "benchmark",
-            "wasm": false,
-            "src": [
-                "./src/main.c"
-            ],
-            "include": [
-                "./include"
-            ],
-            "libraries": [],
-            "libpath": [],
-            "dependencies": [
-                "@stdlib/math/base/assert/is-nan",
-                "@stdlib/math/base/special/exp",
-                "@stdlib/math/base/special/abs2",
-                "@stdlib/constants/float64/pi",
-                "@stdlib/math/base/special/sqrt",
-                "@stdlib/stats/base/dists/normal/cdf"
-            ]
-        },
-        {
-            "task": "examples",
-            "wasm": false,
-            "src": [
-                "./src/main.c"
-            ],
-            "include": [
-                "./include"
-            ],
-            "libraries": [],
-            "libpath": [],
-            "dependencies": [
-                "@stdlib/math/base/assert/is-nan",
-                "@stdlib/math/base/special/exp",
-                "@stdlib/math/base/special/abs2",
-                "@stdlib/constants/float64/pi",
-                "@stdlib/math/base/special/sqrt",
-                "@stdlib/stats/base/dists/normal/cdf"
-            ]
-        }
-    ]
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/quinary",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/exp",
+        "@stdlib/math/base/special/abs2",
+        "@stdlib/constants/float64/pi",
+        "@stdlib/math/base/special/sqrt",
+        "@stdlib/stats/base/dists/normal/cdf"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/exp",
+        "@stdlib/math/base/special/abs2",
+        "@stdlib/constants/float64/pi",
+        "@stdlib/math/base/special/sqrt",
+        "@stdlib/stats/base/dists/normal/cdf"
+      ]
+    },
+    {
+      "task": "examples",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/exp",
+        "@stdlib/math/base/special/abs2",
+        "@stdlib/constants/float64/pi",
+        "@stdlib/math/base/special/sqrt",
+        "@stdlib/stats/base/dists/normal/cdf"
+      ]
+    }
+  ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/src/main.c
@@ -25,9 +25,7 @@
 #include "stdlib/constants/float64/pi.h"
 
 /**
-* Evaluates the probability density function (PDF) for a truncated normal distribution
-* with endpoints `a` and `b`, location parameter `mu`, and scale parameter `sigma`
-* at a value `x`.
+* Evaluates the probability density function (PDF) for a truncated normal distribution with endpoints `a` and `b`, location parameter `mu`, and scale parameter `sigma` at a value `x`.
 *
 * @param x       input value
 * @param a       minimum support


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-09-01 16:38 (PT) (`fd6046b`) and 2026-09-02 01:39 (PT) (`0c7f769`).

This pull request:

-   `stats/base/dists/arcsine/logcdf`:
    -   Fixed malformed return statement in `.../arcsine/logcdf/src/main.c:56` (94b9253a): double space after `LN2`, spurious spaces before `stdlib_base_asin`/`stdlib_base_sqrt` parens, redundant outer parens, and trailing space before `;`. Now matches call-spacing conventions and the JS implementation.
-   `stats/base/dists/truncated-normal/pdf`:
    -   Fixed extra blank line before the C signature code fence in `stats/base/dists/truncated-normal/pdf/README.md`, introduced in ad203e87; brings it in line with every other dists README (single blank line).
    -   Fixed the Doxygen summary line-wrapping in ad203e87 for `stats/base/dists/truncated-normal/pdf`: joined the hard-wrapped summary in `src/main.c` and `include/stdlib/stats/base/dists/truncated-normal/pdf.h` back onto a single line, matching every other `stats/base/dists` header/source in the repo (text otherwise unchanged).
    -   Fixed `manifest.json` indentation for `stats/base/dists/truncated-normal/pdf` (ad203e87) from 4 spaces to 2, matching every sibling `stats/base/dists` manifest; content unchanged, verified via parse-compare.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** All 18 commits merged to `develop` in the review window were audited for (1) stdlib style-guide compliance (compared against established reference packages, e.g. `laplace/pdf`, `gamma/pdf`, `dlast-index-equal`/`glast-index-equal`) and (2) objective bugs within the diffs (formula transcription, addon arity/order, manifest deps vs. includes, search/stride logic, ULP assertion argument order). Deliberately excluded: subjective suggestions, style preferences not required by the style guides, and anything whose fix would require touching code outside the window's diffs (e.g., a latent NaN-parameter edge case in `truncated-normal/pdf` where the new C code exactly mirrors the pre-existing JS implementation — fixing C alone would break JS/C parity).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated review of commits recently merged to `develop`; all fixes were machine-proposed, cross-validated against reference packages, and applied verbatim.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUki2X3AUoN8xkpLKCKKMt

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUki2X3AUoN8xkpLKCKKMt)_