### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/array/base/reject/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/reject/docs/types/index.d.ts
@@ -86,7 +86,7 @@ type Predicate<T, U, ThisArg> = Nullary<ThisArg> | Unary<T, ThisArg> | Binary<T,
 * var x = new Float64Array( [ 1.0, -2.0, -3.0, 4.0 ] );
 *
 * var out = reject( x, isPositiveNumber );
-* // returns <Float64Array>[ -2.0, -3.0 ]
+* // returns [ -2.0, -3.0 ]
 */
 declare function reject<T = unknown, U extends InputArray<T> = InputArray<T>, ThisArg = unknown>( x: U, predicate: Predicate<T, U, ThisArg>, thisArg?: ThisParameterType<Predicate<T, U, ThisArg>> ): Array<T>;
 

--- a/lib/node_modules/@stdlib/array/base/setter/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/setter/docs/types/test.ts
@@ -16,6 +16,7 @@
 * limitations under the License.
 */
 
+import Float16Array = require( '@stdlib/array/float16' );
 import setter = require( './index' );
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/lib/native.js
@@ -31,7 +31,7 @@ var addon = require( './../src/addon.node' );
 * @private
 * @param {number} x - input value
 * @param {PositiveNumber} mu - mean
-* @param {PositiveNumber} lambda - shape parameter
+* @param {NonNegativeNumber} lambda - shape parameter
 * @returns {number} evaluated probability density function
 *
 * @example


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-09-03 18:34 PT (61956b30d) and 2026-09-04 05:18 PT (7653b18ee).

This pull request:

-   `array/base/setter`: `import Float16Array = require( '@stdlib/array/float16' )` was dropped from `lib/node_modules/@stdlib/array/base/setter/docs/types/test.ts` in 1038f593e, leaving fourteen `Float16Array` references unresolved (TS2304) since it's not a global under the pinned TS version. Added the import to match every other declaration test file that commit touched.
-   `array/base/reject`: fix `lib/node_modules/@stdlib/array/base/reject/docs/types/index.d.ts`: doc example still showed `<Float64Array>` output after 1038f593e switched the declaration to a single generic returning `Array<T>`. `reject` always returns a plain array (confirmed `Array.isArray(out) === true`), so update the trailing comment to `// returns [ -2.0, -3.0 ]`.
-   `stats/base/dists/wald/pdf`: fixes `lib/native.js:34`'s `lambda` JSDoc type, missed by 0fdb09de5 when the same param was updated in `main.js`/`factory.js`; native's own `@example` blocks already pass `lambda = 0.0`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed on the 26-commit window:

-   Style guide compliance audit against `docs/style-guides`, comparing changed code against established reference packages (including the new `fft/base/fftpack/float32/cosqi` package against sibling fftpack float32 packages): no violations found.
-   Bug scan of the union diff and per-commit diffs (two independent passes): the `cosqi` FFTPACK port, hypergeometric CDF C rewrite, CI benchmark-scoping script change, and all 16 ULP-based test migrations checked out.
-   Deliberately excluded: anything requiring interpretation or judgment calls, subjective style preferences, and fixes that would expand beyond the reviewed changes (e.g. restoring the per-dtype overloads removed from `array/base/reject` — the generic signature matches runtime behavior and appears intentional).
-   Note: the `wald/pdf` fix touches `lib/native.js`, which the originating commit did not modify; it applies the same one-line change that commit made to `main.js`/`factory.js` to the remaining file in the same package.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of a scheduled automated review of commits recently merged to `develop`; findings were cross-validated by multiple independent review passes before fixes were applied.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3Vzim6APTVc2j1edAQDW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3Vzim6APTVc2j1edAQDW4)_