### PR TITLE
chore: fix EditorConfig lint errors

### DIFF
--- a/lib/node_modules/@stdlib/plot/components/svg/path/lib/defaults.json
+++ b/lib/node_modules/@stdlib/plot/components/svg/path/lib/defaults.json
@@ -1,13 +1,13 @@
 {
-	"autoRender": false,
-	"color": "#000",
-	"isDefined": null,
-	"label": "",
-	"opacity": 0.9,
-	"style": "-",
-	"width": 2,
-	"x": [],
-	"xScale": null,
-	"y": [],
-	"yScale": null
+  "autoRender": false,
+  "color": "#000",
+  "isDefined": null,
+  "label": "",
+  "opacity": 0.9,
+  "style": "-",
+  "width": 2,
+  "x": [],
+  "xScale": null,
+  "y": [],
+  "yScale": null
 }


### PR DESCRIPTION
Resolves #14919.

## Description

This pull request fixes the EditorConfig linting error in `defaults.json` by replacing tab indentation with 2-space indentation, as required by the repository's `.editorconfig` configuration.

## Related Issues

This pull request has the following related issues:

* #14919

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

### AI Assistance

* [x] Yes
* [ ] No

If you answered "yes" above, how did you use AI assistance?

* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [x] Research and understanding

#### Disclosure

I consulted ChatGPT to understand the codebase, issue requirements, and contribution workflow. The proposed change was manually authored by me 

---

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md