### PR TITLE
test: migrate `stats/base/dists/invgamma/logpdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -164,10 +163,8 @@ tape( 'if provided `alpha <= 0`, the created function always returns `NaN`', fun
 tape( 'the created function evaluates the logpdf for `x` given large `alpha` and `beta`', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -179,13 +176,7 @@ tape( 'the created function evaluates the logpdf for `x` given large `alpha` and
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( alpha[ i ], beta[ i ] );
 		y = logpdf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -193,10 +184,8 @@ tape( 'the created function evaluates the logpdf for `x` given large `alpha` and
 tape( 'the created function evaluates the logpdf for `x` given a large shape parameter `alpha`', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -208,13 +197,7 @@ tape( 'the created function evaluates the logpdf for `x` given a large shape par
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( alpha[ i ], beta[ i ] );
 		y = logpdf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -222,10 +205,8 @@ tape( 'the created function evaluates the logpdf for `x` given a large shape par
 tape( 'the created function evaluates the logpdf for `x` given a large scale parameter `beta`', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -237,13 +218,7 @@ tape( 'the created function evaluates the logpdf for `x` given a large scale par
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( alpha[ i ], beta[ i ] );
 		y = logpdf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/test/test.logpdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/test/test.logpdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logpdf = require( './../lib' );
 
 
@@ -116,10 +115,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function evaluates the logpdf for `x` given large `alpha` and `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -130,23 +127,15 @@ tape( 'the function evaluates the logpdf for `x` given large `alpha` and `beta`'
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[ i ], alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpdf for `x` given large shape parameter `alpha`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -157,23 +146,15 @@ tape( 'the function evaluates the logpdf for `x` given large shape parameter `al
 	beta = largeShape.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[ i ], alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpdf for `x` given large scale parameter `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -184,13 +165,7 @@ tape( 'the function evaluates the logpdf for `x` given large scale parameter `be
 	beta = largeRate.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[ i ], alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 5.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -125,10 +124,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 
 tape( 'the function evaluates the logpdf for `x` given large `alpha` and `beta`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -139,23 +136,15 @@ tape( 'the function evaluates the logpdf for `x` given large `alpha` and `beta`'
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[ i ], alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpdf for `x` given large shape parameter `alpha`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -166,23 +155,15 @@ tape( 'the function evaluates the logpdf for `x` given large shape parameter `al
 	beta = largeShape.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[ i ], alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpdf for `x` given large scale parameter `beta`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -193,13 +174,7 @@ tape( 'the function evaluates the logpdf for `x` given large scale parameter `be
 	beta = largeRate.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[ i ], alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 5.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/invgamma/logpdf` from relative tolerance testing to ULP difference testing, per #11352.

Each fixture loop which previously computed `delta`/`tol` against `EPS` now asserts via `@stdlib/assert/is-almost-same-value`:

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], N ), true, 'returns expected value' );
```

The now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires were removed from the affected test files.

### ULP constants

`N` was tightened to the **minimum required** value for each fixture set, measured over the full 1000-element fixture set by starting high and lowering until the smallest integer which still passes. The measured minimums are identical for the JavaScript and native implementations, so the same constants are used in `test.logpdf.js`, `test.factory.js`, and `test.native.js`:

| Fixture set | Previous tolerance (`test.logpdf.js` / `test.native.js`) | Previous tolerance (`test.factory.js`) | Final ULP constant |
| ----------- | ------------------------------------------------------- | -------------------------------------- | ------------------ |
| `both_large` | `1.0 * EPS` | `EPS` | `0` |
| `large_shape` | `1.0 * EPS` | `EPS` | `0` |
| `large_rate` | `5.0 * EPS` | `20.0 * EPS` | `4` |

Notes on the measurement:

-   For `both_large` and `large_shape`, all 1000 fixture values are returned **exactly**, so `0` is the minimum.
-   For `large_rate`, 8 of 1000 values are inexact, with a maximum difference of 4 ULP. `N = 3` fails (1 failing value) and `N = 4` passes, so `4` is exactly minimal rather than merely sufficient.

### Verification

-   `make test TESTS_FILTER=".*/stats/base/dists/invgamma/logpdf/.*"` — 9063 assertions passing, 0 failing.
-   The native addon was built locally (`make install-node-addons`) so that `test.native.js` actually executes rather than skipping; its ULP minimums were measured the same way and match the JavaScript results.
-   The suite was run twice at the final constants with identical results, to confirm there is no FMA/architecture-dependent flakiness.
-   `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/invgamma/logpdf/.*"` is clean.
-   Only the three test files are changed; no fixtures, source, or documentation were touched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running as an unattended scheduled task. The test migration and the empirical ULP bound search were performed by Claude Code; the resulting bounds were verified by running the package test suite locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011f4VNYdb4Z4WCvgbpfyWR3

---
_Generated by [Claude Code](https://claude.ai/code/session_011f4VNYdb4Z4WCvgbpfyWR3)_