### PR TITLE
fix: avoid integer overflow

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/logpmf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/logpmf/src/main.c
@@ -43,13 +43,19 @@ double stdlib_base_dists_hypergeometric_logpmf( const double x, const int32_t N,
 	double lnum;
 	double maxs;
 	double mins;
+	double dn;
+	double dK;
+	double dN;
 
 	if ( stdlib_base_is_nan( x ) || N < 0 || K < 0 || n < 0 || K > N || n > N ) {
 		return 0.0/0.0; // NaN
 	}
 
-	mins = stdlib_base_max( 0, n+K-N );
-	maxs = stdlib_base_min( K, n );
+	dn = (double)n;
+	dN = (double)N;
+	dK = (double)K;
+	mins = stdlib_base_max( 0.0, dn+dK-dN );
+	maxs = stdlib_base_min( dK, dn );
 
 	if ( stdlib_base_is_nonnegative_integer( x ) && mins <= x && x <= maxs ) {
 		lnum = stdlib_base_factorialln( n ) + stdlib_base_factorialln( K ) + stdlib_base_factorialln( N-n ) + stdlib_base_factorialln( N-K );

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/pmf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/pmf/src/main.c
@@ -44,13 +44,19 @@ double stdlib_base_dists_hypergeometric_pmf( const double x, const int32_t N, co
 	double lpmf;
 	double maxs;
 	double mins;
+	double dn;
+	double dK;
+	double dN;
 
 	if ( stdlib_base_is_nan( x ) || N < 0 || K < 0 || n < 0 || K > N || n > N ) {
 		return 0.0/0.0; // NaN
 	}
 
-	mins = stdlib_base_max( 0, n+K-N );
-	maxs = stdlib_base_min( K, n );
+	dn = (double)n;
+	dN = (double)N;
+	dK = (double)K;
+	mins = stdlib_base_max( 0.0, dn+dK-dN );
+	maxs = stdlib_base_min( dK, dn );
 
 	if ( stdlib_base_is_nonnegative_integer( x ) && mins <= x && x <= maxs ) {
 		lnum = stdlib_base_factorialln( n ) + stdlib_base_factorialln( K ) + stdlib_base_factorialln( N-n ) + stdlib_base_factorialln( N-K );

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/quantile/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/quantile/src/main.c
@@ -36,16 +36,14 @@
 * double y = stdlib_base_dists_hypergeometric_quantile( 0.4, 40, 20, 10 );
 * // returns 5
 */
-double stdlib_base_dists_hypergeometric_quantile(
-	const double p,
-	const int32_t N,
-	const int32_t K,
-	const int32_t n
-) {
+double stdlib_base_dists_hypergeometric_quantile( const double p, const int32_t N, const int32_t K, const int32_t n ) {
+	double upper;
+	double lower;
 	double prob;
-	int32_t upper;
-	int32_t lower;
-	int32_t x;
+	double dn;
+	double dK;
+	double dN;
+	double x;
 
 	if (
 		stdlib_base_is_nan( p ) ||
@@ -60,23 +58,26 @@ double stdlib_base_dists_hypergeometric_quantile(
 		return 0.0 / 0.0;
 	}
 
-	lower = stdlib_base_max( 0, n + K - N );
-	upper = stdlib_base_min( n, K );
+	dn = (double)n;
+	dN = (double)N;
+	dK = (double)K;
+	lower = stdlib_base_max( 0.0, dn+dK-dN );
+	upper = stdlib_base_min( dn, dK );
 
 	if ( p == 0.0 ) {
-		return (double)lower;
+		return lower;
 	}
 	if ( p == 1.0 ) {
-		return (double)upper;
+		return upper;
 	}
 
 	x = lower;
 	while ( x <= upper ) {
-		prob = stdlib_base_dists_hypergeometric_cdf( (double)x, N, K, n );
+		prob = stdlib_base_dists_hypergeometric_cdf( x, N, K, n );
 		if ( prob > p ) {
 			break;
 		}
-		x += 1;
+		x += 1.0;
 	}
-	return (double)x;
+	return x;
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   propagates fixes merged to `develop` between 2026-09-03 and 2026-09-04 to sibling packages.

Propagates the `int32_t` overflow fix from 493166d37 (PR #14933) into the three remaining `hypergeometric` packages that share the defect: `pmf`, `logpmf`, and `quantile` each compute `n+K-N` in 32-bit integer arithmetic prior to conversion to `double`, overflowing for in-domain inputs where `n+K > 2^31-1` (e.g. `N = K = n = 2e9`). Applies the same idiom as the fixed `cdf`: `dn`/`dK`/`dN` double locals feeding `stdlib_base_max( 0.0, dn+dK-dN )`, with `quantile` additionally converting `lower`/`upper`/`x` and its search loop to double (`x += 1.0`) and collapsing its signature to the single-line form used across every other `quantile/src/main.c` in `stats/base/dists`.

Source: 493166d37 ("fix: perform support checks before integer narrowing")

-   `@stdlib/stats/base/dists/hypergeometric/pmf`
-   `@stdlib/stats/base/dists/hypergeometric/logpmf`
-   `@stdlib/stats/base/dists/hypergeometric/quantile`

## Related Issues

> Does this pull request have any related issues?

This pull request has no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed before applying the propagation:

-   All commits merged to `develop` in the last 24 hours were screened for generalizable fixes; five candidate patterns were extracted, and pattern searches were run across the respective sibling namespaces.
-   Two independent validation passes confirmed the defect at each of the three target sites (signed `int32_t` overflow of `n+K-N` is reachable for guard-passing inputs) and confirmed the double-arithmetic rewrite is bit-exact for all non-overflowing inputs.
-   An adaptation pass produced the per-site patches and a style pass confirmed conformance with the fixed `cdf` implementation's idiom (declaration ordering, `dn`/`dK`/`dN` locals, single-line signature convention).
-   Deliberately excluded: 17 candidate JSDoc sites for a second pattern (`{PositiveNumber}` → `{NonNegativeNumber}` lambda, source 0fdb09de5) — all rejected because zero-acceptance at those sites is incidental (no degenerate-case branch) or diverges between JS and native paths; one site (`wald/pdf/lib/native.js`) is already fixed by open PR #14969.
-   All three modified files compile cleanly with `gcc -std=c99 -Wall -Wextra -fsyntax-only`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code as part of an automated fix-propagation routine; each target site was verified by two independent validation passes plus adaptation and style-consistency passes before the patches were applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CyugoNH33WVr8ghD2PhZr

---
_Generated by [Claude Code](https://claude.ai/code/session_015CyugoNH33WVr8ghD2PhZr)_