### PR TITLE
chore: fix EditorConfig lint errors (issue #14500)

### DIFF
--- a/lib/node_modules/@stdlib/plot/ctor/lib/props/x-rug-orient/orientations.json
+++ b/lib/node_modules/@stdlib/plot/ctor/lib/props/x-rug-orient/orientations.json
@@ -1,4 +1,4 @@
 [
-	"bottom",
-	"top"
+  "bottom",
+  "top"
 ]


### PR DESCRIPTION
Resolves #14500.

## Description

This pull request replaces the tab indentation on the two values in `orientations.json` with spaces, matching the repository’s EditorConfig requirement and fixing the reported lint failure.

## Related Issues

This pull request has the following related issues:

- #14500

## Questions

No.

## Other

Verification: reviewed the whitespace-only diff against the issue’s exact failing lines. The full project lint was not run locally; CI will validate the EditorConfig check.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

- [x] Yes
- [ ] No

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

This PR was prepared with assistance from an AI coding agent, which identified the issue, applied the whitespace-only fix, and reviewed the diff. The contribution author reviewed the final change before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md