### PR TITLE
test: migrate `stats/incr/pcorrdistmat` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/pcorrdistmat/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/pcorrdistmat/test/test.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var ndarray = require( '@stdlib/ndarray/ctor' );
 var Float64Array = require( '@stdlib/array/float64' );
 var incrpcorrdistmat = require( './../lib' );
@@ -591,9 +590,7 @@ tape( 'the accumulator function incrementally computes a sample Pearson product-
 	var strides;
 	var actual;
 	var shape;
-	var delta;
 	var order;
-	var tol;
 	var acc;
 	var n;
 	var v;
@@ -636,13 +633,7 @@ tape( 'the accumulator function incrementally computes a sample Pearson product-
 			for ( k = 0; k < n; k++ ) {
 				v = actual.get( j, k );
 				e = expected[ i ][ (j*n)+k ];
-				if ( v === e ) {
-					t.strictEqual( v, e, 'returns expected result. i: '+i+'. j: '+j+'. k: '+k+'.' );
-				} else {
-					delta = abs( e - v );
-					tol = 3.0 * EPS * abs( e );
-					t.strictEqual( delta <= tol, true, 'i: '+i+'. j: '+j+'. k: '+k+'. expected: '+e+'. actual: '+v+'. tol: '+tol+'. delta: '+delta+'.' );
-				}
+				t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 			}
 		}
 	}
@@ -655,10 +646,8 @@ tape( 'the accumulator function incrementally computes a sample Pearson product-
 	var actual;
 	var buffer;
 	var shape;
-	var delta;
 	var order;
 	var dist;
-	var tol;
 	var acc;
 	var n;
 	var v;
@@ -707,13 +696,7 @@ tape( 'the accumulator function incrementally computes a sample Pearson product-
 			for ( k = 0; k < n; k++ ) {
 				v = actual.get( j, k );
 				e = expected[ i ][ (j*n)+k ];
-				if ( v === e ) {
-					t.strictEqual( v, e, 'returns expected result. i: '+i+'. j: '+j+'. k: '+k+'.' );
-				} else {
-					delta = abs( e - v );
-					tol = 3.0 * EPS * abs( e );
-					t.strictEqual( delta <= tol, true, 'i: '+i+'. j: '+j+'. k: '+k+'. expected: '+e+'. actual: '+v+'. tol: '+tol+'. delta: '+delta+'.' );
-				}
+				t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 			}
 		}
 	}
@@ -727,9 +710,7 @@ tape( 'the accumulator function incrementally computes a sample Pearson product-
 	var buffer;
 	var means;
 	var shape;
-	var delta;
 	var order;
-	var tol;
 	var acc;
 	var n;
 	var v;
@@ -775,13 +756,7 @@ tape( 'the accumulator function incrementally computes a sample Pearson product-
 			for ( k = 0; k < n; k++ ) {
 				v = actual.get( j, k );
 				e = expected[ i ][ (j*n)+k ];
-				if ( v === e ) {
-					t.strictEqual( v, e, 'returns expected result. i: '+i+'. j: '+j+'. k: '+k+'.' );
-				} else {
-					delta = abs( e - v );
-					tol = 3.0 * EPS * abs( e );
-					t.strictEqual( delta <= tol, true, 'i: '+i+'. j: '+j+'. k: '+k+'. expected: '+e+'. actual: '+v+'. tol: '+tol+'. delta: '+delta+'.' );
-				}
+				t.strictEqual( isAlmostSameValue( v, e, 1 ), true, 'returns expected value' );
 			}
 		}
 	}
@@ -795,10 +770,8 @@ tape( 'the accumulator function incrementally computes a sample Pearson product-
 	var buffer;
 	var means;
 	var shape;
-	var delta;
 	var order;
 	var dist;
-	var tol;
 	var acc;
 	var n;
 	var v;
@@ -850,13 +823,7 @@ tape( 'the accumulator function incrementally computes a sample Pearson product-
 			for ( k = 0; k < n; k++ ) {
 				v = actual.get( j, k );
 				e = expected[ i ][ (j*n)+k ];
-				if ( v === e ) {
-					t.strictEqual( v, e, 'returns expected result. i: '+i+'. j: '+j+'. k: '+k+'.' );
-				} else {
-					delta = abs( e - v );
-					tol = 3.0 * EPS * abs( e );
-					t.strictEqual( delta <= tol, true, 'i: '+i+'. j: '+j+'. k: '+k+'. expected: '+e+'. actual: '+v+'. tol: '+tol+'. delta: '+delta+'.' );
-				}
+				t.strictEqual( isAlmostSameValue( v, e, 1 ), true, 'returns expected value' );
 			}
 		}
 	}


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/incr/pcorrdistmat` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the four `delta`/`tol` (`3.0 * EPS * abs( e )`) comparisons in `test/test.js` with `t.strictEqual( isAlmostSameValue( v, e, N ), true, 'returns expected value' );`, adding the `@stdlib/assert/is-almost-same-value` import and removing the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` imports.

**Final ULP constants:**

| Test | ULP bound |
| ---- | --------- |
| `...correlation distance matrix (order)` | `0` |
| `...correlation distance matrix (distance matrix)` | `0` |
| `...correlation distance matrix (order, means)` | `1` |
| `...correlation distance matrix (distance matrix, means)` | `1` |

These are the measured minimums. Starting from a high bound and tightening, the maximum ULP difference over the full set of hard-coded Julia-derived expected values is exactly `0`, `0`, `1`, and `1`, respectively. The two unknown-means tests are exact matches (`0` is the floor), and the two known-means bounds were verified to be minimal: lowering either from `1` to `0` produces failing assertions (8 failures in total).

The test data is fully deterministic (hard-coded `Float64Array` inputs, no PRNG), and the suite was run twice at the final bounds with identical results:

-   `test/test.js`: 212 passing, 0 failing

`make lint-javascript-tests TESTS_FILTER=".*/stats/incr/pcorrdistmat/.*"` is clean. This package has no `test/test.native.js`, so `test/test.js` is the only changed file.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The conversion mirrors the sibling package `stats/incr/pcorrmat`, which has the same four-block test structure and per-block ULP bounds.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an automated task. The tolerance-to-ULP conversion, the search for the minimum ULP bounds, and the local test/lint verification were all performed by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1SNYoWzDxPfm4UmswRuZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1SNYoWzDxPfm4UmswRuZE)_