### PR TITLE
test: migrate `stats/base/dists/pareto-type1/skewness` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/skewness/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/skewness/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var skewness = require( './../lib' );
 
 
@@ -105,10 +104,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the skewness of a Pareto (Type I) distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -117,13 +114,7 @@ tape( 'the function returns the skewness of a Pareto (Type I) distribution', fun
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = skewness( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/skewness/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/skewness/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -114,10 +113,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 
 tape( 'the function returns the skewness of a Pareto (Type I) distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -126,13 +123,7 @@ tape( 'the function returns the skewness of a Pareto (Type I) distribution', opt
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = skewness( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the tests for `@stdlib/stats/base/dists/pareto-type1/skewness` from computed EPS-based relative tolerance comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   Replaces the `if ( y === expected[i] ) { ... } else { delta/tol ... }` fixture-loop branches in both `test/test.js` and `test/test.native.js` with a single `t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );` assertion.
-   Drops the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**Final ULP constant: `0` in both `test/test.js` and `test/test.native.js`.**

The bound was tightened agentically rather than assumed. Starting from a loose bound and lowering it, the measured maximum ULP difference between the implementation and the Julia fixtures, computed with `@stdlib/number/float64/base/ulp-difference` over the entire 1000-value fixture set, is **0** — i.e. every fixture value is reproduced bit-for-bit, so `0` is the tightest integer bound possible. The previous tolerance was `1.0 * EPS * abs( expected[i] )`.

`test/test.js` was run twice at the final bound to confirm determinism: 1017/1017 assertions passing on both runs, with no FMA/arch-dependent variation.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

`test/test.native.js` uses the same `0` ULP bound as `test/test.js`. The native add-on could not be compiled in the environment this change was prepared in, so those assertions were exercised as a skip (0 tests) rather than run against the compiled add-on. The bound was chosen on the basis that `src/main.c` transcribes `lib/main.js` expression-for-expression — `2.0 * ( 1.0+alpha ) / ( alpha-3.0 ) * sqrt( ( alpha-2.0 ) / alpha )` — with no multiply-add pattern available for compiler contraction, and that 91 of the 93 already-converted `stats/base/dists` packages use an identical bound in both files. Please confirm the native run is green in CI.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the two test files are modified; no source, fixture, docs, or manifest changes.
-   `make eslint-tests TESTS_FILTER=".*/stats/base/dists/pareto-type1/skewness/.*"` is clean for both files.
-   The idiom mirrors the same-family precedent in `stats/base/dists/gamma/skewness` (#14918), which is also a two-parameter closed-form skewness with a Julia fixture loop and an inline ULP literal rather than a named constant.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task. It selected the package, studied the idiom used by already-merged conversions, applied the conversion, measured the minimum ULP bound empirically against the fixtures, and ran the tests and linter.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mjc2C3ZFHUyspndg4jd1q

---
_Generated by [Claude Code](https://claude.ai/code/session_017Mjc2C3ZFHUyspndg4jd1q)_