### PR TITLE
test: migrate `math/base/tools/normhermitepolyf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/tools/normhermitepolyf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/math/base/tools/normhermitepolyf/test/test.factory.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float32/eps' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var factory = require( './../lib' ).factory;
@@ -63,8 +62,6 @@ tape( 'the function returns a function', function test( t ) {
 
 tape( 'the function returns a function which accurately computes `Hen(x)` for random `n` and `x`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -80,17 +77,13 @@ tape( 'the function returns a function which accurately computes `Hen(x)` for ra
 		f = factory( n[ i ] );
 		v = f( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 5.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n[ i ] + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He1(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -107,17 +100,13 @@ tape( 'the function returns a function which accurately computes `He1(x)` for sm
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -134,17 +123,13 @@ tape( 'the function accurately computes `He2(x)` for small positive numbers', fu
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He5(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -161,17 +146,13 @@ tape( 'the function returns a function which accurately computes `He5(x)` for sm
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He1(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -188,17 +169,13 @@ tape( 'the function returns a function which accurately computes `He1(x)` for sm
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He2(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -215,17 +192,13 @@ tape( 'the function returns a function which accurately computes `He2(x)` for sm
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He5(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -242,17 +215,13 @@ tape( 'the function returns a function which accurately computes `He5(x)` for sm
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He1(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -269,17 +238,13 @@ tape( 'the function returns a function which accurately computes `He1(x)` for ti
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He2(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -296,17 +261,13 @@ tape( 'the function returns a function which accurately computes `He2(x)` for ti
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He5(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -323,17 +284,13 @@ tape( 'the function returns a function which accurately computes `He5(x)` for ti
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He1(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -350,17 +307,13 @@ tape( 'the function returns a function which accurately computes `He1(x)` for po
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He2(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -377,17 +330,13 @@ tape( 'the function returns a function which accurately computes `He2(x)` for po
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He5(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -404,17 +353,13 @@ tape( 'the function returns a function which accurately computes `He5(x)` for po
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 5.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He1(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -431,17 +376,13 @@ tape( 'the function returns a function which accurately computes `He1(x)` for ne
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He2(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -458,17 +399,13 @@ tape( 'the function returns a function which accurately computes `He2(x)` for ne
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns a function which accurately computes `He5(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var f;
 	var x;
 	var v;
@@ -485,9 +422,7 @@ tape( 'the function returns a function which accurately computes `He5(x)` for ne
 	for ( i = 0; i < x.length; i++ ) {
 		v = f( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 5.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/tools/normhermitepolyf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/tools/normhermitepolyf/test/test.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float32/eps' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var normhermitepolyf = require( './../lib' );
@@ -31,23 +30,18 @@ var normhermitepolyf = require( './../lib' );
 // FIXTURES //
 
 var random2 = require( './fixtures/python/random2.json' );
-
 var mediumNegative1 = require( './fixtures/python/medium_negative_1.json' );
 var mediumNegative2 = require( './fixtures/python/medium_negative_2.json' );
 var mediumNegative5 = require( './fixtures/python/medium_negative_5.json' );
-
 var mediumPositive1 = require( './fixtures/python/medium_positive_1.json' );
 var mediumPositive2 = require( './fixtures/python/medium_positive_2.json' );
 var mediumPositive5 = require( './fixtures/python/medium_positive_5.json' );
-
 var smallPositive1 = require( './fixtures/python/small_positive_1.json' );
 var smallPositive2 = require( './fixtures/python/small_positive_2.json' );
 var smallPositive5 = require( './fixtures/python/small_positive_5.json' );
-
 var smallNegative1 = require( './fixtures/python/small_negative_1.json' );
 var smallNegative2 = require( './fixtures/python/small_negative_2.json' );
 var smallNegative5 = require( './fixtures/python/small_negative_5.json' );
-
 var tiny1 = require( './fixtures/python/tiny_1.json' );
 var tiny2 = require( './fixtures/python/tiny_2.json' );
 var tiny5 = require( './fixtures/python/tiny_5.json' );
@@ -68,8 +62,6 @@ tape( 'attached to the main export is a `factory` method', function test( t ) {
 
 tape( 'the function accurately computes `Hen(x)` for random `n` and `x`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -83,17 +75,13 @@ tape( 'the function accurately computes `Hen(x)` for random `n` and `x`', functi
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepolyf( n[ i ], x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 5.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n[ i ] + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He1(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -107,17 +95,13 @@ tape( 'the function accurately computes `He1(x)` for small positive numbers', fu
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepolyf( n, x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -131,17 +115,13 @@ tape( 'the function accurately computes `He2(x)` for small positive numbers', fu
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepolyf( n, x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He5(x)` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -155,17 +135,13 @@ tape( 'the function accurately computes `He5(x)` for small positive numbers', fu
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepolyf( n, x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He1(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -179,17 +155,13 @@ tape( 'the function accurately computes `He1(x)` for small negative numbers', fu
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepolyf( n, x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -203,17 +175,13 @@ tape( 'the function accurately computes `He2(x)` for small negative numbers', fu
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepolyf( n, x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He5(x)` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -227,17 +195,13 @@ tape( 'the function accurately computes `He5(x)` for small negative numbers', fu
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepolyf( n, x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He1(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -251,17 +215,13 @@ tape( 'the function accurately computes `He1(x)` for tiny numbers', function tes
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepolyf( n, x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -275,17 +235,13 @@ tape( 'the function accurately computes `He2(x)` for tiny numbers', function tes
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepolyf( n, x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He5(x)` for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -299,17 +255,13 @@ tape( 'the function accurately computes `He5(x)` for tiny numbers', function tes
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepolyf( n, x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He1(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -323,17 +275,13 @@ tape( 'the function accurately computes `He1(x)` for positive medium numbers', f
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepolyf( n, x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -347,17 +295,13 @@ tape( 'the function accurately computes `He2(x)` for positive medium numbers', f
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepolyf( n, x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He5(x)` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -371,17 +315,13 @@ tape( 'the function accurately computes `He5(x)` for positive medium numbers', f
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepolyf( n, x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 5.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He1(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -395,17 +335,13 @@ tape( 'the function accurately computes `He1(x)` for negative medium numbers', f
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepolyf( n, x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He2(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -419,17 +355,13 @@ tape( 'the function accurately computes `He2(x)` for negative medium numbers', f
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepolyf( n, x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 1.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `He5(x)` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -443,9 +375,7 @@ tape( 'the function accurately computes `He5(x)` for negative medium numbers', f
 	for ( i = 0; i < x.length; i++ ) {
 		v = normhermitepolyf( n, x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		delta = abs( v - e );
-		tol = 5.0 * EPS * abs( e );
-		t.ok( delta <= tol, 'within tolerance. n: ' + n + '. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + e + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, e, 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the test suite for `math/base/tools/normhermitepolyf` from relative-tolerance (`EPS * abs(...)`) assertions to ULP-difference assertions using `@stdlib/number/float32/base/assert/is-almost-same-value`, per the tracking issue.
-   Converts `test/test.js` and `test/test.factory.js` (the only two files in this package using the old tolerance idiom).
-   For each fixture group, the tightest passing ULP bound was found empirically by computing the exact ULP difference between the function's output and the (float32-rounded) expected value across the full fixture set, then using that measured maximum as the assertion bound:
    -   `Hen(x)` for random `n`/`x` (`random2` fixture): **4** ULP
    -   `He1`/`He2` for small positive, small negative, tiny, and (positive/negative) medium numbers: **0** ULP
    -   `He2` for small positive/negative numbers: **1** ULP
    -   `He5` for small positive, small negative, and tiny numbers: **1** ULP
    -   `He5` for positive/negative medium numbers: **3** ULP
-   The full test suite was run twice at these bounds to confirm deterministic results (no FMA/architecture-dependent flakiness); both runs passed 15110/15110 assertions.
-   This mirrors the pattern used in the already-converted sibling package `math/base/tools/normhermitepoly` (float64 variant).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored autonomously by Claude Code (running as a scheduled task), including candidate discovery, studying prior art from already-merged ULP-migration PRs, computing the tightest passing ULP bounds, and applying the conversion.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpHLeJk4ESi3EbKFAjv5HW

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpHLeJk4ESi3EbKFAjv5HW)_