### PR TITLE
test: migrate `stats/base/dists/cauchy/logpdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/cauchy/logpdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cauchy/logpdf/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -139,9 +138,7 @@ tape( 'if provided a nonpositive `gamma`, the created function always returns `N
 tape( 'the created function evaluates the logpdf for `x` given `x0` and `gamma` (large gamma)', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
 	var gamma;
-	var tol;
 	var x0;
 	var i;
 	var x;
@@ -154,13 +151,7 @@ tape( 'the created function evaluates the logpdf for `x` given `x0` and `gamma` 
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( x0[i], gamma[i] );
 		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', x0: '+x0[i]+', gamma: '+gamma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 6.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. x0: '+x0[i]+'. gamma: '+gamma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 8 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -168,9 +159,7 @@ tape( 'the created function evaluates the logpdf for `x` given `x0` and `gamma` 
 tape( 'the created function evaluates the logpdf for `x` given `x0` and `gamma` (`x0 < 0`)', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
 	var gamma;
-	var tol;
 	var x0;
 	var i;
 	var x;
@@ -183,13 +172,7 @@ tape( 'the created function evaluates the logpdf for `x` given `x0` and `gamma` 
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( x0[i], gamma[i] );
 		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', x0: '+x0[i]+', gamma: '+gamma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. x0: '+x0[i]+'. gamma: '+gamma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -197,9 +180,7 @@ tape( 'the created function evaluates the logpdf for `x` given `x0` and `gamma` 
 tape( 'the created function evaluates the logpdf for `x` given `x0` and `gamma` (`x0 > 0`)', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
 	var gamma;
-	var tol;
 	var x0;
 	var i;
 	var x;
@@ -212,13 +193,7 @@ tape( 'the created function evaluates the logpdf for `x` given `x0` and `gamma` 
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( x0[i], gamma[i] );
 		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', x0: '+x0[i]+', gamma: '+gamma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. x0: '+x0[i]+'. gamma: '+gamma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/cauchy/logpdf/test/test.logpdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cauchy/logpdf/test/test.logpdf.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logpdf = require( './../lib' );
 
 
@@ -112,9 +111,7 @@ tape( 'if provided a nonpositive `gamma`, the function always returns `NaN`', fu
 
 tape( 'the function evaluates the logpdf for `x` given `x0` and `gamma` (large `gamma`)', function test( t ) {
 	var expected;
-	var delta;
 	var gamma;
-	var tol;
 	var x0;
 	var x;
 	var y;
@@ -126,13 +123,7 @@ tape( 'the function evaluates the logpdf for `x` given `x0` and `gamma` (large `
 	gamma = largeGamma.gamma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], x0[i], gamma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', x0 :'+x0[i]+', gamma: '+gamma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 6.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. x0: '+x0[i]+'. gamma: '+gamma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 8 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -140,8 +131,6 @@ tape( 'the function evaluates the logpdf for `x` given `x0` and `gamma` (large `
 tape( 'the function evaluates the logpdf for `x` given `x0` and `gamma` (`x0 < 0`)', function test( t ) {
 	var expected;
 	var gamma;
-	var delta;
-	var tol;
 	var x0;
 	var x;
 	var y;
@@ -153,22 +142,14 @@ tape( 'the function evaluates the logpdf for `x` given `x0` and `gamma` (`x0 < 0
 	gamma = negativeMedian.gamma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], x0[i], gamma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', x0 :'+x0[i]+', gamma: '+gamma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. x0: '+x0[i]+'. gamma: '+gamma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpdf for `x` given `x0` and `gamma` (`x0 > 0`)', function test( t ) {
 	var expected;
-	var delta;
 	var gamma;
-	var tol;
 	var x0;
 	var x;
 	var y;
@@ -180,13 +161,7 @@ tape( 'the function evaluates the logpdf for `x` given `x0` and `gamma` (`x0 > 0
 	gamma = positiveMedian.gamma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], x0[i], gamma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', x0 :'+x0[i]+', gamma: '+gamma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. x0: '+x0[i]+'. gamma: '+gamma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/cauchy/logpdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cauchy/logpdf/test/test.native.js
@@ -24,10 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -121,9 +120,7 @@ tape( 'if provided a nonpositive `gamma`, the function always returns `NaN`', op
 
 tape( 'the function evaluates the logpdf for `x` given `x0` and `gamma` (large `gamma`)', opts, function test( t ) {
 	var expected;
-	var delta;
 	var gamma;
-	var tol;
 	var x0;
 	var x;
 	var y;
@@ -135,13 +132,7 @@ tape( 'the function evaluates the logpdf for `x` given `x0` and `gamma` (large `
 	gamma = largeGamma.gamma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], x0[i], gamma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', x0 :'+x0[i]+', gamma: '+gamma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 6.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. x0: '+x0[i]+'. gamma: '+gamma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 8 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -149,8 +140,6 @@ tape( 'the function evaluates the logpdf for `x` given `x0` and `gamma` (large `
 tape( 'the function evaluates the logpdf for `x` given `x0` and `gamma` (`x0 < 0`)', opts, function test( t ) {
 	var expected;
 	var gamma;
-	var delta;
-	var tol;
 	var x0;
 	var x;
 	var y;
@@ -162,22 +151,14 @@ tape( 'the function evaluates the logpdf for `x` given `x0` and `gamma` (`x0 < 0
 	gamma = negativeMedian.gamma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], x0[i], gamma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', x0 :'+x0[i]+', gamma: '+gamma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. x0: '+x0[i]+'. gamma: '+gamma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpdf for `x` given `x0` and `gamma` (`x0 > 0`)', opts, function test( t ) {
 	var expected;
-	var delta;
 	var gamma;
-	var tol;
 	var x0;
 	var x;
 	var y;
@@ -189,13 +170,7 @@ tape( 'the function evaluates the logpdf for `x` given `x0` and `gamma` (`x0 > 0
 	gamma = positiveMedian.gamma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], x0[i], gamma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', x0 :'+x0[i]+', gamma: '+gamma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. x0: '+x0[i]+'. gamma: '+gamma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/cauchy/logpdf` from computed relative-tolerance comparisons (`delta = abs( y - expected[ i ] )` / `tol = N * EPS * abs( expected[ i ] )`, asserted via `t.ok( delta <= tol, ... )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to `test/test.logpdf.js`, `test/test.factory.js`, and `test/test.native.js` (three fixture blocks in each).
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from all three test files.

Only test files are changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

The same bounds apply to all three test files, since the JavaScript and C implementations return bit-identical results over the full fixture set:

| Fixture block | Fixture | Previous tolerance | ULP bound |
| --- | --- | --- | :-: |
| large `gamma` | `large_gamma.json` | `6.0 * EPS * abs( expected[ i ] )` | `8` |
| `x0 < 0` | `negative_median.json` | `1.0 * EPS * abs( expected[ i ] )` | `1` |
| `x0 > 0` | `positive_median.json` | `1.0 * EPS * abs( expected[ i ] )` | `1` |

Each value is the minimum integer `N` such that `isAlmostSameValue( y, expected[ i ], N )` holds for every entry in that fixture (1,000 values per fixture). Starting from a high bound and tightening, the measured maxima are exactly `8`, `1`, and `1`; re-running the suite with each bound lowered by one (`7`, `0`, `0`) produces 347 failures, confirming these are the minima and not merely sufficient values.

The native add-on was built locally (`NODE_ADDONS_PATTERN="logpdf" make install-node-addons`) so that `test/test.native.js` actually executed rather than being skipped. The C implementation was measured independently against the same fixtures and yields identical maxima (`8`, `1`, `1`), so `test.native.js` uses the same bounds as the JavaScript tests.

The full package suite (`make test TESTS_FILTER=".*/stats/base/dists/cauchy/logpdf/.*"`) was run twice at the final bounds with identical results: 9,057 assertions passing, no skips and no failures on both runs.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The pre-commit static analysis hook could not run in this environment because the EditorConfig lint step attempts to fetch the `editorconfig-checker` binary from GitHub releases, which was not reachable. EditorConfig compliance (LF endings, tab indentation, no trailing whitespace, final newline) was verified manually instead, and `eslint -c etc/eslint/.eslintrc.tests.js` reports no problems for any of the three changed files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously converted packages in the same family to match the established idiom, performed the conversion, and determined the minimum passing ULP bounds empirically over the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

https://claude.ai/code/session_018heKWNYzhPnwqpM7yHeaxm

---
_Generated by [Claude Code](https://claude.ai/code/session_018heKWNYzhPnwqpM7yHeaxm)_