### PR TITLE
docs: update parameter type

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/wald/cdf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/cdf/lib/native.js
@@ -31,7 +31,7 @@ var addon = require( './../src/addon.node' );
 * @private
 * @param {number} x - input value
 * @param {PositiveNumber} mu - mean
-* @param {number} lambda - shape parameter
+* @param {NonNegativeNumber} lambda - shape parameter
 * @returns {Probability} evaluated cumulative distribution function
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/logcdf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/logcdf/lib/native.js
@@ -31,7 +31,7 @@ var addon = require( './../src/addon.node' );
 * @private
 * @param {number} x - input value
 * @param {PositiveNumber} mu - mean
-* @param {number} lambda - shape parameter
+* @param {NonNegativeNumber} lambda - shape parameter
 * @returns {number} evaluated logCDF
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/logpdf/lib/native.js
@@ -31,7 +31,7 @@ var addon = require( './../src/addon.node' );
 * @private
 * @param {number} x - input value
 * @param {PositiveNumber} mu - mean
-* @param {number} lambda - shape parameter
+* @param {NonNegativeNumber} lambda - shape parameter
 * @returns {number} evaluated logPDF
 *
 * @example


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   propagates fixes merged to `develop` between `c21221c1a` (2026-09-04) and `7993e08c4` (2026-09-05) to sibling packages.

### Propagated fix: `lambda` domain in Wald distribution `native.js` docs

30e311697 ("chore: clean-up") aligned the `lambda` JSDoc type in `@stdlib/stats/base/dists/wald/pdf/lib/native.js` with `lib/main.js`, changing `{PositiveNumber}` to `{NonNegativeNumber}`. `lambda === 0` is a handled degenerate case; validation rejects only negative values, so `pdf`'s `main.js`, `factory.js`, and both JS and C implementations already document and accept a non-negative domain — only `native.js` lagged with the stricter positive-only type. The same mismatch exists in the sibling Wald distribution functions and needs the identical one-line correction:

-   `stats/base/dists/wald/cdf/lib/native.js`
-   `stats/base/dists/wald/logcdf/lib/native.js`
-   `stats/base/dists/wald/logpdf/lib/native.js`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed before applying the changes:

-   All 39 commits merged to `develop` in the 24-hour window were reviewed for propagatable fix patterns; candidate patterns from `810e5f590` (int32 overflow), `c21221c1a` (missing option validation), `42bbbb1d6` (benchmark require path), `b04bbafa8` (JSDoc parameter types), `39365ed17` (README copy), and `1d377422c` (expired TLS fixtures) were searched across their respective namespaces and yielded zero remaining sites — the repository is already consistent for those patterns.
-   For the surviving pattern, each target site was verified independently twice against the package's `lib/main.js`, `lib/factory.js`, JS validation logic, and C implementation (`src/main.c`), confirming `lambda === 0` is an explicitly handled degenerate case at every site.
-   Remaining `wald` packages (`kurtosis`, `mean`, `mgf`, `mode`, `quantile`, `skewness`, `stdev`, `variance`) were checked and are already consistent (`{PositiveNumber}` there is correct, as validation rejects `lambda <= 0`).
-   Deliberately excluded: `wald/quantile/lib/bisect.js` (internal helper invoked only after argument screening), and TypeScript declaration files (TS has no `NonNegativeNumber` type).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated fix-propagation routine: it identified the source commit, located sibling packages with the same documentation mismatch, and applied the equivalent one-line fixes after multi-pass automated validation.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpSMAc3bMjNLZnyKm6WXbt

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpSMAc3bMjNLZnyKm6WXbt)_