### PR TITLE
test: migrate `stats/base/dists/gumbel/variance` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/variance/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var variance = require( './../lib' );
 
 
@@ -76,9 +75,7 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', function t
 
 tape( 'the function returns the variance of a Gumbel distribution', function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -89,13 +86,7 @@ tape( 'the function returns the variance of a Gumbel distribution', function tes
 	for ( i = 0; i < mu.length; i++ ) {
 		y = variance( mu[i], beta[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/variance/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/variance/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -88,9 +87,7 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', opts, func
 
 tape( 'the function returns the variance of a Gumbel distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -101,13 +98,7 @@ tape( 'the function returns the variance of a Gumbel distribution', opts, functi
 	for ( i = 0; i < mu.length; i++ ) {
 		y = variance( mu[i], beta[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/gumbel/variance` from computed relative-tolerance comparisons (`delta = abs( y - expected[ i ] )` / `tol = 2.0 * EPS * abs( expected[ i ] )`, asserted via `t.ok( delta <= tol, ... )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to `test/test.js` and `test/test.native.js` (one fixture block in each).
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from both test files, along with the `delta` and `tol` variable declarations and the redundant `y === expected[ i ]` exact-match branch.

The `if ( expected[i] !== null )` guard is retained, matching the migration of the sibling package `stats/base/dists/gumbel/stdev`.

Only test files are changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| Fixture block | Fixture | Previous tolerance | ULP bound |
| --- | --- | --- | :-: |
| variance of a Gumbel distribution | `julia/data.json` | `2.0 * EPS * abs( expected[ i ] )` | `1` |

`1` is the minimum integer `N` such that `isAlmostSameValue( y, expected[ i ], N )` holds for every entry in the fixture. Starting from a high bound and tightening, the measured maximum ULP difference over the 100 fixture values is exactly `1`: 59 values are bit-identical to the reference and the remaining 41 differ by a single ULP. Re-running the suite with the bound lowered to `0` produces 41 failures, confirming `1` is the minimum and not merely a sufficient value.

The native add-on was built locally (`NODE_ADDONS_PATTERN="gumbel/variance" make install-node-addons`) so that `test/test.native.js` actually executed rather than being skipped. The C implementation was measured independently against the same fixtures and yields an identical maximum (`1`, with the same 59/41 split), so `test.native.js` uses the same bound as the JavaScript tests.

The full package suite (`make test TESTS_FILTER=".*/stats/base/dists/gumbel/variance/.*"`) was run twice at the final bound with identical results: `test.js` 110/110 passing and `test.native.js` 111/111 passing, no skips and no failures on both runs.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The EditorConfig lint step could not run in this environment because it attempts to fetch the `editorconfig-checker` binary from GitHub releases, which was not reachable. EditorConfig compliance (LF endings, tab indentation, no trailing whitespace, final newline) was verified manually instead, and `eslint -c etc/eslint/.eslintrc.tests.js` reports no problems for either changed file.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously converted packages in the same family to match the established idiom, performed the conversion, and determined the minimum passing ULP bound empirically over the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vBForGQDHUjtG73Vv2mYM

---
_Generated by [Claude Code](https://claude.ai/code/session_012vBForGQDHUjtG73Vv2mYM)_