### PR TITLE
test: migrate `stats/base/dists/t/logpdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/t/logpdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/logpdf/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -132,8 +131,6 @@ tape( 'if provided a nonpositive `v`, the created function always returns `NaN`'
 tape( 'the created function evaluates the logpdf for `x` given parameter `v` (when `x` and `v` are small)', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
-	var tol;
 	var i;
 	var v;
 	var x;
@@ -145,13 +142,7 @@ tape( 'the created function evaluates the logpdf for `x` given parameter `v` (wh
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( v[i] );
 		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -159,8 +150,6 @@ tape( 'the created function evaluates the logpdf for `x` given parameter `v` (wh
 tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` is large and `v` small)', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
-	var tol;
 	var i;
 	var v;
 	var x;
@@ -172,13 +161,7 @@ tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` i
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( v[i] );
 		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -186,8 +169,6 @@ tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` i
 tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` is small and `v` large)', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
-	var tol;
 	var i;
 	var v;
 	var x;
@@ -199,13 +180,7 @@ tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` i
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( v[i] );
 		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 50.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 84 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -213,8 +188,6 @@ tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` i
 tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` and `v` are large)', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
-	var tol;
 	var i;
 	var v;
 	var x;
@@ -226,13 +199,7 @@ tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` a
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( v[i] );
 		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 32 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/t/logpdf/test/test.logpdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/logpdf/test/test.logpdf.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logpdf = require( './../lib' );
 
 
@@ -103,8 +102,6 @@ tape( 'if provided a nonpositive `v`, the function always returns `NaN`', functi
 
 tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` and `v` are small)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -115,21 +112,13 @@ tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` a
 	v = smallSmall.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], v[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` is large and `v` small)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -140,21 +129,13 @@ tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` i
 	v = largeSmall.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], v[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` is small and `v` large)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -165,21 +146,13 @@ tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` i
 	v = smallLarge.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], v[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 50.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 84 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` and `v` are large)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -190,13 +163,7 @@ tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` a
 	v = largeLarge.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], v[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 32 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/t/logpdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/logpdf/test/test.native.js
@@ -24,10 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -112,8 +111,6 @@ tape( 'if provided a nonpositive `v`, the function always returns `NaN`', opts, 
 
 tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` and `v` are small)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -124,21 +121,13 @@ tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` a
 	v = smallSmall.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], v[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` is large and `v` small)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -149,21 +138,13 @@ tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` i
 	v = largeSmall.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], v[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` is small and `v` large)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -174,21 +155,13 @@ tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` i
 	v = smallLarge.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], v[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 50.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 84 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` and `v` are large)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -199,13 +172,7 @@ tape( 'the function evaluates the logpdf for `x` given parameter `v` (when `x` a
 	v = largeLarge.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], v[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 32 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of  #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for stats/base/dists/t/logpdf from relative tolerance (EPS/delta/tol) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
-   updates test/test.logpdf.js, test/test.factory.js, and test/test.native.js. No other files are changed.
-   removes the now-unused EPS and abs imports and the corresponding delta/tol variable declarations from each file.
-   ULP bounds were verified directly against the fixture data using a script that computes the actual ULP distance between computed and expected values for every input. Verified minimums: small_small=4, large_small=4, small_large=84, large_large=32 (identical across JS and native implementations, confirmed by running the same verification against both).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
