### PR TITLE
test: migrate `stats/base/dists/levy/logcdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/levy/logcdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/logcdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -156,8 +155,6 @@ tape( 'if provided a nonpositive `c`, the created function always returns `NaN`'
 tape( 'the created function evaluates the logcdf for `x` given positive `mu`', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var i;
@@ -171,13 +168,7 @@ tape( 'the created function evaluates the logcdf for `x` given positive `mu`', f
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( mu[i], c[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -185,8 +176,6 @@ tape( 'the created function evaluates the logcdf for `x` given positive `mu`', f
 tape( 'the created function evaluates the logcdf for `x` given negative `mu`', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var i;
@@ -200,13 +189,7 @@ tape( 'the created function evaluates the logcdf for `x` given negative `mu`', f
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( mu[i], c[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -214,8 +197,6 @@ tape( 'the created function evaluates the logcdf for `x` given negative `mu`', f
 tape( 'the created function evaluates the logcdf for `x` given large variance ( = large `b`)', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var i;
@@ -229,13 +210,7 @@ tape( 'the created function evaluates the logcdf for `x` given large variance ( 
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( mu[i], c[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/logcdf/test/test.logcdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/logcdf/test/test.logcdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logcdf = require( './../lib' );
 
 
@@ -105,8 +104,6 @@ tape( 'if provided a nonpositive `c`, the function returns `NaN`', function test
 
 tape( 'the function evaluates the logcdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var i;
@@ -119,28 +116,18 @@ tape( 'the function evaluates the logcdf for `x` given positive `mu`', function 
 	c = positiveMean.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], mu[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var i;
 	var x;
 	var y;
-
-	tol = EPS;
 
 	expected = negativeMean.expected;
 	x = negativeMean.x;
@@ -148,21 +135,13 @@ tape( 'the function evaluates the logcdf for `x` given negative `mu`', function 
 	c = negativeMean.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], mu[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given large variance ( = large `b` )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var i;
@@ -175,13 +154,7 @@ tape( 'the function evaluates the logcdf for `x` given large variance ( = large 
 	c = largeVariance.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], mu[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/logcdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/logcdf/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -114,8 +113,6 @@ tape( 'if provided a nonpositive `c`, the function returns `NaN`', opts, functio
 
 tape( 'the function evaluates the logcdf for `x` given positive `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var i;
@@ -128,28 +125,18 @@ tape( 'the function evaluates the logcdf for `x` given positive `mu`', opts, fun
 	c = positiveMean.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], mu[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given negative `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var i;
 	var x;
 	var y;
-
-	tol = EPS;
 
 	expected = negativeMean.expected;
 	x = negativeMean.x;
@@ -157,21 +144,13 @@ tape( 'the function evaluates the logcdf for `x` given negative `mu`', opts, fun
 	c = negativeMean.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], mu[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given large variance ( = large `b` )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var i;
@@ -184,13 +163,7 @@ tape( 'the function evaluates the logcdf for `x` given large variance ( = large 
 	c = largeVariance.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], mu[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the `stats/base/dists/levy/logcdf` test suite (`test.logcdf.js`, `test.factory.js`, `test.native.js`) from the relative-tolerance (`EPS`/`abs`-based) idiom to `@stdlib/assert/is-almost-same-value`-based ULP difference assertions.
-   determines the tightest ULP bound per test body by computing the exact ULP difference (via `@stdlib/number/float64/base/ulp-difference`) between the actual and expected fixture values, for both the JavaScript implementation and the built native (C) addon, and confirms the result is deterministic across repeated runs.
-   final ULP constant used: `ULP = 0` (exact match) for all three converted files (`test.logcdf.js`, `test.factory.js`, `test.native.js`), across all three fixture sets (`positive_mean`, `negative_mean`, `large_variance`).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Only the test files in `stats/base/dists/levy/logcdf/test/` were changed; no `package.json` changes were needed. `make test TESTS_FILTER=".*/stats/base/dists/levy/logcdf/.*"` passes for all four test files (`test.js`: 3/3, `test.logcdf.js`: 3016/3016, `test.factory.js`: 3020/3020, `test.native.js`: 3016/3016, the latter run against a locally built native addon), run twice to confirm determinism, and `npx eslint` reports no lint errors on the changed files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, including computing the tightest ULP bounds and applying the test-file edits.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNJXXvVVMrtVcU25HhpuJ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNJXXvVVMrtVcU25HhpuJ7)_