### PR TITLE
chore: fix JavaScript lint error

### DIFF
--- a/lib/node_modules/@stdlib/fs/resolve-parent-path/lib/async.js
+++ b/lib/node_modules/@stdlib/fs/resolve-parent-path/lib/async.js
@@ -92,7 +92,7 @@ function resolveParentPath( path, options, clbk ) {
 	* @param {boolean} bool - boolean indicating if a path exists
 	* @returns {void}
 	*/
-	function onExists( error, bool ) { // eslint-disable-line handle-callback-err
+	function onExists( error, bool ) { // eslint-disable-line n/handle-callback-err
 		if ( bool ) {
 			return done( null, spath );
 		}


### PR DESCRIPTION
Resolves #14949.

## Description

This pull request:

-   Updates the stale `eslint-disable-line handle-callback-err` directive in `lib/node_modules/@stdlib/fs/resolve-parent-path/lib/async.js` to `n/handle-callback-err`. Since the migration from `eslint-plugin-node` to `eslint-plugin-n` (#10952), the rule is registered as `n/handle-callback-err`, so the unprefixed directive no longer matches and the lint run reports both an unhandled `error` argument and an unused disable directive.

## Related Issues

This pull request has the following related issues:

-   #14949

## Questions

No.

## Other

The failure can be reproduced with eslint 8.57.0 and eslint-plugin-n 17.17.0 using `--report-unused-disable-directives` and the rule configuration from `etc/eslint/rules/nodejs.js` (`[ 'error', '^(err|error)$' ]`). After updating the directive, the file lints cleanly. The change is comment-only and does not alter runtime behavior.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

I used AI assistance to identify the stale eslint-disable directive, confirm the rule renaming from the `eslint-plugin-n` migration, and reproduce and verify the failure locally before and after the one-line fix. I reviewed the complete diff.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
