### PR TITLE
test: migrate `stats/base/dists/geometric/cdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/cdf/test/test.cdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( './../lib' );
 
 
@@ -90,8 +89,6 @@ tape( 'if provided a value outside `[0,1]` for success probability `p`, the func
 
 tape( 'the function evaluates the cdf for `x` given small parameter `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var p;
 	var y;
@@ -102,21 +99,13 @@ tape( 'the function evaluates the cdf for `x` given small parameter `p`', functi
 	p = smallP.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 20 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given large parameter `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var p;
 	var y;
@@ -127,13 +116,7 @@ tape( 'the function evaluates the cdf for `x` given large parameter `p`', functi
 	p = largeP.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/cdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -122,9 +121,7 @@ tape( 'if provided a success probability `p` outside of `[0,1]`, the created fun
 
 tape( 'the created function evaluates the cdf for `x` given small parameter `p`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var x;
 	var p;
 	var y;
@@ -136,22 +133,14 @@ tape( 'the created function evaluates the cdf for `x` given small parameter `p`'
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( p[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 20 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given large parameter `p`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var x;
 	var p;
 	var y;
@@ -163,13 +152,7 @@ tape( 'the created function evaluates the cdf for `x` given large parameter `p`'
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( p[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/cdf/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -99,8 +98,6 @@ tape( 'if provided a value outside `[0,1]` for success probability `p`, the func
 
 tape( 'the function evaluates the cdf for `x` given small parameter `p`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var p;
 	var y;
@@ -111,21 +108,13 @@ tape( 'the function evaluates the cdf for `x` given small parameter `p`', opts, 
 	p = smallP.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 20 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given large parameter `p`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var p;
 	var y;
@@ -136,13 +125,7 @@ tape( 'the function evaluates the cdf for `x` given large parameter `p`', opts, 
 	p = largeP.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/geometric/cdf` from relative tolerance testing (`delta <= tol`, where `tol = N * EPS * abs( expected )`) to ULP difference testing using `@stdlib/assert/is-almost-same-value`.
-   updates `test/test.cdf.js`, `test/test.factory.js`, and `test/test.native.js`, removing the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires, along with the `delta` and `tol` variables.

The ULP bounds were tightened to the measured minimum for each fixture set:

| Fixture set | ULP bound | Notes |
| ----------- | --------- | ----- |
| `small_p.json` | `20` | `19` fails (previous relative tolerance was `20.0 * EPS`) |
| `large_p.json` | `1` | `0` fails (previous relative tolerance was `1.0 * EPS`) |

The minima were measured by descending search over the full 1000-element fixture sets and are identical for the main export, the `factory` output, and the native C implementation. The suite was run twice at the final bounds to confirm determinism, and the native tests were exercised against a locally built addon (rather than skipped).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, following the conversion idiom established in previously merged migrations within the same package family (e.g., `stats/base/dists/cosine/cdf`). The ULP bounds were determined empirically, and the tests were run locally to verify.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HadbJC22oZnBP4fyQYVnn4

---
_Generated by [Claude Code](https://claude.ai/code/session_01HadbJC22oZnBP4fyQYVnn4)_