### PR TITLE
test: migrate `stats/base/dists/gumbel/pdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/pdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -140,10 +139,8 @@ tape( 'if provided a nonpositive `beta`, the created function always returns `Na
 
 tape( 'the created function evaluates the pdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var beta;
 	var pdf;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -157,13 +154,7 @@ tape( 'the created function evaluates the pdf for `x` given positive `mu`', func
 		pdf = factory( mu[i], beta[i] );
 		y = pdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -171,10 +162,8 @@ tape( 'the created function evaluates the pdf for `x` given positive `mu`', func
 
 tape( 'the created function evaluates the pdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var beta;
 	var pdf;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -188,13 +177,7 @@ tape( 'the created function evaluates the pdf for `x` given negative `mu`', func
 		pdf = factory( mu[i], beta[i] );
 		y = pdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -202,10 +185,8 @@ tape( 'the created function evaluates the pdf for `x` given negative `mu`', func
 
 tape( 'the created function evaluates the pdf for `x` given large variance ( = large `beta`)', function test( t ) {
 	var expected;
-	var delta;
 	var beta;
 	var pdf;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -219,13 +200,7 @@ tape( 'the created function evaluates the pdf for `x` given large variance ( = l
 		pdf = factory( mu[i], beta[i] );
 		y = pdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/pdf/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -107,9 +106,7 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', opts, func
 
 tape( 'the function evaluates the pdf for `x` given positive `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -122,13 +119,7 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', opts, functi
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], beta[i] );
 		if ( expected[i] !== null) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -136,9 +127,7 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', opts, functi
 
 tape( 'the function evaluates the pdf for `x` given negative `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -151,13 +140,7 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', opts, functi
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], beta[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -165,9 +148,7 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', opts, functi
 
 tape( 'the function evaluates the pdf for `x` given large variance ( = large `beta` )', opts, function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -180,13 +161,7 @@ tape( 'the function evaluates the pdf for `x` given large variance ( = large `be
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], beta[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/pdf/test/test.pdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( './../lib' );
 
 
@@ -98,9 +97,7 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', function t
 
 tape( 'the function evaluates the pdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -113,13 +110,7 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', function tes
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], beta[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -127,9 +118,7 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', function tes
 
 tape( 'the function evaluates the pdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -142,13 +131,7 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', function tes
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], beta[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -156,9 +139,7 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', function tes
 
 tape( 'the function evaluates the pdf for `x` given large variance ( = large `beta` )', function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -171,13 +152,7 @@ tape( 'the function evaluates the pdf for `x` given large variance ( = large `be
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], beta[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/gumbel/pdf` from relative tolerance testing (`delta <= EPS * abs( expected )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].

The following test files were updated:

-   `test/test.pdf.js`
-   `test/test.factory.js`
-   `test/test.native.js`

In each file, the `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` imports were removed, the `@stdlib/assert/is-almost-same-value` import was added, and each `if ( y === expected[i] ) { ... } else { ... }` tolerance block was replaced with a single `t.strictEqual( isAlmostSameValue( y, expected[ i ], N ), true, 'returns expected value' );` assertion. The pre-existing `expected[i] !== null` fixture guards were left intact.

### ULP bounds

The ULP bound was tightened to the measured minimum over the full fixture set. For every fixture (`positive_mean`, `negative_mean`, `large_variance`) and for both the main and factory entry points, the maximum observed ULP difference is **1**, so **`1` ULP** is used throughout:

| Fixture | Fixture size | Measured minimum ULP |
| --- | --- | --- |
| `positive_mean` | 1000 | 1 |
| `negative_mean` | 1000 | 1 |
| `large_variance` | 1000 | 1 |

At `0` ULPs, 548 of the 3015 assertions in `test/test.pdf.js` and 548 of the 3018 assertions in `test/test.factory.js` fail, confirming that `1` is the tightest bound which still passes. The suite was run twice at the final bound with identical results.

`test/test.native.js` uses the same `1` ULP bound, matching the convention in previously migrated packages in this family (e.g., `stats/base/dists/gumbel/cdf`, `stats/base/dists/pareto-type1/pdf`). The C implementation in `src/main.c` is a direct transliteration of `lib/main.js` and delegates to the same `exp` routine.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Only test files are changed; no implementation, documentation, or fixture files were touched.

Note on verification: in the environment used to author this PR, `make install-node-modules` could not complete (`es-object-atoms@^1.1.2` is not resolvable from the registry), so the native add-on could not be built and `test/test.native.js` was skipped locally, as it is whenever the add-on is absent. The JavaScript test files were run directly (twice, green) and linted with the repository's own `etc/eslint/.eslintrc.tests.js` configuration via the pre-commit hook, which reported no issues.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, which studied previously merged migrations in this family, applied the mechanical conversion, and measured the minimum ULP bound over the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5hkgpAq7yZHbDyNf71eS8

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5hkgpAq7yZHbDyNf71eS8)_