### PR TITLE
test: migrate `stats/base/dists/levy/median` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/levy/median/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/median/test/test.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var median = require( './../lib' );
 
 
@@ -76,8 +75,6 @@ tape( 'if provided a nonpositive `c`, the function returns `NaN`', function test
 
 tape( 'the function returns the median of a Lévy distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var y;
@@ -89,13 +86,7 @@ tape( 'the function returns the median of a Lévy distribution', function test( 
 	for ( i = 0; i < mu.length; i++ ) {
 		y = median( mu[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/median/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/median/test/test.native.js
@@ -24,10 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -88,8 +87,6 @@ tape( 'if provided a nonpositive `c`, the function returns `NaN`', opts, functio
 
 tape( 'the function returns the median of a Lévy distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var y;
@@ -101,13 +98,7 @@ tape( 'the function returns the median of a Lévy distribution', opts, function 
 	for ( i = 0; i < mu.length; i++ ) {
 		y = median( mu[i], c[i] );
 		if ( expected[i] !== null) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/median/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/median/test/test.native.js
@@ -97,7 +97,7 @@ tape( 'the function returns the median of a Lévy distribution', opts, function 
 	c = data.c;
 	for ( i = 0; i < mu.length; i++ ) {
 		y = median( mu[i], c[i] );
-		if ( expected[i] !== null) {
+		if ( expected[i] !== null ) {
 			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}


### PR DESCRIPTION
Resolves a part of  #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for stats/base/dists/levy/median from relative tolerance (EPS/delta/tol) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
-   updates test/test.js and test/test.native.js. No other files are changed.
-   removes the now-unused EPS and abs imports and the corresponding delta/tol variable declarations from each file.
-   the ULP bound was verified directly against the fixture data using a script that computes the actual ULP distance between computed and expected values for every input. Verified minimum: 1 (all fixture values matched exactly on both JS and native, confirmed by running the verification against both implementations).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
