### PR TITLE
test: migrate `stats/base/dists/gamma/skewness` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/skewness/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/skewness/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var skewness = require( './../lib' );
 
 
@@ -96,10 +95,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the skewness of a gamma distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -108,13 +105,7 @@ tape( 'the function returns the skewness of a gamma distribution', function test
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = skewness( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/skewness/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/skewness/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -105,10 +104,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 
 tape( 'the function returns the skewness of a gamma distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -117,13 +114,7 @@ tape( 'the function returns the skewness of a gamma distribution', opts, functio
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = skewness( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/gamma/skewness` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `delta`/`tol` (`2.0 * EPS * abs( expected[i] )`) comparisons in `test/test.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );`, adding the `@stdlib/assert/is-almost-same-value` import and removing the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` imports.

**Final ULP constant: `0` for both `test/test.js` and `test/test.native.js`.**

This is the measured minimum. Starting from a high bound and tightening, the maximum ULP difference over the full 200-case Julia fixture set (`test/fixtures/julia/data.json`) is `0` for both the JavaScript and native implementations: all 200 cases are bit-for-bit exact, so the bound cannot be tightened further. The suite was run twice at the final bound with identical results, and the native addon was compiled locally so that `test/test.native.js` actually executed rather than being skipped:

-   `test/test.js`: 214 passing, 0 failing
-   `test/test.native.js`: 214 passing, 0 failing

This matches the sibling package `stats/base/dists/gamma/kurtosis`, which also uses a bound of `0`.

Only the two test files are changed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The JavaScript and native implementations agree exactly here, so the same ULP bound applies to both files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an automated task. The tolerance-to-ULP conversion, the search for the minimum ULP bound, and the local test/lint verification were all performed by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F98j9sSCh3XzoRpXNvsPc6

---
_Generated by [Claude Code](https://claude.ai/code/session_01F98j9sSCh3XzoRpXNvsPc6)_