### PR TITLE
docs: add missing notes sections to output-mutating `blas/ext/base/ndarray` packages

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cwxsa/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cwxsa/README.md
@@ -70,6 +70,10 @@ The function has the following parameters:
 
 <section class="notes">
 
+## Notes
+
+-   The output ndarray is modified **in-place** (i.e., the output ndarray is **mutated**).
+
 </section>
 
 <!-- /.notes -->

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dwxsa/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dwxsa/README.md
@@ -69,6 +69,10 @@ The function has the following parameters:
 
 <section class="notes">
 
+## Notes
+
+-   The output ndarray is modified **in-place** (i.e., the output ndarray is **mutated**).
+
 </section>
 
 <!-- /.notes -->

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gwxpy/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gwxpy/README.md
@@ -80,6 +80,10 @@ The function has the following parameters:
 
 <section class="notes">
 
+## Notes
+
+-   The output ndarray is modified **in-place** (i.e., the output ndarray is **mutated**).
+
 </section>
 
 <!-- /.notes -->

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gwxsa/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gwxsa/README.md
@@ -69,6 +69,10 @@ The function has the following parameters:
 
 <section class="notes">
 
+## Notes
+
+-   The output ndarray is modified **in-place** (i.e., the output ndarray is **mutated**).
+
 </section>
 
 <!-- /.notes -->

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/swxsa/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/swxsa/README.md
@@ -69,6 +69,10 @@ The function has the following parameters:
 
 <section class="notes">
 
+## Notes
+
+-   The output ndarray is modified **in-place** (i.e., the output ndarray is **mutated**).
+
 </section>
 
 <!-- /.notes -->

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/zwxsa/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/zwxsa/README.md
@@ -70,6 +70,10 @@ The function has the following parameters:
 
 <section class="notes">
 
+## Notes
+
+-   The output ndarray is modified **in-place** (i.e., the output ndarray is **mutated**).
+
 </section>
 
 <!-- /.notes -->


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request populates the empty `notes` section in the README of six output-mutating `blas/ext/base/ndarray` packages, adding the canonical in-place-mutation note that 217/223 (97%) of their siblings already carry.

**Namespace summary (`@stdlib/blas/ext/base/ndarray`).** 223 members analyzed. Structural features (file tree, `package.json` shape, README section set/order, test/benchmark/example naming) and semantic features (public signature, validation prologue, error construction, JSDoc shape, dependencies) were extracted per package. Features with a clear ≥75% majority: file tree (100%), `package.json` top-level keys (100%), test/benchmark/example file naming (100%), and the README `## Notes` section (97%). Features excluded for lack of a clear majority: `package.json` `scripts` key set (predominantly empty), `returnKind` (genuinely bimodal — reducers return a value, mappers mutate an ndarray), and the validation-prologue / error-construction dimensions (absent namespace-wide, since these are thin wrappers delegating to `@stdlib/blas/ext/base/<name>`).

The six packages below each carry an *empty* `<section class="notes">` scaffold — the `## Notes` heading and bullet were omitted when the packages were scaffolded (all added together on 2026-08-29). Each assigns results to a separate output ndarray and mutates it in place, so the standard output-mutation note applies, matching 24 output-mutating siblings (e.g. `gxpy`, `gaxpby`).

### `blas/ext/base/ndarray/cwxsa`

Subtracts a single-precision complex floating-point scalar from an input ndarray, writing to a separate output ndarray. The notes section was an empty scaffold; the output ndarray is mutated in-place, matching 24 output-mutating siblings and the 97% namespace convention. Adds the missing in-place note.

### `blas/ext/base/ndarray/dwxsa`

Subtracts a double-precision floating-point scalar from an input ndarray into a separate output ndarray. Empty notes scaffold left behind at scaffolding time; the function mutates the output ndarray in-place. Adds the canonical note present in 97% of the namespace.

### `blas/ext/base/ndarray/gwxsa`

Generic-precision variant subtracting a scalar from an input ndarray into a separate output ndarray. Notes scaffold was empty despite the output ndarray being mutated in-place, exactly as in its typed siblings. Adds the missing in-place note (97% conformance).

### `blas/ext/base/ndarray/swxsa`

Single-precision floating-point scalar subtraction into a separate output ndarray. The output ndarray is mutated in-place; the notes section was an empty scaffold. Adds the canonical output-mutation note shared by 24 siblings.

### `blas/ext/base/ndarray/zwxsa`

Double-precision complex floating-point scalar subtraction into a separate output ndarray. Empty notes scaffold; output ndarray mutated in-place. Adds the missing in-place note (present in 97% of the namespace).

### `blas/ext/base/ndarray/gwxpy`

Adds two input ndarrays elementwise into a third, separate output ndarray, mutating it in-place. The notes section was an empty scaffold; the direct analog `gxpy` carries the canonical note. Adds the missing in-place note (97% conformance).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

**Validation.** Structural features were extracted from the filesystem; semantic features via a programmatic source scan across all 223 members (confirming the validation-prologue and error-construction dimensions are empty namespace-wide, and that the `returnKind` and dependency-set variation reflects genuine 1-D-reducer / 1-D-mapper / 2-D-matrix functional differences rather than drift). The single surviving candidate — six READMEs missing the `## Notes` section — passed three-agent validation (semantic-review, cross-reference, and structural-review), each returning `confirmed-drift` for all six packages, with tests/examples confirmed independent of the change.

**Deliberately excluded** (no correction proposed): the 10 native-C-addon packages' `include/*.h` + `manifest.json` files (a legitimate native-binding subset, not drift); the 17 `tril`/`triu` packages' differing dependency set (2-D matrix operations legitimately requiring different ndarray accessors); `returnKind` bimodality; and all features without a ≥75% majority.

This is a documentation-only change — no source, test, example, or type-declaration files were modified (24 insertions across 6 README files, 4 lines each).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running an automated cross-package drift-detection routine. Claude enumerated the namespace, extracted structural and semantic features per package, computed the per-feature majority pattern, validated the single surviving finding with a three-agent review, and applied the documentation fix. All changes were verified against sibling-package conventions.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Yk9q6NEhcnwGE9WKZxYF3

---
_Generated by [Claude Code](https://claude.ai/code/session_016Yk9q6NEhcnwGE9WKZxYF3)_