### PR TITLE
test: migrate `stats/base/dists/binomial/logpmf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -260,8 +259,6 @@ tape( 'if `p` equals `1.0`, the created function evaluates a degenerate distribu
 tape( 'the created function evaluates the logpmf for `x` given large `n` and `p`', function test( t ) {
 	var expected;
 	var logpmf;
-	var delta;
-	var tol;
 	var x;
 	var n;
 	var p;
@@ -275,13 +272,7 @@ tape( 'the created function evaluates the logpmf for `x` given large `n` and `p`
 	for ( i = 0; i < x.length; i++ ) {
 		logpmf = factory( n[i], p[i] );
 		y = logpmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', n: '+n[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 30.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 36 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -289,8 +280,6 @@ tape( 'the created function evaluates the logpmf for `x` given large `n` and `p`
 tape( 'the created function evaluates the logpmf for `x` given a large `n` and small `p`', function test( t ) {
 	var expected;
 	var logpmf;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -304,13 +293,7 @@ tape( 'the created function evaluates the logpmf for `x` given a large `n` and s
 	for ( i = 0; i < x.length; i++ ) {
 		logpmf = factory( n[i], p[i] );
 		y = logpmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', n: '+n[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 20.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 24 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -318,8 +301,6 @@ tape( 'the created function evaluates the logpmf for `x` given a large `n` and s
 tape( 'the created function evaluates the logpmf for `x` given small `n` and large `p`', function test( t ) {
 	var expected;
 	var logpmf;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -333,13 +314,7 @@ tape( 'the created function evaluates the logpmf for `x` given small `n` and lar
 	for ( i = 0; i < x.length; i++ ) {
 		logpmf = factory( n[i], p[i] );
 		y = logpmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', n: '+n[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 20.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 17 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -347,8 +322,6 @@ tape( 'the created function evaluates the logpmf for `x` given small `n` and lar
 tape( 'the created function evaluates the logpmf for `x` given small `n` and `p`', function test( t ) {
 	var expected;
 	var logpmf;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -362,13 +335,7 @@ tape( 'the created function evaluates the logpmf for `x` given small `n` and `p`
 	for ( i = 0; i < x.length; i++ ) {
 		logpmf = factory( n[i], p[i] );
 		y = logpmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', n: '+n[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 10.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 16 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/test/test.logpmf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/test/test.logpmf.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logpmf = require( './../lib' );
 
 
@@ -184,8 +183,6 @@ tape( 'if `p` equals `1.0`, the function evaluates a degenerate distribution cen
 
 tape( 'the function evaluates the logpmf for `x` given large `n` and `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -198,21 +195,13 @@ tape( 'the function evaluates the logpmf for `x` given large `n` and `p`', funct
 	p = highHigh.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpmf( x[i], n[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', n: '+n[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 30.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 36 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpmf for `x` given large `n` and small `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var n;
 	var p;
 	var i;
@@ -225,21 +214,13 @@ tape( 'the function evaluates the logpmf for `x` given large `n` and small `p`',
 	p = highSmall.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpmf( x[i], n[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', n: '+n[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 20.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 24 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpmf for `x` given small `n` and large `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -252,21 +233,13 @@ tape( 'the function evaluates the logpmf for `x` given small `n` and large `p`',
 	p = smallHigh.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpmf( x[i], n[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', n: '+n[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 20.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 17 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpmf for `x` given small `n` and `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -279,13 +252,7 @@ tape( 'the function evaluates the logpmf for `x` given small `n` and `p`', funct
 	p = smallSmall.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpmf( x[i], n[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', n: '+n[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 10.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 16 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/test/test.native.js
@@ -23,10 +23,9 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -142,8 +141,6 @@ tape( 'if `p` equals `1.0`, the function evaluates a degenerate distribution cen
 
 tape( 'the function evaluates the logpmf for `x` given large `n` and `p`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -156,21 +153,13 @@ tape( 'the function evaluates the logpmf for `x` given large `n` and `p`', opts,
 	p = highHigh.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpmf( x[ i ], n[ i ], p[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', n: '+n[ i ]+', p: '+p[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 30.0 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. n: '+n[ i ]+'. p: '+p[ i ]+'. y: '+y+'. Expected: '+expected[ i ]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 36 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpmf for `x` given large `n` and small `p`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var n;
 	var p;
 	var i;
@@ -183,21 +172,13 @@ tape( 'the function evaluates the logpmf for `x` given large `n` and small `p`',
 	p = highSmall.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpmf( x[ i ], n[ i ], p[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', n: '+n[ i ]+', p: '+p[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. n: '+n[ i ]+'. p: '+p[ i ]+'. y: '+y+'. Expected: '+expected[ i ]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 24 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpmf for `x` given small `n` and large `p`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -210,21 +191,13 @@ tape( 'the function evaluates the logpmf for `x` given small `n` and large `p`',
 	p = smallHigh.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpmf( x[ i ], n[ i ], p[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', n: '+n[ i ]+', p: '+p[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. n: '+n[ i ]+'. p: '+p[ i ]+'. y: '+y+'. Expected: '+expected[ i ]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 17 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpmf for `x` given small `n` and `p`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var p;
@@ -237,13 +210,7 @@ tape( 'the function evaluates the logpmf for `x` given small `n` and `p`', opts,
 	p = smallSmall.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpmf( x[ i ], n[ i ], p[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', n: '+n[ i ]+', p: '+p[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. n: '+n[ i ]+'. p: '+p[ i ]+'. y: '+y+'. Expected: '+expected[ i ]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 16 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for stats/base/dists/binomial/logpmf from relative tolerance (abs/EPS-based) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
-   updates test/test.factory.js, test/test.logpmf.js, and test/test.native.js. test/test.js contains no fixture-based numeric assertions and required no changes.
-   removes the now-unused abs and EPS imports and the corresponding delta/tol variable declarations, collapsing each if/else exact-match-or-tolerance branch into a single isAlmostSameValue assertion.

Measured minimum ULP bounds (identical across the pure JS implementation, the factory-generated function, and the native addon):

| Fixture | ULP |
|---|---|
| small_small | 16 |
| small_high | 17 |
| high_small | 24 |
| high_high | 36 |

Each bound is the exact maximum observed ULP difference over its fixture, measured separately against the main export, the factory-generated function, and a locally-built native addon (all three converged on the same values).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
