### PR TITLE
build(workflows): tolerate `metadata-action` YAML parse failures in `process_metadata.yml`

### DIFF
--- a/.github/workflows/process_metadata.yml
+++ b/.github/workflows/process_metadata.yml
@@ -92,11 +92,14 @@ jobs:
         # Pin action to full length commit SHA
         uses: stdlib-js/metadata-action@3ccf68f24c51ae23470319e8e5619d539df8212b # v3.0.0
 
+        # Continue with subsequent steps even when this step fails (e.g., due to unparsable YAML in a commit message or issue comment) in order to "pass" the job and not trigger failure e-mails/notifications:
+        continue-on-error: true
+
       # Check the metadata for directives to send tweets:
       - name: 'Send tweets'
 
-        # Only run this step if a user has write access:
-        if: steps.assert-write-access.outcome == 'success'
+        # Only run this step if a user has write access and metadata was successfully extracted:
+        if: ${{ steps.assert-write-access.outcome == 'success' && steps.extract-metadata.outcome == 'success' }}
 
         # Pin action to full length commit SHA
         uses: stdlib-js/metadata-tweet-action@8e9b688c86150797c1c7f60bc8f7c9a9a30e10fe # v2.0.0
@@ -111,8 +114,8 @@ jobs:
       - name: 'Check metadata for workflow dispatch directives'
         id: check-workflow-dispatch
 
-        # Only run this step if a user has write access:
-        if: steps.assert-write-access.outcome == 'success'
+        # Only run this step if a user has write access and metadata was successfully extracted:
+        if: ${{ steps.assert-write-access.outcome == 'success' && steps.extract-metadata.outcome == 'success' }}
 
         env:
           METADATA: ${{ steps.extract-metadata.outputs.metadata }}


### PR DESCRIPTION
## Description

This pull request:

-   fixes `process_metadata.yml` so a YAML parse failure in `stdlib-js/metadata-action` no longer fails the "Process Metadata" job
-   adds `continue-on-error: true` to the "Extract metadata" step, matching the existing pattern on the "Exit if user does not have write access" step in the same file
-   gates the two downstream steps ("Send tweets" and "Check metadata for workflow dispatch directives") on `steps.extract-metadata.outcome == 'success'`, matching the `continue-on-error` + `outcome` gate pattern already used in `publish_coverage_pr.yml`, so they no-op instead of running on empty or garbage metadata

## Related Issues

This pull request does not have any related issues.

## Questions

No.

## Other

Root cause: `process_metadata.yml` ran 4 times on 2026-09-02 (runs 33633418814, 33633419895, 33633423946, 33633428450), all within the same minute, all triggered by `issue_comment` events on 4 different PRs, and all failed at the "Extract metadata" step with:

```
YAMLException: end of the stream or a document separator is expected (2:1)
```

`stdlib-js/metadata-action` parses YAML front-matter out of raw commit-message/comment text. An AI-generated PR review comment containing a Markdown table with a bare `|` (empty cell) on its own line breaks the action's `js-yaml` parser. The action is pinned by commit SHA in a separate repository and cannot be patched here, so the fix is workflow-side: tolerate the failure and skip the steps that depend on its output.

Validation: no automated test suite covers GitHub Actions YAML. Ran `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/process_metadata.yml'))"` to confirm the file is syntactically valid.

Three independent reviews were run against the diff:

-   Reviewer A (correctness): first revision (`continue-on-error` only, no outcome gates) got `request_changes` because the downstream steps could then run on empty metadata; the revision adding the two outcome gates got `approve`.
-   Reviewer B (regression scope): `approve`. Diff is 3 hunks in 1 file. Happy path is unchanged — the outcome gate is a no-op when extraction succeeds. Previously-unreachable-with-empty-metadata paths are now explicitly closed.
-   Reviewer C (style/conventions): `approve`. `${{ }}`-wrapped multi-condition `if:` matches the file's existing convention (the "Dispatch workflow with inputs" step already uses this form). Comment style, indentation, and YAML re-checked.

One non-blocking style note: `publish_coverage_pr.yml` uses unwrapped `if:` for single-condition gates, this PR uses `${{ }}`-wrapped multi-condition gates. Both are valid, this file already mixes both forms. No change made.

Branch: `philipp/ci-fix-process-metadata-yaml-parse-2026-09-02`, commit `67ee1d83f52f69d3eb8523498f2cab599826ca6b`.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an unattended scheduled routine that investigates CI failures on `develop`.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gXw4miWt7onhg4K8YQEJL

---
_Generated by [Claude Code](https://claude.ai/code/session_017gXw4miWt7onhg4K8YQEJL)_