### PR TITLE
test: migrate `stats/base/dists/cosine/logpdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/logpdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/logpdf/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -170,8 +169,6 @@ tape( 'if `s` equals `0`, the created function evaluates a degenerate distributi
 tape( 'the created function evaluates the logpdf for `x` given positive `mu`', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
-	var tol;
 	var mu;
 	var s;
 	var x;
@@ -186,13 +183,7 @@ tape( 'the created function evaluates the logpdf for `x` given positive `mu`', f
 		logpdf = factory( mu[i], s[i] );
 		y = logpdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -201,8 +192,6 @@ tape( 'the created function evaluates the logpdf for `x` given positive `mu`', f
 tape( 'the created function evaluates the logpdf for `x` given negative `mu`', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
-	var tol;
 	var mu;
 	var s;
 	var x;
@@ -217,13 +206,7 @@ tape( 'the created function evaluates the logpdf for `x` given negative `mu`', f
 		logpdf = factory( mu[i], s[i] );
 		y = logpdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -232,8 +215,6 @@ tape( 'the created function evaluates the logpdf for `x` given negative `mu`', f
 tape( 'the created function evaluates the logpdf for `x` given large variance ( = large `s`)', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
-	var tol;
 	var mu;
 	var s;
 	var x;
@@ -248,13 +229,7 @@ tape( 'the created function evaluates the logpdf for `x` given large variance ( 
 		logpdf = factory( mu[i], s[i] );
 		y = logpdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 15.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 8 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/logpdf/test/test.logpdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/logpdf/test/test.logpdf.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logpdf = require( './../lib' );
 
 
@@ -127,8 +126,6 @@ tape( 'if provided `s` equal to `0`, the function evaluates a degenerate distrib
 
 tape( 'the function evaluates the logpdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -142,13 +139,7 @@ tape( 'the function evaluates the logpdf for `x` given positive `mu`', function 
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -156,8 +147,6 @@ tape( 'the function evaluates the logpdf for `x` given positive `mu`', function 
 
 tape( 'the function evaluates the logpdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -171,13 +160,7 @@ tape( 'the function evaluates the logpdf for `x` given negative `mu`', function 
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -185,8 +168,6 @@ tape( 'the function evaluates the logpdf for `x` given negative `mu`', function 
 
 tape( 'the function evaluates the logpdf for `x` given large variance ( = large `s` )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -200,13 +181,7 @@ tape( 'the function evaluates the logpdf for `x` given large variance ( = large 
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 15.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 8 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/logpdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/logpdf/test/test.native.js
@@ -23,10 +23,9 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -136,8 +135,6 @@ tape( 'if provided `s` equal to `0`, the function evaluates a degenerate distrib
 
 tape( 'the function evaluates the logpdf for `x` given positive `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -151,13 +148,7 @@ tape( 'the function evaluates the logpdf for `x` given positive `mu`', opts, fun
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -165,8 +156,6 @@ tape( 'the function evaluates the logpdf for `x` given positive `mu`', opts, fun
 
 tape( 'the function evaluates the logpdf for `x` given negative `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -180,13 +169,7 @@ tape( 'the function evaluates the logpdf for `x` given negative `mu`', opts, fun
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -194,8 +177,6 @@ tape( 'the function evaluates the logpdf for `x` given negative `mu`', opts, fun
 
 tape( 'the function evaluates the logpdf for `x` given large variance ( = large `s` )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -209,13 +190,7 @@ tape( 'the function evaluates the logpdf for `x` given large variance ( = large 
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 15.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 8 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of  #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for stats/base/dists/cosine/logpdf from relative tolerance (abs/EPS-based) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
-   updates test/test.factory.js, test/test.logpdf.js, and test/test.native.js. test/test.js contains no fixture-based numeric assertions and required no changes.
-   removes the unused abs and EPS imports and the corresponding delta/tol variable declarations, collapsing each if/else exact-match-or-tolerance branch into a single isAlmostSameValue assertion. The pre-existing `if ( expected[i] !== null )` guard, which skips assertions for fixture rows without a defined reference value, is preserved unchanged.

Measured minimum ULP bounds (identical across the pure JS implementation, the factory-generated function, and the native addon):

| Fixture | ULP |
|---|---|
| positive_mean | 0 |
| negative_mean | 1 |
| large_variance | 8 |

Each bound is the exact maximum observed ULP difference over its fixture (excluding rows with a null expected value), measured separately against the main export, the factory-generated function, and a locally-built native addon (all three converged on the same values). A bound of 0 for positive_mean reflects exact bitwise agreement across all non-null fixture rows for that case.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
