### PR TITLE
test: migrate `stats/base/dists/betaprime/pdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/pdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -161,11 +160,9 @@ tape( 'if provided `alpha <= 0`, the created function always returns `NaN`', fun
 
 tape( 'the created function evaluates the pdf for `x` given large `alpha` and `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
 	var pdf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -177,24 +174,16 @@ tape( 'the created function evaluates the pdf for `x` given large `alpha` and `b
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( alpha[i], beta[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 290.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 451 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the pdf for `x` given a large `alpha`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
 	var pdf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -206,24 +195,16 @@ tape( 'the created function evaluates the pdf for `x` given a large `alpha`', fu
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( alpha[i], beta[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 150.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 134 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the pdf for `x` given a large `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
 	var pdf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -235,13 +216,7 @@ tape( 'the created function evaluates the pdf for `x` given a large `beta`', fun
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( alpha[i], beta[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 250.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 138 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/pdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -131,10 +130,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 
 tape( 'the function evaluates the pdf for `x` given large `alpha` and `beta`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -145,23 +142,15 @@ tape( 'the function evaluates the pdf for `x` given large `alpha` and `beta`', o
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 290.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 451 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given large `alpha`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -172,23 +161,15 @@ tape( 'the function evaluates the pdf for `x` given large `alpha`', opts, functi
 	beta = largeAlpha.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 150.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 134 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given large `beta`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -199,13 +180,7 @@ tape( 'the function evaluates the pdf for `x` given large `beta`', opts, functio
 	beta = largeBeta.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 250.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 138 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/pdf/test/test.pdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( './../lib' );
 
 
@@ -122,10 +121,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function evaluates the pdf for `x` given large `alpha` and `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -136,23 +133,15 @@ tape( 'the function evaluates the pdf for `x` given large `alpha` and `beta`', f
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 290.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 451 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given large `alpha`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -163,23 +152,15 @@ tape( 'the function evaluates the pdf for `x` given large `alpha`', function tes
 	beta = largeAlpha.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 150.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 134 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given large `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -190,13 +171,7 @@ tape( 'the function evaluates the pdf for `x` given large `beta`', function test
 	beta = largeBeta.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 250.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 138 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the tests for `@stdlib/stats/base/dists/betaprime/pdf` from computed EPS-based relative tolerance comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   Replaces the `if ( y === expected[i] ) { ... } else { delta/tol ... }` fixture-loop branches in `test/test.pdf.js`, `test/test.factory.js`, and `test/test.native.js` with a single `t.strictEqual( isAlmostSameValue( y, expected[ i ], N ), true, 'returns expected value' );` assertion.
-   Drops the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**Final ULP constants (identical in all three test files, one per fixture block):**

| Fixture | Previous tolerance | Final ULP bound | Measured max ULP difference |
| --- | --- | --- | --- |
| `both_large.json` | `290.0 * EPS * abs( expected[i] )` | `451` | 451 |
| `large_alpha.json` | `150.0 * EPS * abs( expected[i] )` | `134` | 134 |
| `large_beta.json` | `250.0 * EPS * abs( expected[i] )` | `138` | 138 |

The bounds were tightened empirically rather than assumed. Starting from a loose bound and lowering it, the maximum ULP difference between the implementation and the Julia fixtures was measured over the entire fixture set (1000 values per fixture, 3000 values total) for both the main export and the `factory` path, which agree exactly. Each bound is the tightest integer that passes: at `450`, `133`, and `137` respectively, the corresponding fixture set fails with exactly one failing assertion.

The suite was run twice at the final bounds to confirm determinism, with no FMA/arch-dependent variation:

-   `test/test.pdf.js`: 3021/3021 assertions passing on both runs.
-   `test/test.factory.js`: 3024/3024 assertions passing on both runs.
-   `test/test.js`: 3/3 assertions passing on both runs.
-   `test/test.native.js`: skipped (the native add-on is not built in this environment), so its bounds mirror the JS ones, consistent with the same-family precedent noted below.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves a part of #11352

## Questions

> Any questions for reviewers of this pull request?

Two things worth a reviewer's eye:

1.  The `both_large` bound of `451` is the largest of the three and is noticeably looser than the `175` used for the sibling `stats/base/dists/betaprime/cdf` (#14962). The error distribution over that fixture is smooth rather than driven by a single outlier (median 57 ULP, p90 165, p99 293, max 451), which is consistent with error accumulating through the `betaln`/`pow` evaluation when both shape parameters are large, and it sits within the previous `290 * EPS` relative tolerance. I believe this is a faithful measurement rather than a signal of a defect, but please confirm you are comfortable with a bound this size rather than treating it as motivation for a follow-up look at the implementation.
2.  `test/test.native.js` could not be executed here because the native add-on is not built, so its ULP values are the measured JS ones rather than independently measured against the C implementation. Every already-converted package I checked (`invgamma/logpdf`, `cauchy/logpdf`, `levy/pdf`) uses identical values across the JS and native test files, so this follows precedent, but it is worth a reviewer confirming against a build with the add-on compiled.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the three test files are modified; no source, fixture, docs, or manifest changes.
-   The idiom mirrors the same-family precedent in `stats/base/dists/betaprime/cdf` (#14962) and `stats/base/dists/invgamma/logpdf` (#14981): a distinct inline ULP literal per fixture block rather than a single shared named constant, `isAlmostSameValue` required immediately after `tape`, and the assertion message normalized to `'returns expected value'`.
-   Verification note: `make install-node-modules` could not complete in this environment because the reachable npm registry snapshot does not contain `es-object-atoms@^1.1.2`, which a transitive dependency requires. Tests and linting were therefore run against a dependency tree installed with that package pinned to `1.1.1`. `tape` and the repo's own ESLint configuration (`etc/eslint/.eslintrc.tests.js`, including the local `eslint-plugin-stdlib` rules) both ran successfully; ESLint reports no findings on the three changed files. The EditorConfig and dependency-license hooks could not run because they require network access outside this session's scope, so EditorConfig compliance (LF endings, UTF-8, tabs, no trailing whitespace, final newline) was verified manually instead.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task. It selected the package, studied the idiom used by already-merged conversions, applied the conversion, measured the minimum ULP bounds empirically against the fixtures, and ran the tests and linter.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkCFfgEc15grCX9Zku69DQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkCFfgEc15grCX9Zku69DQ)_