### PR TITLE
test: migrate `stats/base/dists/pareto-type1/logcdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logcdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logcdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -189,10 +188,8 @@ tape( 'if provided a nonpositive `beta`, the created function always returns `Na
 tape( 'the created function evaluates the logcdf for `x` given large `alpha` and `beta`', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -204,13 +201,7 @@ tape( 'the created function evaluates the logcdf for `x` given large `alpha` and
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( alpha[i], beta[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -218,10 +209,8 @@ tape( 'the created function evaluates the logcdf for `x` given large `alpha` and
 tape( 'the created function evaluates the logcdf for `x` given large `alpha` parameter', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -233,13 +222,7 @@ tape( 'the created function evaluates the logcdf for `x` given large `alpha` par
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( alpha[i], beta[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -247,10 +230,8 @@ tape( 'the created function evaluates the logcdf for `x` given large `alpha` par
 tape( 'the created function evaluates the logcdf for `x` given large `beta` parameter', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -262,13 +243,7 @@ tape( 'the created function evaluates the logcdf for `x` given large `beta` para
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( alpha[i], beta[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logcdf/test/test.logcdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logcdf/test/test.logcdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logcdf = require( './../lib' );
 
 
@@ -129,10 +128,8 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', function t
 
 tape( 'the function evaluates the logcdf for `x` given large `alpha` and `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -143,23 +140,15 @@ tape( 'the function evaluates the logcdf for `x` given large `alpha` and `beta`'
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given large `alpha` parameter', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -170,23 +159,15 @@ tape( 'the function evaluates the logcdf for `x` given large `alpha` parameter',
 	beta = largeAlpha.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given large rate parameter `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -197,13 +178,7 @@ tape( 'the function evaluates the logcdf for `x` given large rate parameter `bet
 	beta = largeBeta.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logcdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logcdf/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -138,10 +137,8 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', opts, func
 
 tape( 'the function evaluates the logcdf for `x` given large `alpha` and `beta`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -152,23 +149,15 @@ tape( 'the function evaluates the logcdf for `x` given large `alpha` and `beta`'
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given large `alpha` parameter', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -179,23 +168,15 @@ tape( 'the function evaluates the logcdf for `x` given large `alpha` parameter',
 	beta = largeAlpha.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given large rate parameter `beta`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -206,13 +187,7 @@ tape( 'the function evaluates the logcdf for `x` given large rate parameter `bet
 	beta = largeBeta.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/pareto-type1/logcdf` from relative tolerance testing to ULP difference testing, replacing the `delta`/`tol` comparisons with `isAlmostSameValue( y, expected[ i ], <ulp> )` assertions from [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   updates `test/test.logcdf.js`, `test/test.factory.js`, and `test/test.native.js`. All nine fixture loops (`both_large`, `large_alpha`, `large_beta` in each file) previously used `tol = 1.0 * EPS * abs( expected[ i ] )`.
-   uses a **ULP bound of `0`** in every converted assertion. This is the measured minimum: over the full fixture set (3 x 1000 values), the JavaScript implementation, the `factory` implementation, and the compiled native implementation each return the exact fixture value for every case (maximum measured ULP difference: `0`). The now unused `abs` and `EPS` imports are removed.

Verification:

-   The package test suite is green (9078 assertions, including the native tests with the addon built locally), and was run twice at the final ULP value to confirm determinism.
-   `eslint` (using `etc/eslint/.eslintrc.tests.js`) reports no problems for the three modified files.
-   Only test files are changed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an unattended, scheduled test-migration run. The ULP bound was determined empirically by measuring the maximum ULP difference across the full fixture set for the JavaScript, factory, and native implementations, rather than guessed.

* * *

@stdlib-js/reviewers

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MN5txP8RfuUxDtjF1VAtaq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MN5txP8RfuUxDtjF1VAtaq)_