### PR TITLE
test: migrate `stats/base/dists/binomial/pmf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -259,9 +258,7 @@ tape( 'if `p` equals `1.0`, the created function evaluates a degenerate distribu
 
 tape( 'the created function evaluates the pmf for `x` given large `n` and `p`', function test( t ) {
 	var expected;
-	var delta;
 	var pmf;
-	var tol;
 	var x;
 	var n;
 	var p;
@@ -275,22 +272,14 @@ tape( 'the created function evaluates the pmf for `x` given large `n` and `p`', 
 	for ( i = 0; i < x.length; i++ ) {
 		pmf = factory( n[i], p[i] );
 		y = pmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', n: '+n[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 260.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 503 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the pmf for `x` given a large `n` and small `p`', function test( t ) {
 	var expected;
-	var delta;
 	var pmf;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -304,22 +293,14 @@ tape( 'the created function evaluates the pmf for `x` given a large `n` and smal
 	for ( i = 0; i < x.length; i++ ) {
 		pmf = factory( n[i], p[i] );
 		y = pmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', n: '+n[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 270.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 345 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the pmf for `x` given small `n` and large `p`', function test( t ) {
 	var expected;
-	var delta;
 	var pmf;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -333,22 +314,14 @@ tape( 'the created function evaluates the pmf for `x` given small `n` and large 
 	for ( i = 0; i < x.length; i++ ) {
 		pmf = factory( n[i], p[i] );
 		y = pmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', n: '+n[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 80.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 120 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the pmf for `x` given small `n` and `p`', function test( t ) {
 	var expected;
-	var delta;
 	var pmf;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -362,13 +335,7 @@ tape( 'the created function evaluates the pmf for `x` given small `n` and `p`', 
 	for ( i = 0; i < x.length; i++ ) {
 		pmf = factory( n[i], p[i] );
 		y = pmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', n: '+n[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 100.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 156 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/test/test.native.js
@@ -24,10 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -173,8 +172,6 @@ tape( 'if `p` equals `1.0`, the function evaluates a degenerate distribution cen
 
 tape( 'the function evaluates the pmf for `x` given large `n` and `p`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -187,21 +184,13 @@ tape( 'the function evaluates the pmf for `x` given large `n` and `p`', opts, fu
 	p = highHigh.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[ i ], n[ i ], p[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + ', n: ' + n[ i ] + ', p: ' + p[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 260.0 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: ' + x[ i ] + '. n: ' + n[ i ] + '. p: ' + p[ i ] + '. y: ' + y + '. Expected: ' + expected[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 503 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pmf for `x` given large `n` and small `p`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var n;
 	var p;
 	var i;
@@ -214,21 +203,13 @@ tape( 'the function evaluates the pmf for `x` given large `n` and small `p`', op
 	p = highSmall.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[ i ], n[ i ], p[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + ', n: ' + n[ i ] + ', p: ' + p[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 270.0 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: ' + x[ i ] + '. n: ' + n[ i ] + '. p: ' + p[ i ] + '. y: ' + y + '. Expected: ' + expected[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 345 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pmf for `x` given small `n` and large `p`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -241,21 +222,13 @@ tape( 'the function evaluates the pmf for `x` given small `n` and large `p`', op
 	p = smallHigh.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[ i ], n[ i ], p[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + ', n: ' + n[ i ] + ', p: ' + p[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 80.0 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: ' + x[ i ] + '. n: ' + n[ i ] + '. p: ' + p[ i ] + '. y: ' + y + '. Expected: ' + expected[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 120 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pmf for `x` given small `n` and `p`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -268,13 +241,7 @@ tape( 'the function evaluates the pmf for `x` given small `n` and `p`', opts, fu
 	p = smallSmall.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[ i ], n[ i ], p[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + ', n: ' + n[ i ] + ', p: ' + p[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 120.0 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: ' + x[ i ] + '. n: ' + n[ i ] + '. p: ' + p[ i ] + '. y: ' + y + '. Expected: ' + expected[ i ] + '. tol: ' + tol + '. delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 156 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/test/test.pmf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/test/test.pmf.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pmf = require( './../lib' );
 
 
@@ -184,8 +183,6 @@ tape( 'if `p` equals `1.0`, the function evaluates a degenerate distribution cen
 
 tape( 'the function evaluates the pmf for `x` given large `n` and `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -198,21 +195,13 @@ tape( 'the function evaluates the pmf for `x` given large `n` and `p`', function
 	p = highHigh.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[i], n[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', n: '+n[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 260.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 503 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pmf for `x` given large `n` and small `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var n;
 	var p;
 	var i;
@@ -225,21 +214,13 @@ tape( 'the function evaluates the pmf for `x` given large `n` and small `p`', fu
 	p = highSmall.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[i], n[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', n: '+n[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 270.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 345 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pmf for `x` given small `n` and large `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -252,21 +233,13 @@ tape( 'the function evaluates the pmf for `x` given small `n` and large `p`', fu
 	p = smallHigh.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[i], n[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', n: '+n[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 80.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 120 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pmf for `x` given small `n` and `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -279,13 +252,7 @@ tape( 'the function evaluates the pmf for `x` given small `n` and `p`', function
 	p = smallSmall.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[i], n[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', n: '+n[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 100.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 156 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for stats/base/dists/binomial/pmf from relative tolerance (abs/EPS-based) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
-   updates test/test.factory.js, test/test.pmf.js, and test/test.native.js. test/test.js contains no fixture-based numeric assertions and required no changes.
-   removes the now-unused abs and EPS imports and the corresponding delta/tol variable declarations, collapsing each if/else exact-match-or-tolerance branch into a single isAlmostSameValue assertion.

Measured minimum ULP bounds (identical across the pure JS implementation, the factory-generated function, and the native addon):

| Fixture | ULP |
|---|---|
| small_small | 156 |
| small_high | 120 |
| high_small | 345 |
| high_high | 503 |

Each bound is the exact maximum observed ULP difference over its fixture, measured separately against the main export, the factory-generated function, and a locally-built native addon (all three converged on the same values).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
