### PR TITLE
chore: add keyword

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/e/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/e/package.json
@@ -59,6 +59,7 @@
     "euler",
     "napier",
     "ieee754",
+    "float",
     "single",
     "precision",
     "floating-point",

--- a/lib/node_modules/@stdlib/constants/float32/ln-two/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/ln-two/package.json
@@ -61,6 +61,7 @@
     "logarithm",
     "log",
     "ieee754",
+    "float",
     "single",
     "sgl",
     "precision",

--- a/lib/node_modules/@stdlib/constants/float32/phi/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/phi/package.json
@@ -69,6 +69,7 @@
     "number",
     "divine",
     "ieee754",
+    "float",
     "single",
     "floating-point",
     "float32"

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/package.json
@@ -62,6 +62,7 @@
     "square",
     "root",
     "ieee754",
+    "float",
     "single",
     "precision",
     "floating-point",

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half/package.json
@@ -62,6 +62,7 @@
     "sqrt1_2",
     "math.sqrt1_2",
     "ieee754",
+    "float",
     "single",
     "floating-point",
     "float32"

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-phi/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-phi/package.json
@@ -69,6 +69,7 @@
     "number",
     "divine",
     "ieee754",
+    "float",
     "single",
     "floating-point",
     "float32",

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/package.json
@@ -60,6 +60,7 @@
     "square",
     "root",
     "ieee754",
+    "float",
     "single",
     "precision",
     "floating-point",

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-three/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-three/package.json
@@ -61,6 +61,7 @@
     "three",
     "sqrt3",
     "ieee754",
+    "float",
     "single",
     "floating-point",
     "float32"

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/package.json
@@ -62,6 +62,7 @@
     "sqrt2",
     "math.sqrt2",
     "ieee754",
+    "float",
     "single",
     "floating-point",
     "float32"


### PR DESCRIPTION
## Description

This pull request adds the missing `float` keyword to nine `@stdlib/constants/float32` packages whose metadata had drifted from the namespace convention.

**Namespace:** `@stdlib/constants/float32` — 68 members (value-export constant modules). Structural and metadata features were extracted across all members; features with a clear ≥75% majority were checked for outliers. Features analyzed with a clear majority: file tree, `package.json` key/scripts/directories shape, `manifest.json` shape, README section structure, and per-keyword presence. Features without a clear majority — JSDoc `@type` (`number` 62%), full keyword-set equality, and `## See Also` (generator-owned) — were excluded.

The `float` keyword is present in 59/68 (87%) members. The nine outliers below lacked it despite their `float64` twins each carrying the analogous width token (`double`/`dbl`), and despite conforming single-precision siblings (`pi`, `ln-pi`, `half-pi`, `sqrt-two-pi`, `ln-half`) carrying `float`. The keyword is inserted after `ieee754` to match sibling ordering. One commit per package.

Packages:

-   `constants/float32/e`
-   `constants/float32/ln-two`
-   `constants/float32/phi`
-   `constants/float32/sqrt-half`
-   `constants/float32/sqrt-half-pi`
-   `constants/float32/sqrt-phi`
-   `constants/float32/sqrt-pi`
-   `constants/float32/sqrt-three`
-   `constants/float32/sqrt-two`

## Related Issues

None.

## Questions

No.

## Other

Metadata-only change; no source, tests, examples, or observable behavior are affected. `keywords` is not referenced by any test or example in the namespace, and the additions pass the `package.json` schema (unique items, valid token pattern).

Deliberately excluded from this PR after review:

-   Adding `float32` to the exponent/precision family (`exponent-bias`, `precision`, the `max`/`min` base2/base10 exponent constants). Their `float64` twins also omit `float64`; the subfamily omits the width token in both namespaces by convention, not drift.
-   Adding `math`/`mathematics` to the safe-integer/factorial/Fibonacci/Lucas/Tribonacci family. Their `float64` twins also omit both keywords — a cross-namespace subfamily convention.
-   A test-local variable rename in `ln-pi`/`num-bytes` — out of scope (test change) and cosmetic.

Validation: structural extraction across all 68 members, followed by three independent reviews (semantic, cross-reference against tests and docs, and structural with a cross-namespace parity check against the `float64` twin packages). Only the `float` group was confirmed as unintentional drift; the two families above were reclassified as intentional and dropped.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This pull request was authored by Claude Code, which performed the cross-package drift analysis, applied the metadata corrections, and drafted this description. All findings were validated against the repository's own conventions and the `float64` twin namespace before inclusion.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199zc489ELpyoA8EB3eDEF7

---
_Generated by [Claude Code](https://claude.ai/code/session_0199zc489ELpyoA8EB3eDEF7)_