### PR TITLE
docs: update parameter types

### DIFF
--- a/lib/node_modules/@stdlib/iter/cusome-by/lib/main.js
+++ b/lib/node_modules/@stdlib/iter/cusome-by/lib/main.js
@@ -34,7 +34,7 @@ var iteratorSymbol = require( '@stdlib/symbol/iterator' );
 * Returns an iterator which cumulatively tests whether at least `n` iterated values pass a test implemented by a predicate function.
 *
 * @param {Iterator} iterator - input iterator
-* @param {number} n - the number of items
+* @param {PositiveInteger} n - the number of items
 * @param {Function} predicate - predicate function
 * @param {*} [thisArg] - execution context
 * @throws {TypeError} first argument must be an iterator

--- a/lib/node_modules/@stdlib/iter/push/lib/main.js
+++ b/lib/node_modules/@stdlib/iter/push/lib/main.js
@@ -33,7 +33,7 @@ var format = require( '@stdlib/string/format' );
 * Returns an iterator which appends additional values to the end of a provided iterator.
 *
 * @param {Iterator} iterator - input iterator
-* @param {*} items - values to append
+* @param {...*} items - values to append
 * @throws {TypeError} first argument must be an iterator protocol-compliant object
 * @returns {Iterator} iterator
 *

--- a/lib/node_modules/@stdlib/iter/step/lib/main.js
+++ b/lib/node_modules/@stdlib/iter/step/lib/main.js
@@ -40,7 +40,7 @@ var DEFAULT_LENGTH = 1e308;
 *
 * @param {number} start - starting value (inclusive)
 * @param {number} increment - increment
-* @param {number} [N=1e308] - number of values
+* @param {NonNegativeInteger} [N=1e308] - number of values
 * @throws {TypeError} first argument must be a number
 * @throws {TypeError} second argument must be a number
 * @throws {TypeError} third argument must be a nonnegative integer

--- a/lib/node_modules/@stdlib/iter/unshift/lib/main.js
+++ b/lib/node_modules/@stdlib/iter/unshift/lib/main.js
@@ -33,7 +33,7 @@ var format = require( '@stdlib/string/format' );
 * Returns an iterator which prepends values to the beginning of a provided iterator.
 *
 * @param {Iterator} iterator - input iterator
-* @param {*} items - values to prepend
+* @param {...*} items - values to prepend
 * @throws {TypeError} first argument must be an iterator protocol-compliant object
 * @returns {Iterator} iterator
 *


### PR DESCRIPTION
## Description

This pull request corrects four drifted JSDoc `@param` data type annotations in the `@stdlib/iter` namespace so that each documented type matches the parameter's runtime validation and the surrounding namespace convention. All changes are documentation-only; no runtime behavior, function signatures, or test expectations change.

### Namespace summary

-   Members analyzed: 65 non-autogenerated packages.
-   Features analyzed: file tree, `package.json` shape, README sections, `manifest.json` shape, and test/benchmark/example naming (structural); public signature, return kind, validation prologue, error construction, JSDoc shape, and dependencies (semantic).
-   Features with a clear majority (≥75%): file tree, `package.json` top-level keys, test/benchmark/example naming, error construction (`format`), `@example` presence, iterator-argument validation (`isIteratorLike`), and per-type JSDoc parameter conventions.
-   Features excluded (no clear majority): README `Notes`/`See Also` presence and ordering (`See Also` is generator-owned; `Notes` content is package-specific), and `@throws`/validation-prologue length (these vary with each function's genuine argument set).

### `@stdlib/iter/cusome-by`

`n` is validated with `isPositiveInteger` and its `@throws` tag states the argument must be a positive integer, yet the `@param` type read `{number}`. Corrected to `{PositiveInteger}`, matching the parameter's own validation and the 9/9 sibling packages that document an `isPositiveInteger`-validated count as `{PositiveInteger}`.

### `@stdlib/iter/step`

`N` is validated with `isNonNegativeInteger` and its `@throws` tag states the argument must be a nonnegative integer, yet the `@param` type read `{number}`. Corrected to `{NonNegativeInteger}`, matching the sibling range generators `linspace`, `logspace`, and `datespace`.

### `@stdlib/iter/push`

`items` is a rest parameter collected from `arguments`; the TypeScript declaration and REPL text already document it as `...items`, but the `@param` type read `{*}`. Corrected to `{...*}`, matching the 6/6 sibling packages with a trailing variadic parameter (`concat`, `mapn`, `union`, `intersection`, `pipeline`, `pipeline-thunk`).

### `@stdlib/iter/unshift`

Identical to `push`: `items` is a rest parameter whose `@param` type read `{*}` while the declaration and REPL text already use `...items`. Corrected to `{...*}`.

## Related Issues

No.

## Questions

No.

## Other

Validation performed: structural feature extraction across all 65 members; per-package semantic feature extraction; and a three-agent adversarial review (semantic, cross-reference, structural) of each candidate correction. The cross-reference pass confirmed no test, example, `.d.ts`, or REPL fixture depends on the current annotations, and that the corrected annotations agree with the existing TypeScript declarations.

Deliberately excluded from this pull request:

-   Error-message wording differences in `advance`/`nth` (would change observable thrown-message content).
-   A `linspace` magic-number refactor (only 2/3 comparable siblings share the named-constant pattern — below the 75% threshold).
-   README `Notes`/`See Also` differences (generator-owned, or package-specific prose requiring human authorship).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This pull request was authored by Claude Code (Claude Opus 4.8) running an automated cross-package API-drift detection routine over the `@stdlib/iter` namespace. Claude extracted structural and semantic features from every package, identified the majority convention per feature, validated each candidate with a three-agent adversarial review, and applied the documentation-only corrections. The changes were checked for behavioral and test neutrality.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UM3RoGKRFr5LaA7zSGp8dR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UM3RoGKRFr5LaA7zSGp8dR)_