### PR TITLE
test: migrate `stats/incr/mmpe` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/mmpe/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/mmpe/test/test.js
@@ -22,8 +22,7 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var incrmmpe = require( './../lib' );
 
 
@@ -73,10 +72,8 @@ tape( 'the function returns an accumulator function', function test( t ) {
 tape( 'the accumulator function computes a moving mean percentage error incrementally', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
 	var acc;
-	var tol;
 	var N;
 	var i;
 
@@ -103,13 +100,7 @@ tape( 'the accumulator function computes a moving mean percentage error incremen
 	];
 	for ( i = 0; i < N; i++ ) {
 		actual = acc( data[i][0], data[i][1] );
-		if ( actual === expected[i] ) {
-			t.strictEqual( actual, expected[i], 'returns expected value' );
-		} else {
-			delta = abs( expected[i] - actual );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+actual+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/incr/mmpe` from relative tolerance (`EPS`-scaled) assertions to ULP-based assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].

Details:

-   `test/test.js` is the only test file in the package containing computed-tolerance assertions; no `test.native.js` exists.
-   Replaced the `abs`/`EPS` `delta <= tol` comparison (and the associated `delta`/`tol` locals and requires) with `t.strictEqual( isAlmostSameValue( actual, expected[i], N ), true, 'returns expected value' );`.
-   The package contains a single computed-tolerance assertion, whose ULP bound was tightened to the **measured minimum** by starting from `N = 64` and lowering `N` until the smallest integer which still passes across every fixture value:
    -   `the accumulator function computes a moving mean percentage error incrementally`: **1 ULP** (passes at `1`; fails at `0` with 3 failing assertions; previous tolerance was `1.0 * EPS`).
-   The suite was run twice at the final bound to confirm determinism: 98/98 passing on both runs.
-   `make lint-javascript-tests TESTS_FILTER=".*/stats/incr/mmpe/.*"` is clean, and the only changed file is `lib/node_modules/@stdlib/stats/incr/mmpe/test/test.js`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, which studied prior ULP migrations in this repository (including the sibling package `stats/incr/mpe`), applied the same idiom here, and empirically searched for the minimum passing ULP bound.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmuE4qxqzr54jsqv5pq1rk

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmuE4qxqzr54jsqv5pq1rk)_