### PR TITLE
test: migrate `stats/base/dists/t/logcdf` to ULP-base assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/t/logcdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/logcdf/test/test.factory.js
@@ -22,11 +22,10 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var LN_HALF = require( '@stdlib/constants/float64/ln-half' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -131,8 +130,6 @@ tape( 'if provided a nonpositive `v`, the created function always returns `NaN`'
 tape( 'the created function evaluates the logcdf for `x` given parameter `v` (when `x` and `v` are small)', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
-	var tol;
 	var i;
 	var v;
 	var x;
@@ -144,13 +141,7 @@ tape( 'the created function evaluates the logcdf for `x` given parameter `v` (wh
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( v[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 11 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -158,8 +149,6 @@ tape( 'the created function evaluates the logcdf for `x` given parameter `v` (wh
 tape( 'the function evaluates the logcdf for `x` given parameter `v` (when `x` is large and `v` small)', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
-	var tol;
 	var i;
 	var v;
 	var x;
@@ -171,13 +160,7 @@ tape( 'the function evaluates the logcdf for `x` given parameter `v` (when `x` i
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( v[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 11 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -185,8 +168,6 @@ tape( 'the function evaluates the logcdf for `x` given parameter `v` (when `x` i
 tape( 'the function evaluates the logcdf for `x` given parameter `v` (when `x` is small and `v` large)', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
-	var tol;
 	var i;
 	var v;
 	var x;
@@ -198,13 +179,7 @@ tape( 'the function evaluates the logcdf for `x` given parameter `v` (when `x` i
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( v[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 14 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -212,8 +187,6 @@ tape( 'the function evaluates the logcdf for `x` given parameter `v` (when `x` i
 tape( 'the function evaluates the logcdf for `x` given parameter `v` (when `x` and `v` are large)', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
-	var tol;
 	var i;
 	var v;
 	var x;
@@ -225,13 +198,7 @@ tape( 'the function evaluates the logcdf for `x` given parameter `v` (when `x` a
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( v[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 30.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 49 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/t/logcdf/test/test.logcdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/logcdf/test/test.logcdf.js
@@ -22,11 +22,10 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var LN_HALF = require( '@stdlib/constants/float64/ln-half' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logcdf = require( './../lib' );
 
 
@@ -101,8 +100,6 @@ tape( 'if provided a nonpositive `v`, the function always returns `NaN`', functi
 
 tape( 'the function evaluates the logcdf for `x` given parameter `v` (when `x` and `v` are small)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -113,21 +110,13 @@ tape( 'the function evaluates the logcdf for `x` given parameter `v` (when `x` a
 	v = smallSmall.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], v[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 11 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given parameter `v` (when `x` is large and `v` small)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -138,21 +127,13 @@ tape( 'the function evaluates the logcdf for `x` given parameter `v` (when `x` i
 	v = largeSmall.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], v[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 11 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given parameter `v` (when `x` is small and `v` large)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -163,21 +144,13 @@ tape( 'the function evaluates the logcdf for `x` given parameter `v` (when `x` i
 	v = smallLarge.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], v[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 14 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given parameter `v` (when `x` and `v` are large)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var y;
@@ -188,13 +161,7 @@ tape( 'the function evaluates the logcdf for `x` given parameter `v` (when `x` a
 	v = largeLarge.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], v[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. v: '+v[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 30.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+v[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 49 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-  migrates the test suite for stats/base/dists/t/logcdf from relative tolerance (EPS/delta/tol) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
- updates test/test.factory.js and test/test.logcdf.js. No other files are changed
- removes the now-unused EPS and abs imports and the corresponding delta/tol variable declarations from each file.
- ULP bounds were verified directly against the fixture data using a script that computes the actual ULP distance between computed and expected values for every input. Verified minimums: small_small=11, large_small=11, small_large=14, large_large=49 (identical across JS and native implementations, confirmed by running the same verification against both).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
