### PR TITLE
fix: perform support checks before integer narrowing

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/cdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/cdf/src/main.c
@@ -38,21 +38,18 @@
 * double y = stdlib_base_dists_hypergeometric_cdf( 1.0, 8, 4, 2 );
 * // returns ~0.786
 */
-double stdlib_base_dists_hypergeometric_cdf(
-	const double x,
-	const int32_t N,
-	const int32_t K,
-	const int32_t n
-) {
-	int32_t upper;
-	int32_t lower;
+double stdlib_base_dists_hypergeometric_cdf( const double x, const int32_t N, const int32_t K, const int32_t n ) {
+	double upper;
+	double lower;
 	double denom;
-	int32_t xi;
 	double num;
 	double ret;
-	int32_t i;
-	double xd;
+	double dx;
+	double dn;
+	double dK;
+	double dN;
 	double p;
+	double i;
 
 	if (
 		stdlib_base_is_nan( x ) ||
@@ -62,31 +59,28 @@ double stdlib_base_dists_hypergeometric_cdf(
 		K > N ||
 		n > N
 	) {
-		return 0.0 / 0.0;
+		return 0.0 / 0.0; // NaN
 	}
 	if ( stdlib_base_is_infinite( x ) ) {
 		return ( x > 0.0 ) ? 1.0 : 0.0;
 	}
-
-	xd = stdlib_base_trunc( x );
-
-	lower = stdlib_base_max( 0, n + K - N );
-	upper = stdlib_base_min( n, K );
-
-	if ( xd < (double)lower ) {
+	dn = (double)n;
+	dN = (double)N;
+	dK = (double)K;
+	dx = stdlib_base_trunc( x );
+	lower = stdlib_base_max( 0.0, dn+dK-dN );
+	upper = stdlib_base_min( dn, dK );
+	if ( dx < lower ) {
 		return 0.0;
 	}
-	if ( xd >= (double)upper ) {
+	if ( dx >= upper ) {
 		return 1.0;
 	}
-	xi = (int32_t)xd;
-
-	p = stdlib_base_dists_hypergeometric_pmf( (double)xi, N, K, n );
+	p = stdlib_base_dists_hypergeometric_pmf( dx, N, K, n );
 	ret = p;
-
-	for ( i = xi - 1; i >= lower; i-- ) {
-		num = (double)( i + 1 ) * (double)( N - K - ( n - i - 1 ) );
-		denom = (double)( K - i ) * (double)( n - i );
+	for ( i = dx-1.0; i >= lower; i -= 1.0 ) {
+		num = ( i + 1.0 ) * ( dN - dK - dn + i + 1.0 ) );
+		denom = ( dK - i ) * ( dn - i );
 		p = ( num / denom ) * p;
 		ret += p;
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/cdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/cdf/src/main.c
@@ -26,7 +26,7 @@
 #include <stdint.h>
 
 /**
-* Evaluates the cumulative distribution function (CDF) for a hypergeometric distribution.
+* Evaluates the cumulative distribution function (CDF) for a hypergeometric distribution with population size `N`, subpopulation size `K`, and number of draws `n` at a value `x`.
 *
 * @param x    input value
 * @param N    population size
@@ -47,6 +47,7 @@ double stdlib_base_dists_hypergeometric_cdf(
 	double denom;
 	double num;
 	double ret;
+	double xd;
 	double p;
 	int32_t upper;
 	int32_t lower;
@@ -67,17 +68,18 @@ double stdlib_base_dists_hypergeometric_cdf(
 		return ( x > 0.0 ) ? 1.0 : 0.0;
 	}
 
-	xi = (int32_t)stdlib_base_trunc( x );
+	xd = stdlib_base_trunc( x );
 
 	lower = stdlib_base_max( 0, n + K - N );
 	upper = stdlib_base_min( n, K );
 
-	if ( xi < lower ) {
+	if ( xd < (double)lower ) {
 		return 0.0;
 	}
-	if ( xi >= upper ) {
+	if ( xd >= (double)upper ) {
 		return 1.0;
 	}
+	xi = (int32_t)xd;
 
 	p = stdlib_base_dists_hypergeometric_pmf( (double)xi, N, K, n );
 	ret = p;

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/cdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/cdf/src/main.c
@@ -79,7 +79,7 @@ double stdlib_base_dists_hypergeometric_cdf( const double x, const int32_t N, co
 	p = stdlib_base_dists_hypergeometric_pmf( dx, N, K, n );
 	ret = p;
 	for ( i = dx-1.0; i >= lower; i -= 1.0 ) {
-		num = ( i + 1.0 ) * ( dN - dK - dn + i + 1.0 ) );
+		num = ( i + 1.0 ) * ( dN - dK - dn + i + 1.0 );
 		denom = ( dK - i ) * ( dn - i );
 		p = ( num / denom ) * p;
 		ret += p;

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/cdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/cdf/src/main.c
@@ -44,15 +44,15 @@ double stdlib_base_dists_hypergeometric_cdf(
 	const int32_t K,
 	const int32_t n
 ) {
-	double denom;
-	double num;
-	double ret;
-	double xd;
-	double p;
 	int32_t upper;
 	int32_t lower;
+	double denom;
 	int32_t xi;
+	double num;
+	double ret;
 	int32_t i;
+	double xd;
+	double p;
 
 	if (
 		stdlib_base_is_nan( x ) ||


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between f29c023be (2026-09-03 02:05 +0530) and d656ebac8 (2026-09-03 11:31 +0500).

This pull request:

-   **`stats/base/dists/hypergeometric/cdf`**:
    -   Fixes the double-to-int32 truncation order in `stats/base/dists/hypergeometric/cdf`: `f29c023be`'s `main.c` cast `x` to `int32_t` before the support-bound checks, so any finite `x` outside int32 range hit UB (INT32_MIN on x86-64) and `cdf(1.0e10, 20, 20, 10)` wrongly returned `0.0` instead of `1.0`. Now `lib/node_modules/@stdlib/stats/base/dists/hypergeometric/cdf/src/main.c` truncates into a `double` and compares against `(double)lower`/`(double)upper` before narrowing, matching the JS reference; verified against a standalone harness for `1e10`/`1e300` plus in-support values.
    -   Fixes the CDF doc comment in `src/main.c` (f29c023be) — it was missing the `N`/`K`/`n`/`x` parameter clause present in `cdf.h`, `lib/native.js`, `lib/main.js`, and the quantile package's `src/main.c`. Restored it for consistency.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** All 20 commits merged to `develop` in the last 24 hours were reviewed for bugs, typos, and stdlib style-guide compliance (new code compared against established sibling packages: `blas/ext/index-of-not-equal` for `blas/ext/index-of-falsy`; `stats/base/dists/hypergeometric/pmf`/`logpmf` for the new C implementations). The bug fix was double-confirmed by independent review passes and reproduced/validated with a standalone C harness (buggy: `cdf(1e10, 20, 20, 10) == 0.0`; fixed: `1.0`; all in-support and NaN/±infinity cases unchanged), plus a syntax check against the package headers. Deliberately excluded: anything subjective, interpretive, or requiring changes outside the reviewed diff window. The ULP-based test migrations, bot docs commits, and the clean-up commit were reviewed and found clean.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of a scheduled automated review of commits recently merged to `develop`; findings were cross-validated by independent review passes and the fix was verified with a standalone C harness.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8PkS1AQnkLGgAAEiFeQq7

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8PkS1AQnkLGgAAEiFeQq7)_