### PR TITLE
test: migrate `stats/base/dists/bradford/quantile` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/quantile/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/quantile/test/test.factory.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -109,8 +108,6 @@ tape( 'if provided a finite `c`, the function returns a function which returns `
 tape( 'the created function evaluates the quantile for `p` given small `c`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var c;
 	var i;
 	var p;
@@ -122,13 +119,7 @@ tape( 'the created function evaluates the quantile for `p` given small `c`', fun
 	for ( i = 0; i < expected.length; i++ ) {
 		quantile = factory( c[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+'. c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.2 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 5 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -136,8 +127,6 @@ tape( 'the created function evaluates the quantile for `p` given small `c`', fun
 tape( 'the created function evaluates the quantile for `p` given a medium `c`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var c;
 	var i;
 	var p;
@@ -149,13 +138,7 @@ tape( 'the created function evaluates the quantile for `p` given a medium `c`', 
 	for ( i = 0; i < expected.length; i++ ) {
 		quantile = factory( c[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+'. c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.2 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 6 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -163,8 +146,6 @@ tape( 'the created function evaluates the quantile for `p` given a medium `c`', 
 tape( 'the created function evaluates the quantile for `p` given a large `c`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var c;
 	var i;
 	var p;
@@ -176,13 +157,7 @@ tape( 'the created function evaluates the quantile for `p` given a large `c`', f
 	for ( i = 0; i < expected.length; i++ ) {
 		quantile = factory( c[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+'. c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 4.8 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 7 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/quantile/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/quantile/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -100,8 +99,6 @@ tape( 'if provided a number outside `[0,1]` for `p` and a valid `c`, the functio
 
 tape( 'the function evaluates the quantile for `p` given small parameter `c`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var p;
 	var c;
 	var y;
@@ -113,13 +110,7 @@ tape( 'the function evaluates the quantile for `p` given small parameter `c`', o
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[i] );
-				tol = 3.2 * EPS * abs( expected[i] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 5 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -127,8 +118,6 @@ tape( 'the function evaluates the quantile for `p` given small parameter `c`', o
 
 tape( 'the function evaluates the quantile for `p` given medium parameter `c`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var p;
 	var c;
 	var y;
@@ -140,13 +129,7 @@ tape( 'the function evaluates the quantile for `p` given medium parameter `c`', 
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[i] );
-				tol = 3.2 * EPS * abs( expected[i] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 6 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -154,8 +137,6 @@ tape( 'the function evaluates the quantile for `p` given medium parameter `c`', 
 
 tape( 'the function evaluates the quantile for `p` given large parameter `c`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var p;
 	var c;
 	var y;
@@ -167,13 +148,7 @@ tape( 'the function evaluates the quantile for `p` given large parameter `c`', o
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[i] );
-				tol = 4.8 * EPS * abs( expected[i] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 7 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/quantile/test/test.quantile.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/quantile/test/test.quantile.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var quantile = require( './../lib' );
 
 
@@ -91,8 +90,6 @@ tape( 'if provided a number outside `[0,1]` for `p` and a valid `c`, the functio
 
 tape( 'the function evaluates the quantile for `p` given small parameter `c`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var p;
 	var c;
 	var y;
@@ -103,21 +100,13 @@ tape( 'the function evaluates the quantile for `p` given small parameter `c`', f
 	c = smallC.c;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+'. c:'+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.2 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 5 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the quantile for `p` given medium parameter `c`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var p;
 	var c;
 	var y;
@@ -128,21 +117,13 @@ tape( 'the function evaluates the quantile for `p` given medium parameter `c`', 
 	c = mediumC.c;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+'. c:'+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.2 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 6 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the quantile for `p` given large parameter `c`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var p;
 	var c;
 	var y;
@@ -153,13 +134,7 @@ tape( 'the function evaluates the quantile for `p` given large parameter `c`', f
 	c = largeC.c;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+'. c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 4.8 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 7 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/bradford/quantile` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `delta`/`tol` (`3.2 * EPS * abs( expected[i] )` and `4.8 * EPS * abs( expected[i] )`) comparisons in `test/test.quantile.js`, `test/test.factory.js`, and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( y, expected[ i ], N ), true, 'returns expected value' );`, adding the `@stdlib/assert/is-almost-same-value` import and removing the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` imports.

**Final ULP constants (identical across all three test files):**

| Fixture | ULP bound |
| ------- | --------- |
| `small_c.json` | `5` |
| `medium_c.json` | `6` |
| `large_c.json` | `7` |

These are the measured minimums. Starting from a high bound and tightening, the maximum ULP difference over the full 1000-case-per-group Python fixture set is exactly `5`, `6`, and `7` respectively. Each bound was verified to be minimal: lowering any one of them by a single ULP produces failing assertions (1, 1, and 2 failures respectively). The bounds hold identically for the JavaScript and native implementations, so the same values apply to all three files.

The suite was run twice at the final bounds with identical results, and the native addon was compiled locally so that `test/test.native.js` actually executed rather than being skipped:

-   `test/test.js`: 3 passing, 0 failing
-   `test/test.quantile.js`: 3011 passing, 0 failing
-   `test/test.factory.js`: 3013 passing, 0 failing
-   `test/test.native.js`: 3011 passing, 0 failing

`test/test.js` contains only export smoke tests and is unchanged. The `expected[i] !== null` guards in `test/test.native.js` are preserved. Only the three test files containing tolerance math are changed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The conversion mirrors the sibling package `stats/base/dists/bradford/cdf`, which uses the same three-fixture structure and per-fixture-group ULP bounds.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an automated task. The tolerance-to-ULP conversion, the search for the minimum ULP bounds, and the local test/lint verification were all performed by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wtya3dXa2SDCVsefgMHKb

---
_Generated by [Claude Code](https://claude.ai/code/session_012wtya3dXa2SDCVsefgMHKb)_