### PR TITLE
test: migrate `stats/incr/mvmr` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/mvmr/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/mvmr/test/test.js
@@ -22,9 +22,8 @@
 
 var tape = require( 'tape' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var zeros = require( '@stdlib/array/base/zeros' );
 var incrmvmr = require( './../lib' );
 
@@ -196,9 +195,7 @@ tape( 'the accumulator function computes a moving variance-to-mean ratio increme
 tape( 'if not provided an input value, the accumulator function returns the current accumulated value', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
-	var tol;
 	var acc;
 	var i;
 
@@ -213,19 +210,15 @@ tape( 'if not provided an input value, the accumulator function returns the curr
 
 	expected = 19.0/5.0;
 	actual = acc();
-	delta = abs( actual - expected );
-	tol = EPS * expected;
 
-	t.strictEqual( delta < tol, true, 'expected: '+expected+'. actual: '+actual+'. tol: '+tol+'. delta: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( actual, expected, 0 ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if not provided an input value, the accumulator function returns the current accumulated value (known mean)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
-	var tol;
 	var acc;
 	var i;
 
@@ -240,10 +233,8 @@ tape( 'if not provided an input value, the accumulator function returns the curr
 
 	expected = 12.666666666666666/5.0;
 	actual = acc();
-	delta = abs( actual - expected );
-	tol = EPS * expected;
 
-	t.strictEqual( delta < tol, true, 'expected: '+expected+'. actual: '+actual+'. tol: '+tol+'. delta: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( actual, expected, 0 ), true, 'returns expected value' );
 	t.end();
 });
 


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/incr/mvmr` from computed relative-tolerance assertions to ULP-difference assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].

Specifically, in `test/test.js`:

-   replaces the `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires with `@stdlib/assert/is-almost-same-value`.
-   removes the `delta`/`tol` scratch variables from the two affected test blocks.
-   replaces `t.strictEqual( delta < tol, true, ... )` with `t.strictEqual( isAlmostSameValue( actual, expected, 0 ), true, 'returns expected value' );`.

The package has no `test/test.native.js`, so `test/test.js` is the only changed file. Pre-existing exact comparisons elsewhere in the file (`t.strictEqual`, `t.deepEqual`, and the `isnan` fixture-loop branches) are left untouched.

### ULP bound

The final ULP constant is **`0`** for both converted assertions, which is the measured minimum and the tightest bound expressible:

| Test block | `expected` | `actual` | measured ULP diff |
| --- | --- | --- | :-: |
| `acc()` returns the current accumulated value | `19.0/5.0` (`3.8`) | `3.8` | 0 |
| `acc()` returns the current accumulated value (known mean) | `12.666666666666666/5.0` (`2.533333333333333`) | `2.533333333333333` | 0 |

Both accumulator results are bit-identical to the expected values, so `0` is both the measured maximum ULP difference and the floor for `isAlmostSameValue`. The bound is not vacuous: `isAlmostSameValue( x, y, 0 )` is `true` only for bit-identical values (verified directly against a neighbouring double).

The previous tolerance was `1.0 * EPS * expected` (roughly 2 ULP at these magnitudes), so this migration tightens the accuracy budget for this package.

The full package suite (`make test TESTS_FILTER=".*/stats/incr/mvmr/.*"`) was run twice at the final bound with identical results: 396 assertions passing, no skips and no failures on both runs. `make lint-javascript-tests TESTS_FILTER=".*/stats/incr/mvmr/.*"` reports no problems.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The pre-commit static analysis hook could not run in this environment because the EditorConfig lint step attempts to fetch the `editorconfig-checker` binary from GitHub releases, which was not reachable. EditorConfig compliance (LF endings, UTF-8, tab indentation, no trailing whitespace, final newline) was verified manually instead.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously converted packages in the same family to match the established idiom, performed the conversion, and determined the minimum passing ULP bound empirically.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mjhs9W8ix61Uhr9tyD8phw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mjhs9W8ix61Uhr9tyD8phw)_