### PR TITLE
test: migrate `stats/base/dists/weibull/quantile` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -169,8 +168,6 @@ tape( 'the created function evaluates the quantile for `p` given large `lambda` 
 	var expected;
 	var quantile;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var p;
@@ -183,13 +180,7 @@ tape( 'the created function evaluates the quantile for `p` given large `lambda` 
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( k[i], lambda[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', lambda: '+lambda[i]+', k: '+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. lambda: '+lambda[i]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -198,8 +189,6 @@ tape( 'the created function evaluates the quantile for `p` given large shape par
 	var expected;
 	var quantile;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var p;
@@ -212,13 +201,7 @@ tape( 'the created function evaluates the quantile for `p` given large shape par
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( k[i], lambda[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', lambda: '+lambda[i]+', k: '+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. lambda: '+lambda[i]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -227,8 +210,6 @@ tape( 'the created function evaluates the quantile for `p` given large scale par
 	var expected;
 	var quantile;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var p;
@@ -241,13 +222,7 @@ tape( 'the created function evaluates the quantile for `p` given large scale par
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( k[i], lambda[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', lambda: '+lambda[i]+', k: '+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 5.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. lambda: '+lambda[i]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 6 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/test/test.native.js
@@ -24,11 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-
 
 // FIXTURES //
 
@@ -96,8 +94,6 @@ tape( 'if provided `k <= 0` or `lambda <= 0`, the function returns `NaN`', opts,
 tape( 'the function evaluates the quantile for `p` given large `k` and `lambda`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var p;
 	var k;
 	var y;
@@ -109,13 +105,7 @@ tape( 'the function evaluates the quantile for `p` given large `k` and `lambda`'
 	lambda = bothLarge.lambda;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[ i ], k[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'p: ' + p[ i ] + ', k: ' + k[ i ] + ', lambda: ' + lambda[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: ' + p[ i ] + '. k: ' + k[ i ] + '. lambda: ' + lambda[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -123,8 +113,6 @@ tape( 'the function evaluates the quantile for `p` given large `k` and `lambda`'
 tape( 'the function evaluates the quantile for `p` given large `lambda`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var p;
 	var k;
 	var y;
@@ -136,20 +124,7 @@ tape( 'the function evaluates the quantile for `p` given large `lambda`', opts, 
 	lambda = largeScale.lambda;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[ i ], k[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'p: ' + p[ i ] + ', k: ' + k[ i ] + ', lambda: ' + lambda[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			if ( k[ i ] > 4.0 ||
-				lambda[ i ] > 4.0 ||
-				p[ i ] < 0.01 ||
-				p[ i ] > 0.99 ) {
-				tol = 8.0 * EPS * abs( expected[ i ] ); // Increase the tolerance factor for extreme values
-			} else {
-				tol = 2.0 * EPS * abs( expected[ i ] );
-			}
-			t.ok( delta <= tol, 'within tolerance. p: ' + p[ i ] + '. k: ' + k[ i ] + '. lambda: ' + lambda[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 6 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -157,8 +132,6 @@ tape( 'the function evaluates the quantile for `p` given large `lambda`', opts, 
 tape( 'the function evaluates the quantile for `p` given large `k`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var p;
 	var k;
 	var y;
@@ -170,13 +143,7 @@ tape( 'the function evaluates the quantile for `p` given large `k`', opts, funct
 	lambda = largeShape.lambda;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[ i ], k[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'p: ' + p[ i ] + ', k: ' + k[ i ] + ', lambda: ' + lambda[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: ' + p[ i ] + '. k: ' + k[ i ] + '. lambda: ' + lambda[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/test/test.native.js
@@ -28,6 +28,7 @@ var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 
+
 // FIXTURES //
 
 var bothLarge = require( './fixtures/julia/both_large.json' );

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/test/test.quantile.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/test/test.quantile.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var quantile = require( './../lib' );
 
 
@@ -119,8 +118,6 @@ tape( 'if provided a nonpositive `lambda`, the function returns `NaN`', function
 tape( 'the function evaluates the p-th quantile given large parameters `lambda` and `k`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var p;
 	var k;
 	var y;
@@ -132,13 +129,7 @@ tape( 'the function evaluates the p-th quantile given large parameters `lambda` 
 	k = bothLarge.k;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -146,8 +137,6 @@ tape( 'the function evaluates the p-th quantile given large parameters `lambda` 
 tape( 'the function evaluates the p-th quantile given large shape parameter `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var p;
 	var k;
 	var y;
@@ -159,13 +148,7 @@ tape( 'the function evaluates the p-th quantile given large shape parameter `lam
 	k = largeShape.k;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -173,8 +156,6 @@ tape( 'the function evaluates the p-th quantile given large shape parameter `lam
 tape( 'the function evaluates the p-th quantile given large scale parameter `k`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var p;
 	var k;
 	var y;
@@ -186,13 +167,7 @@ tape( 'the function evaluates the p-th quantile given large scale parameter `k`'
 	k = largeScale.k;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 5.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 6 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for `stats/base/dists/weibull/quantile` from relative tolerance (`abs`/`EPS`-based) assertions to ULP difference assertions using `@stdlib/assert/is-almost-same-value`.
-   updates `test/test.factory.js`, `test/test.native.js`, and `test/test.quantile.js`.
-   removes the now-unused `abs` and `EPS` imports and the corresponding `delta`/`tol` variable declarations, collapsing each if/else exact-match-or-tolerance branch into a single `isAlmostSameValue` assertion.

Measured minimum ULP bounds:

| Fixture | ULP |
|---|---|
| bothlarge  | 0 |
| large shape  | 1 |
| large scale | 6 |
## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 
## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
