### PR TITLE
test: migrate `stats/base/dists/exponential/logpdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/logpdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/logpdf/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -128,8 +127,6 @@ tape( 'the created function evaluates the logpdf for `x` given parameter `lambda
 	var expected;
 	var logpdf;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -140,13 +137,7 @@ tape( 'the created function evaluates the logpdf for `x` given parameter `lambda
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( lambda[i] );
 		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 30.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -155,8 +146,6 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 	var expected;
 	var logpdf;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -167,13 +156,7 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( lambda[i] );
 		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 22.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -182,8 +165,6 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 	var expected;
 	var logpdf;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -194,13 +175,7 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( lambda[i] );
 		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 22.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -209,8 +184,6 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 	var expected;
 	var logpdf;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -221,13 +194,7 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( lambda[i] );
 		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 30.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/logpdf/test/test.logpdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/logpdf/test/test.logpdf.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logpdf = require( './../lib' );
 
 
@@ -101,8 +100,6 @@ tape( 'if provided a negative `lambda`, the function always returns `NaN`', func
 tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when `x` and `lambda` are small)', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -112,13 +109,7 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 	lambda = smallSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 30.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'.  lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -126,8 +117,6 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when `x` is large and `lambda` small)', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -137,13 +126,7 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 	lambda = largeSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 22.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'.  lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -151,8 +134,6 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when `x` is small and `lambda` large)', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -162,13 +143,7 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 	lambda = smallLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 22.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'.  lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -176,8 +151,6 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when `x` and `lambda` are large)', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -187,13 +160,7 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 	lambda = largeLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 30.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'.  lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/logpdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/logpdf/test/test.native.js
@@ -24,10 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -110,8 +109,6 @@ tape( 'if provided a negative `lambda`, the function always returns `NaN`', opts
 tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when `x` and `lambda` are small)', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -121,13 +118,7 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 	lambda = smallSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 30.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'.  lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -135,8 +126,6 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when `x` is large and `lambda` small)', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -146,13 +135,7 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 	lambda = largeSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 22.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'.  lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -160,8 +143,6 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when `x` is small and `lambda` large)', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -171,13 +152,7 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 	lambda = smallLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 22.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'.  lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -185,8 +160,6 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when `x` and `lambda` are large)', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -196,13 +169,7 @@ tape( 'the function evaluates the logpdf for `x` given parameter `lambda` (when 
 	lambda = largeLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 30.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'.  lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for stats/base/dists/exponential/logpdf from relative tolerance (abs/EPS-based) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
-   updates test/test.factory.js, test/test.logpdf.js, and test/test.native.js. test/test.js contains no fixture-based numeric assertions and required no changes.
-   removes the now-unused abs and EPS imports and the corresponding delta/tol variable declarations, collapsing each if/else exact-match-or-tolerance branch into a single isAlmostSameValue assertion.

Measured minimum ULP bounds (identical across the pure JS implementation, the factory-generated function, and the native addon):

| Fixture | ULP |
|---|---|
| small_small | 2 |
| large_small | 2 |
| small_large | 2 |
| large_large | 1 |

Each bound is the exact maximum observed ULP difference over its fixture, measured separately against test.js's main export, test.factory.js's factory-generated function, and a locally-built native addon (all three converged on the same values).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
