### PR TITLE
test: migrate `stats/base/dists/exponential/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/stdev/test/test.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -62,8 +61,6 @@ tape( 'if provided a rate parameter `lambda` that is not a nonnegative number, t
 tape( 'the function returns the standard deviation of an exponential distribution', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var y;
 
@@ -71,13 +68,7 @@ tape( 'the function returns the standard deviation of an exponential distributio
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( lambda[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[i], 'lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/stdev/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -71,8 +70,6 @@ tape( 'if provided a rate parameter `lambda` that is not a nonnegative number, t
 tape( 'the function returns the standard deviation of an exponential distribution', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var y;
 
@@ -80,13 +77,7 @@ tape( 'the function returns the standard deviation of an exponential distributio
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stddev( lambda[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[i], 'lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for `@stdlib/stats/base/dists/exponential/stdev` from relative tolerance testing to ULP difference testing, as described in #11352.
-   replaces the previous `EPS`-scaled tolerance comparisons (`delta <= tol`) with `isAlmostSameValue( y, expected[ i ], N )` assertions using `@stdlib/assert/is-almost-same-value`, and uses the message `'returns expected value'` for each fixture-loop assertion.
-   updates both `test/test.js` and `test/test.native.js`.

The ULP bound was tightened to the minimum integer that passes over the full fixture set. All `50` fixture values match the reference output exactly, so the minimum required ULP is:

-   `test/test.js`: **0 ULP**
-   `test/test.native.js`: **0 ULP**

The suite was run twice at the final bound to confirm determinism (no FMA/arch flakiness).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves a part of #11352.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored primarily by Claude Code: it converted the tolerance-based fixture assertions to ULP-based assertions and measured the minimum passing ULP bound over the full fixture set.

* * *

@stdlib-js/reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Ba3VZAiNQUyCZRWJuJQqw

---
_Generated by [Claude Code](https://claude.ai/code/session_019Ba3VZAiNQUyCZRWJuJQqw)_