### PR TITLE
test: migrate `stats/base/dists/hypergeometric/mode` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/mode/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/mode/test/test.js
@@ -22,9 +22,8 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mode = require( './../lib' );
 
 
@@ -119,8 +118,6 @@ tape( 'if provided an `n` which is not a nonnegative integer, the function retur
 
 tape( 'the function returns the mode of a hypergeometric distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var N;
 	var K;
 	var n;
@@ -133,13 +130,7 @@ tape( 'the function returns the mode of a hypergeometric distribution', function
 	n = data.n;
 	for ( i = 0; i < n.length; i++ ) {
 		y = mode( N[i], K[i], n[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'N: '+N[i]+', K: '+K[i]+', n: '+n[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. N: '+N[i]+'. K: '+K[i]+'. n: '+n[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/mode/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/mode/test/test.native.js
@@ -24,8 +24,7 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 
 
 // FIXTURES //
@@ -87,8 +86,6 @@ tape( 'if provided an `n` which is not a nonnegative integer, the function retur
 
 tape( 'the function returns the mode of a hypergeometric distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var N;
 	var K;
 	var n;
@@ -101,13 +98,7 @@ tape( 'the function returns the mode of a hypergeometric distribution', opts, fu
 	n = data.n;
 	for ( i = 0; i < n.length; i++ ) {
 		y = mode( N[i], K[i], n[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'N: '+N[i]+', K: '+K[i]+', n: '+n[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. N: '+N[i]+'. K: '+K[i]+'. n: '+n[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/hypergeometric/mode` from relative tolerance testing to ULP difference testing.

Specifically, in both `test/test.js` and `test/test.native.js`, the `if ( y === expected[i] ) { ... } else { delta/tol ... }` fixture-loop branch is replaced with a single assertion, the `@stdlib/assert/is-almost-same-value` require is added, and the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires (along with the `delta` and `tol` locals) are removed.

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
```

**Final ULP constant: `0` for both `test/test.js` and `test/test.native.js`.**

This is the measured minimum. Starting from a high bound and tightening, all 100 Julia fixture values are returned *exactly*: the maximum ULP difference between the returned and expected values across the full fixture set is `0`, so no nonzero budget is required. Both the JavaScript and C implementations evaluate `floor( ( n+1 ) * ( K+1 ) / ( N+2 ) )`, which is an exactly representable small integer for every fixture case, so no rounding slack exists to accommodate.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Notes on verification:

-   `test/test.js` passes 120/120 assertions, run twice to confirm determinism.
-   The native addon could not be compiled in the environment used to prepare this change, so `test/test.native.js` skips locally. To confirm that `0` is also correct for the C implementation, the expression in `src/main.c` was compiled standalone and evaluated against the same fixtures: 0 mismatches across all 100 cases, including under an FMA-permissive build (`-march=native -ffp-contract=fast`).
-   ESLint is clean on both changed files under `etc/eslint/.eslintrc.tests.js`.
-   The only files changed are the two test files.

The idiom follows the already-merged conversions in this family, in particular `stats/base/dists/beta/mode` (#14988), which also tightened to `0`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This PR was authored by Claude Code running as an unattended scheduled task. It selected the package, mirrored the conversion idiom from already-merged PRs in the same family, and measured the minimum ULP bound empirically against the fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7H6KrLos5PV8CfYrD8ygq

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7H6KrLos5PV8CfYrD8ygq)_