### PR TITLE
test: migrate `stats/base/dists/laplace/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/stdev/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -76,8 +75,6 @@ tape( 'if provided a nonpositive `b`, the function returns `NaN`', function test
 
 tape( 'the function returns the standard deviation of a Laplace distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var y;
@@ -89,13 +86,7 @@ tape( 'the function returns the standard deviation of a Laplace distribution', f
 	for ( i = 0; i < mu.length; i++ ) {
 		y = stdev( mu[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/stdev/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -88,8 +87,6 @@ tape( 'if provided a nonpositive `b`, the function returns `NaN`', opts, functio
 
 tape( 'the function returns the standard deviation of a Laplace distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var y;
@@ -100,14 +97,8 @@ tape( 'the function returns the standard deviation of a Laplace distribution', o
 	b = data.b;
 	for ( i = 0; i < mu.length; i++ ) {
 		y = stdev( mu[i], b[i] );
-		if ( expected[i] !== null) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+		if ( expected[i] !== null ) {
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/laplace/stdev` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `delta`/`tol` (`EPS * abs( expected[i] )`) comparisons in `test/test.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );`, adding the `@stdlib/assert/is-almost-same-value` import and removing the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` imports.

**Final ULP constant: `1` for both `test/test.js` and `test/test.native.js`.**

This is the measured minimum. Starting from a high bound and tightening, the maximum ULP difference over the full 1000-case Python fixture set (`test/fixtures/python/data.json`) is exactly `1` for both the JavaScript and native implementations (551 of the 1000 cases are bit-for-bit exact). A bound of `0` fails 449 of the 1010 assertions, so `1` cannot be tightened further. The suite was run twice at the final bound with identical results, and the native addon was compiled locally so that `test/test.native.js` actually executed rather than being skipped:

-   `test/test.js`: 1010 passing, 0 failing
-   `test/test.native.js`: 1011 passing, 0 failing

Only the two test files are changed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The JavaScript and native implementations agree here (both compute a single multiplication by `sqrt(2)`), so the same ULP bound applies to both files, consistent with other converted `stats/base/dists/*/stdev` packages.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an automated task. The tolerance-to-ULP conversion, the search for the minimum ULP bound, and the local test/lint verification were all performed by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M81QiKCao79ZzPSr4XXVrD

---
_Generated by [Claude Code](https://claude.ai/code/session_01M81QiKCao79ZzPSr4XXVrD)_