### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/lapack/base/zlaswp/test/test.zlaswp.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlaswp/test/test.zlaswp.js
@@ -44,7 +44,6 @@ var COL_MAJOR_IPIV_STRIDE_NEG = require( './fixtures/column_major_ipiv_stride_ne
 var COL_MAJOR_LDA = require( './fixtures/column_major_lda.json' );
 var COL_MAJOR_REV_PIVOTS = require( './fixtures/column_major_reverse_pivots.json' );
 var COL_MAJOR_K1 = require( './fixtures/column_major_k1.json' );
-
 var ROW_MAJOR = require( './fixtures/row_major_no_offsets.json' );
 var ROW_MAJOR_IPIV_STRIDE_POS = require( './fixtures/row_major_ipiv_stride_positive.json' );
 var ROW_MAJOR_IPIV_STRIDE_NEG = require( './fixtures/row_major_ipiv_stride_negative.json' );

--- a/lib/node_modules/@stdlib/string/base/uppercase/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/uppercase/lib/main.js
@@ -31,7 +31,7 @@
 * // returns 'BEEP'
 */
 function uppercase( str ) {
-	return str.toUpperCase();
+	return str.toUpperCase(); // eslint-disable-line no-restricted-syntax
 }
 
 


### PR DESCRIPTION
resolves #14920

## Description

> What is the purpose of this pull request?

This pull request:

- Fixes the JavaScript lint errors reported in #14920.
- Adds a line-local ESLint exception for the native `String.prototype.toUpperCase()` usage in `@stdlib/string/base/uppercase`.
- Removes the unexpected empty line between `require` statements in the `zlaswp` test.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- #14920

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

- `git diff --check` passes.
- Focused `uppercase` tests pass.
- Focused `zlaswp` tests pass.
- Filtered repository tests pass.
- Full ESLint validation could not be completed locally because `@stylistic/eslint-plugin-ts` is missing from the local environment.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Copilot was used to assist with understanding the reported lint errors and implementing the two minimal changes required to address them. I reviewed the resulting diff and validation results before committing the changes.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md