### PR TITLE
test: migrate `stats/base/dists/levy/quantile` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -125,8 +124,6 @@ tape( 'if provided a negative `c`, the created function always returns `NaN`', f
 tape( 'the created function evaluates the quantile function at `p` given positive `mu`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var p;
@@ -141,13 +138,7 @@ tape( 'the created function evaluates the quantile function at `p` given positiv
 		quantile = factory( mu[i], c[i] );
 		y = quantile( p[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 20.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 33 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -156,8 +147,6 @@ tape( 'the created function evaluates the quantile function at `p` given positiv
 tape( 'the created function evaluates the quantile function at `p` given negative `mu`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var p;
@@ -172,13 +161,7 @@ tape( 'the created function evaluates the quantile function at `p` given negativ
 		quantile = factory( mu[i], c[i] );
 		y = quantile( p[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 350.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 512 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -187,8 +170,6 @@ tape( 'the created function evaluates the quantile function at `p` given negativ
 tape( 'the created function evaluates the quantile function at `p` given large variance ( = large `c`)', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var p;
@@ -203,13 +184,7 @@ tape( 'the created function evaluates the quantile function at `p` given large v
 		quantile = factory( mu[i], c[i] );
 		y = quantile( p[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 30.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 35 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/test/test.native.js
@@ -24,10 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -97,8 +96,6 @@ tape( 'if provided a negative `c`, the function returns `NaN`', opts, function t
 
 tape( 'the function evaluates the quantile function at `p` given positive `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var p;
 	var c;
@@ -112,13 +109,7 @@ tape( 'the function evaluates the quantile function at `p` given positive `mu`',
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], mu[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 20.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 33 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -126,8 +117,6 @@ tape( 'the function evaluates the quantile function at `p` given positive `mu`',
 
 tape( 'the function evaluates the quantile function at `p` given negative `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var p;
 	var c;
@@ -141,13 +130,7 @@ tape( 'the function evaluates the quantile function at `p` given negative `mu`',
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], mu[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 350.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 512 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -155,8 +138,6 @@ tape( 'the function evaluates the quantile function at `p` given negative `mu`',
 
 tape( 'the function evaluates the quantile function at `p` given large variance ( = large `c` )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var p;
 	var c;
@@ -170,13 +151,7 @@ tape( 'the function evaluates the quantile function at `p` given large variance 
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], mu[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 30.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 35 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/test/test.quantile.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/test/test.quantile.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var quantile = require( './../lib' );
 
 
@@ -88,8 +87,6 @@ tape( 'if provided a negative `c`, the function returns `NaN`', function test( t
 
 tape( 'the function evaluates the quantile function at `p` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var p;
 	var c;
@@ -103,13 +100,7 @@ tape( 'the function evaluates the quantile function at `p` given positive `mu`',
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], mu[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 20.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 33 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -117,8 +108,6 @@ tape( 'the function evaluates the quantile function at `p` given positive `mu`',
 
 tape( 'the function evaluates the quantile function at `p` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var p;
 	var c;
@@ -132,13 +121,7 @@ tape( 'the function evaluates the quantile function at `p` given negative `mu`',
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], mu[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 350.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 512 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -146,8 +129,6 @@ tape( 'the function evaluates the quantile function at `p` given negative `mu`',
 
 tape( 'the function evaluates the quantile function at `p` given large variance ( = large `c` )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var p;
 	var c;
@@ -161,13 +142,7 @@ tape( 'the function evaluates the quantile function at `p` given large variance 
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], mu[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 30.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 35 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-    migrates the test suite for stats/base/dists/levy/quantile from relative tolerance (abs/EPS-based) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
-   updates test/test.factory.js, test/test.quantile.js, and test/test.native.js. test/test.js contains no fixture-based numeric assertions and required no changes.
-   removes the unused abs and EPS imports and the corresponding delta/tol variable declarations, collapsing each if/else exact-match-or-tolerance branch into a single isAlmostSameValue assertion. The pre-existing `if ( expected[i] !== null )` guard, which skips assertions for fixture rows without a defined reference value, is preserved unchanged.

Measured minimum ULP bounds (identical across the pure JS implementation, the factory-generated function, and the native addon):

| Fixture | ULP |
|---|---|
| positive_mean | 33 |
| negative_mean | 512 |
| large_variance | 35 |

Each bound is the exact maximum observed ULP difference over its fixture (excluding rows with a null expected value), measured separately against the main export, the factory-generated function, and a locally-built native addon (all three converged on the same values). A bound of 0 for positive_mean reflects exact bitwise agreement across all non-null fixture rows for that case.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
