### PR TITLE
test: migrate `lapack/base/dlapy2` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/lapack/base/dlapy2/test/test.js
+++ b/lib/node_modules/@stdlib/lapack/base/dlapy2/test/test.js
@@ -78,13 +78,10 @@ tape( 'the function returns `NaN` if either argument is `NaN`', function test( t
 
 tape( 'the function computes the hypotenuse', function test( t ) {
 	var expected;
-	var ULP;
 	var h;
 	var x;
 	var y;
 	var i;
-
-	ULP = 2;
 
 	x = data.x;
 	y = data.y;
@@ -92,7 +89,7 @@ tape( 'the function computes the hypotenuse', function test( t ) {
 
 	for ( i = 0; i < x.length; i++ ) {
 		h = dlapy2( x[ i ], y[ i ] );
-		t.strictEqual( isAlmostSameValue( h, expected[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( h, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/lapack/base/dlapy2/test/test.js
+++ b/lib/node_modules/@stdlib/lapack/base/dlapy2/test/test.js
@@ -22,8 +22,7 @@
 
 var tape = require( 'tape' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
@@ -79,12 +78,13 @@ tape( 'the function returns `NaN` if either argument is `NaN`', function test( t
 
 tape( 'the function computes the hypotenuse', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
+	var ULP;
 	var h;
 	var x;
 	var y;
 	var i;
+
+	ULP = 2;
 
 	x = data.x;
 	y = data.y;
@@ -92,13 +92,7 @@ tape( 'the function computes the hypotenuse', function test( t ) {
 
 	for ( i = 0; i < x.length; i++ ) {
 		h = dlapy2( x[ i ], y[ i ] );
-		if ( h === expected[ i ] ) {
-			t.ok( true, 'x: '+x[i]+'. y: '+y[i]+'. h: '+h+'. Expected: '+expected[i]+'.' );
-		} else {
-			delta = abs( h - expected[ i ] );
-			tol = 1.5 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y[i]+'. h: '+h+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( h, expected[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `lapack/base/dlapy2` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `delta`/`tol` (`1.5 * EPS * abs( expected[i] )`) comparison in the `'the function computes the hypotenuse'` test in `test/test.js` with `t.strictEqual( isAlmostSameValue( h, expected[ i ], ULP ), true, 'returns expected value' );`, adding the `@stdlib/assert/is-almost-same-value` import and removing the now unused `@stdlib/constants/float64/eps` and `@stdlib/math/base/special/abs` imports.
-   collapses the prior `if ( h === expected[ i ] ) { ... } else { ... }` branch, since `isAlmostSameValue` already treats an exact match as passing.

**Final ULP constant:**

| Test | ULP bound |
| ---- | --------- |
| `the function computes the hypotenuse` | `2` |

This is the measured minimum. Starting from a high bound and tightening by directly computing the ULP difference between `dlapy2(x[i], y[i])` and the Julia-derived `expected[i]` for all 2003 fixture pairs, the maximum observed ULP difference is exactly `2`. Verified minimality: `N = 1` produces 15 failing assertions and `N = 0` produces 743 failing assertions, while `N = 2` (and above) produces 0 failures.

The test data is fully deterministic (fixture-driven from `test/fixtures/julia/data.json`, no PRNG), and the suite was run twice at the final bound with identical results:

-   `test/test.js`: 2019 passing, 0 failing (both runs)

`npx eslint lib/node_modules/@stdlib/lapack/base/dlapy2/test/test.js` is clean. This package has no `test/test.native.js` (pure JavaScript implementation, no native binding), so `test/test.js` is the only changed file.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The other test blocks in this file (`'the function computes the hypotenuse (canonical inputs)'`, `'the function avoids overflow'`, `'the function avoids underflow'`, zero/NaN handling) already use exact `t.strictEqual` comparisons against exactly-representable values and were left unchanged, per the RFC's guidance to avoid extraneous changes.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an automated task. The tolerance-to-ULP conversion, the search for the minimum ULP bound, and the local test/lint verification were all performed by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr3us8Az7qFzLnaxiLg8xv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kr3us8Az7qFzLnaxiLg8xv)_