### PR TITLE
test: migrate `stats/base/dists/levy/pdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.factory.js
@@ -25,8 +25,9 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var factory = require( './../lib/factory.js' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var factory = require( './../lib/factory.js' );
+
 
 
 // FIXTURES //

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -137,9 +136,7 @@ tape( 'if provided a nonpositive `c`, the created function always returns `NaN`'
 
 tape( 'the created function evaluates the pdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var pdf;
-	var tol;
 	var mu;
 	var c;
 	var x;
@@ -154,13 +151,7 @@ tape( 'the created function evaluates the pdf for `x` given positive `mu`', func
 		pdf = factory( mu[i], c[i] );
 		y = pdf( x[i] );
 		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -168,9 +159,7 @@ tape( 'the created function evaluates the pdf for `x` given positive `mu`', func
 
 tape( 'the created function evaluates the pdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var pdf;
-	var tol;
 	var mu;
 	var c;
 	var x;
@@ -185,13 +174,7 @@ tape( 'the created function evaluates the pdf for `x` given negative `mu`', func
 		pdf = factory( mu[i], c[i] );
 		y = pdf( x[i] );
 		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -199,9 +182,7 @@ tape( 'the created function evaluates the pdf for `x` given negative `mu`', func
 
 tape( 'the created function evaluates the pdf for `x` given large variance ( = large `c`)', function test( t ) {
 	var expected;
-	var delta;
 	var pdf;
-	var tol;
 	var mu;
 	var c;
 	var x;
@@ -216,13 +197,7 @@ tape( 'the created function evaluates the pdf for `x` given large variance ( = l
 		pdf = factory( mu[i], c[i] );
 		y = pdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.factory.js
@@ -26,6 +26,7 @@ var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var factory = require( './../lib/factory.js' );
+var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.factory.js
@@ -29,7 +29,6 @@ var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
-
 // FIXTURES //
 
 var positiveMean = require( './fixtures/julia/positive_mean.json' );

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.native.js
@@ -27,6 +27,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
+var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.native.js
@@ -24,10 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -104,8 +103,6 @@ tape( 'if provided a nonpositive `c`, the function returns `NaN`', opts, functio
 
 tape( 'the function evaluates the pdf for `x` given positive `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var c;
@@ -119,13 +116,7 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', opts, functi
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], c[i] );
 		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -133,8 +124,6 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', opts, functi
 
 tape( 'the function evaluates the pdf for `x` given negative `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var c;
@@ -148,13 +137,7 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', opts, functi
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], c[i] );
 		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -162,8 +145,6 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', opts, functi
 
 tape( 'the function evaluates the pdf for `x` given large variance ( = large `c` )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var c;
@@ -177,13 +158,7 @@ tape( 'the function evaluates the pdf for `x` given large variance ( = large `c`
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.pdf.js
@@ -29,7 +29,6 @@ var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( './../lib' );
 
 
-
 // FIXTURES //
 
 var positiveMean = require( './fixtures/julia/positive_mean.json' );

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.pdf.js
@@ -26,6 +26,7 @@ var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var pdf = require( './../lib' );
+var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.pdf.js
@@ -25,8 +25,9 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var pdf = require( './../lib' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var pdf = require( './../lib' );
+
 
 
 // FIXTURES //

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/test/test.pdf.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( './../lib' );
 
 
@@ -95,8 +94,6 @@ tape( 'if provided a nonpositive `c`, the function returns `NaN`', function test
 
 tape( 'the function evaluates the pdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var c;
@@ -110,13 +107,7 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', function tes
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], c[i] );
 		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -124,8 +115,6 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', function tes
 
 tape( 'the function evaluates the pdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var c;
@@ -139,13 +128,7 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', function tes
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], c[i] );
 		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -153,8 +136,6 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', function tes
 
 tape( 'the function evaluates the pdf for `x` given large variance ( = large `c` )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var c;
@@ -168,13 +149,7 @@ tape( 'the function evaluates the pdf for `x` given large variance ( = large `c`
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for stats/base/dists/levy/pdf from relative tolerance (abs/EPS-based) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
-   updates test/test.factory.js, test/test.pdf.js, and test/test.native.js. test/test.js contains no fixture-based numeric assertions and required no changes.
-   removes the unused abs import and the delta/tol variable declarations, collapsing each if/else exact-match-or-tolerance branch into a single isAlmostSameValue assertion. The pre-existing guards  `expected[i] !== null` (all blocks) and the additional `!(expected[i] === 0.0 && y < EPS)` zero-magnitude guard (positive_mean and negative_mean blocks only)  are preserved unchanged, including the EPS import, which those guards still require.

Measured minimum ULP bounds (identical across the pure JS implementation, the factory-generated function, and the native addon):

| Fixture | ULP |
|---|---|
| positive_mean | 3 |
| negative_mean | 3 |
| large_variance | 3 |

Each bound is the exact maximum observed ULP difference over its fixture (excluding rows skipped by the pre-existing guards), measured separately against the main export, the factory-generated function, and a locally-built native addon (all three converged on the same value).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
