### PR TITLE
test: migrate `stats/incr/kurtosis` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/kurtosis/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/kurtosis/test/test.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var incrkurtosis = require( './../lib' );
 
@@ -43,9 +42,7 @@ tape( 'the function returns an accumulator function', function test( t ) {
 tape( 'the accumulator function incrementally computes a corrected sample excess kurtosis', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
-	var tol;
 	var acc;
 	var i;
 
@@ -68,9 +65,7 @@ tape( 'the accumulator function incrementally computes a corrected sample excess
 		if ( expected[i] === null ) {
 			t.strictEqual( actual, null, 'returns expected value' );
 		} else {
-			delta = abs( actual - expected[ i ] );
-			tol = 1.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. actual: '+actual+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/incr/kurtosis` from relative tolerance (`EPS`-based) assertions to ULP-based assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].

Specifically, in `test/test.js`:

-   replaces the `abs`/`EPS` requires with `@stdlib/assert/is-almost-same-value`.
-   removes the `delta`/`tol` scratch variables and the `t.ok( delta <= tol, ... )` assertion.
-   asserts via `t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );`.

The package has no `test/test.native.js`, so `test/test.js` is the only changed file.

### ULP bound

The final ULP constant is **`2`**, which is the measured minimum for this fixture set. Per-case measured ULP differences against the `e1071` R package reference values:

| `expected` | measured ULP diff |
| ---------- | ----------------- |
| `-6` | 0 |
| `-3.309339678762642` | 2 |
| `-0.1906596382525679` | 0 |

Verified by bisection: the suite fails at `1` ULP and passes at `2` ULP. The suite was run twice at the final value to confirm determinism (34 assertions passing on both runs).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The pre-existing tolerance factor was `1.5 * EPS`, which is looser than the measured 2 ULP bound now asserted, so this migration tightens the accuracy budget for this package.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an automated task. The ULP bound was determined empirically by measuring per-case ULP differences and bisecting the suite, and the resulting change was verified locally (`make test TESTS_FILTER=".*/stats/incr/kurtosis/.*"` and `make lint-javascript-tests TESTS_FILTER=".*/stats/incr/kurtosis/.*"`).

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuNzAYMeykWvsZndN8V36F

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuNzAYMeykWvsZndN8V36F)_