### PR TITLE
test: migrate `stats/base/dists/triangular/kurtosis` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/kurtosis/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/kurtosis/test/test.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var kurtosis = require( './../lib' );
 
 
@@ -73,8 +72,6 @@ tape( 'if provided parameters not satisfying `a <= c <= b`, the function returns
 
 tape( 'the function returns the excess kurtosis of a triangular distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var c;
@@ -87,13 +84,7 @@ tape( 'the function returns the excess kurtosis of a triangular distribution', f
 	c = data.c;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = kurtosis( a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/kurtosis/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/kurtosis/test/test.native.js
@@ -23,9 +23,8 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -82,8 +81,6 @@ tape( 'if provided parameters not satisfying `a <= c <= b`, the function returns
 
 tape( 'the function returns the excess kurtosis of a triangular distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var c;
@@ -96,13 +93,7 @@ tape( 'the function returns the excess kurtosis of a triangular distribution', o
 	c = data.c;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = kurtosis( a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/triangular/kurtosis` from relative tolerance testing to ULP difference testing.

Both `test/test.js` and `test/test.native.js` are updated. In each, the fixture loop's `delta`/`tol` computation and the `y === expected[i]` special case are replaced with a single `isAlmostSameValue` assertion, and the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires are dropped in favor of `@stdlib/assert/is-almost-same-value`.

**Final ULP constant: `0`** in both `test/test.js` and `test/test.native.js`.

This was tightened from a starting bound of `64` down to the measured minimum. Over the full 500-case Julia fixture set, all returned values are bit-for-bit identical to the expected values, so `0` is both the measured minimum and the floor. This is expected: the excess kurtosis of a triangular distribution is the constant `-3/5`, and both the JavaScript and C implementations return the literal `-0.6` for all valid parameterizations.

Verification:

-   `make test TESTS_FILTER=".*/stats/base/dists/triangular/kurtosis/.*"` — 509 passing in `test/test.js`, 509 passing in `test/test.native.js` (the native add-on was built locally so the native suite actually ran rather than being skipped).
-   The suite was run twice at the final ULP value with identical results, confirming no FMA/architecture-dependent flakiness.
-   `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/triangular/kurtosis/.*"` — clean.
-   Only the two test files are changed; no source, fixture, or documentation files were touched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Opened as a draft.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. It selected the package, mirrored the conversion idiom from previously merged ULP migration PRs, searched for the minimum passing ULP bound, and ran the tests and linter locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrTwxnLH2X9mVqP3AArNwd
