### PR TITLE
test: migrate `stats/base/dists/betaprime/cdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/test/test.cdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( './../lib' );
 
 
@@ -132,10 +131,8 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', function t
 
 tape( 'the function evaluates the cdf for `x` given large `alpha` and `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -146,23 +143,15 @@ tape( 'the function evaluates the cdf for `x` given large `alpha` and `beta`', f
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 100.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 175 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given large `alpha`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -173,23 +162,15 @@ tape( 'the function evaluates the cdf for `x` given large `alpha`', function tes
 	beta = largeAlpha.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 80.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 81 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given large `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -200,13 +181,7 @@ tape( 'the function evaluates the cdf for `x` given large `beta`', function test
 	beta = largeBeta.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 80.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 38 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -185,11 +184,9 @@ tape( 'if provided a nonpositive `alpha`, the created function always returns `N
 
 tape( 'the created function evaluates the cdf for `x` given large `alpha` and `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
 	var cdf;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -201,24 +198,16 @@ tape( 'the created function evaluates the cdf for `x` given large `alpha` and `b
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( alpha[i], beta[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 100.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 175 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given large `alpha`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
 	var cdf;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -230,24 +219,16 @@ tape( 'the created function evaluates the cdf for `x` given large `alpha`', func
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( alpha[i], beta[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 80.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 81 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given large `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
 	var cdf;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -259,13 +240,7 @@ tape( 'the created function evaluates the cdf for `x` given large `beta`', funct
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( alpha[i], beta[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 80.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 38 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the tests for `@stdlib/stats/base/dists/betaprime/cdf` from computed EPS-based relative tolerance comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   Replaces the `if ( y === expected[i] ) { ... } else { delta/tol ... }` fixture-loop branches in both `test/test.cdf.js` and `test/test.factory.js` with a single `t.strictEqual( isAlmostSameValue( y, expected[ i ], N ), true, 'returns expected value' );` assertion.
-   Drops the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**Final ULP constants (identical in `test/test.cdf.js` and `test/test.factory.js`, one per fixture block):**

| Fixture | Previous tolerance | Final ULP bound | Measured max ULP difference |
| --- | --- | --- | --- |
| `both_large.json` | `100.0 * EPS * abs( expected[i] )` | `175` | 175 |
| `large_alpha.json` | `80.0 * EPS * abs( expected[i] )` | `81` | 81 |
| `large_beta.json` | `80.0 * EPS * abs( expected[i] )` | `38` | 38 |

The bounds were tightened empirically rather than assumed. Starting from a loose bound and lowering it, the maximum ULP difference between the implementation and the Julia fixtures was measured over the entire fixture set (1000 values per fixture, 3000 values total) for both the main export and the `factory` path, which agree exactly. Each bound is the tightest integer that passes: at `174`, `80`, and `37` respectively, the corresponding fixture set fails.

The suite was run twice at the final bounds to confirm determinism, with no FMA/arch-dependent variation:

-   `test/test.cdf.js`: 3024/3024 assertions passing on both runs.
-   `test/test.factory.js`: 3028/3028 assertions passing on both runs.
-   `test/test.js`: 3/3 assertions passing on both runs.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

The `both_large` bound of `175` is the largest of the three, which is expected: that fixture drives the incomplete beta function evaluation into the regime where both shape parameters are large, and several fixture values are near the subnormal/underflow end of the range (e.g. `x = 0.059`, `alpha = 23.66`, `beta = 29.65`, expected `2.1864411027246387e-16`). This is comparable to the previous `100 * EPS` relative tolerance and is well within the range of bounds already in use elsewhere in `stats/base/dists`. Please confirm this is acceptable rather than a signal that the implementation itself warrants a follow-up.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the two test files are modified; no source, fixture, docs, or manifest changes. This package has no `test/test.native.js`.
-   `make test TESTS_FILTER=".*/stats/base/dists/betaprime/cdf/.*"` is green and `make eslint-tests TESTS_FILTER=".*/stats/base/dists/betaprime/cdf/.*"` is clean.
-   The idiom mirrors the same-family precedent in `stats/base/dists/pareto-type1/logcdf` (#14948) for the loop rewrite and require ordering, and `stats/base/dists/gamma/quantile` for the use of a distinct inline ULP literal per fixture block rather than a single shared constant.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task. It selected the package, studied the idiom used by already-merged conversions, applied the conversion, measured the minimum ULP bounds empirically against the fixtures, and ran the tests and linter.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197iZ9Zvb5stg7KGYTS2tV7

---
_Generated by [Claude Code](https://claude.ai/code/session_0197iZ9Zvb5stg7KGYTS2tV7)_