### PR TITLE
test: migrate `blas/base/srotm` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/srotm/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/srotm/test/test.ndarray.js
@@ -23,8 +23,7 @@
 var tape = require( 'tape' );
 var Float32Array = require( '@stdlib/array/float32' );
 var scopy = require( '@stdlib/blas/base/scopy' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var srotm = require( './../lib/ndarray.js' );
 
 
@@ -37,22 +36,14 @@ var srotm = require( './../lib/ndarray.js' );
 * @param {Object} t - test object
 * @param {Collection} actual - actual values
 * @param {Collection} expected - expected values
-* @param {number} rtol - relative tolerance
+* @param {NonNegativeInteger} ulp - maximum allowed ULP difference
 */
-function isApprox( t, actual, expected, rtol ) {
-	var delta;
-	var tol;
+function isApprox( t, actual, expected, ulp ) {
 	var i;
 
 	t.strictEqual( actual.length, expected.length, 'returns expected value' );
 	for ( i = 0; i < expected.length; i++ ) {
-		if ( actual[ i ] === expected[ i ] ) {
-			t.strictEqual( actual[ i ], expected[ i ], 'returns expected value' );
-		} else {
-			delta = abs( actual[ i ] - expected[ i ] );
-			tol = rtol * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. actual: '+actual[ i ]+'. expected: '+expected[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( actual[ i ], expected[ i ], ulp ), true, 'returns expected value' );
 	}
 }
 
@@ -75,6 +66,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=1, sy=1)', func
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var ox;
 	var oy;
 	var xe;
@@ -84,6 +76,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=1, sy=1)', func
 	var y;
 	var i;
 
+	ULP = 1;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -111,8 +104,8 @@ tape( 'the function applies a modified Givens plane rotation (sx=1, sy=1)', func
 		x = new Float32Array( xbuf );
 		y = new Float32Array( ybuf );
 		out = srotm( N[ i ], x, 1, ox[ i ], y, 1, oy[ i ], param );
-		isApprox( t, x, xe[ i ], 5.0 );
-		isApprox( t, y, ye[ i ], 5.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -123,6 +116,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=2, sy=-2)', fun
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var ox;
 	var oy;
 	var xe;
@@ -132,6 +126,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=2, sy=-2)', fun
 	var y;
 	var i;
 
+	ULP = 1;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -159,8 +154,8 @@ tape( 'the function applies a modified Givens plane rotation (sx=2, sy=-2)', fun
 		x = new Float32Array( xbuf );
 		y = new Float32Array( ybuf );
 		out = srotm( N[ i ], x, 2, ox[ i ], y, -2, oy[ i ], param );
-		isApprox( t, x, xe[ i ], 10.0 );
-		isApprox( t, y, ye[ i ], 10.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -171,6 +166,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=-2, sy=1)', fun
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var ox;
 	var oy;
 	var xe;
@@ -180,6 +176,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=-2, sy=1)', fun
 	var y;
 	var i;
 
+	ULP = 2;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -207,8 +204,8 @@ tape( 'the function applies a modified Givens plane rotation (sx=-2, sy=1)', fun
 		x = new Float32Array( xbuf );
 		y = new Float32Array( ybuf );
 		out = srotm( N[ i ], x, -2, ox[ i ], y, 1, oy[ i ], param );
-		isApprox( t, x, xe[ i ], 10.0 );
-		isApprox( t, y, ye[ i ], 10.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -219,6 +216,7 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', function test( t )
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var ox;
 	var oy;
 	var xe;
@@ -228,6 +226,7 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', function test( t )
 	var y;
 	var i;
 
+	ULP = 1;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -255,8 +254,8 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', function test( t )
 		x = new Float32Array( xbuf );
 		y = new Float32Array( ybuf );
 		out = srotm( N[ i ], x, -1, ox[ i ], y, -2, oy[ i ], param );
-		isApprox( t, x, xe[ i ], 4.0 );
-		isApprox( t, y, ye[ i ], 4.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -264,10 +263,13 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', function test( t )
 
 tape( 'the function applies a plane rotation', function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 0
@@ -302,8 +304,8 @@ tape( 'the function applies a plane rotation', function test( t ) {
 		10.0 // 2
 	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -338,18 +340,21 @@ tape( 'the function applies a plane rotation', function test( t ) {
 		10.0
 	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports an `x` stride', function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 0
@@ -385,8 +390,8 @@ tape( 'the function supports an `x` stride', function test( t ) {
 		10.0
 	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -421,18 +426,21 @@ tape( 'the function supports an `x` stride', function test( t ) {
 		10.0
 	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports an `x` offset', function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0,
@@ -456,8 +464,8 @@ tape( 'the function supports an `x` offset', function test( t ) {
 	xe = new Float32Array( [ 1.0, -16.0, -21.0, 4.0, 5.0 ] );
 	ye = new Float32Array( [ 10.0, 7.0, 14.0, 9.0, 10.0 ] );
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 1
@@ -492,8 +500,8 @@ tape( 'the function supports an `x` offset', function test( t ) {
 		10.0
 	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 2
@@ -528,18 +536,21 @@ tape( 'the function supports an `x` offset', function test( t ) {
 		10.0
 	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports a `y` stride', function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 0
@@ -574,8 +585,8 @@ tape( 'the function supports a `y` stride', function test( t ) {
 		16.0  // 2
 	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -610,18 +621,21 @@ tape( 'the function supports a `y` stride', function test( t ) {
 		10.0
 	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports a `y` offset', function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 0
@@ -645,8 +659,8 @@ tape( 'the function supports a `y` offset', function test( t ) {
 	xe = new Float32Array( [ -20.0, -25.0, 3.0, 4.0, 5.0 ] );
 	ye = new Float32Array( [ 6.0, 9.0, 8.0, 13.0, 10.0 ] );
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -681,8 +695,8 @@ tape( 'the function supports a `y` offset', function test( t ) {
 		10.0
 	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -717,8 +731,8 @@ tape( 'the function supports a `y` offset', function test( t ) {
 		2.0  // 0
 	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
@@ -769,10 +783,13 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function leav
 
 tape( 'the function supports complex access patterns', function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		0.6, // 1
@@ -799,8 +816,8 @@ tape( 'the function supports complex access patterns', function test( t ) {
 	xe = new Float32Array( [ -0.9, -0.8, -0.5, 0.8, 0.9, -0.3, -0.4 ] );
 	ye = new Float32Array( [ 1.7, -0.9, 0.5, 0.7, -0.6, 0.2, 0.8 ] );
 
-	isApprox( t, x, xe, 5.0 );
-	isApprox( t, y, ye, 5.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/base/srotm/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/srotm/test/test.ndarray.native.js
@@ -24,8 +24,7 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var Float32Array = require( '@stdlib/array/float32' );
 var scopy = require( '@stdlib/blas/base/scopy' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -46,22 +45,14 @@ var opts = {
 * @param {Object} t - test object
 * @param {Collection} actual - actual values
 * @param {Collection} expected - expected values
-* @param {number} rtol - relative tolerance
+* @param {NonNegativeInteger} ulp - maximum allowed ULP difference
 */
-function isApprox( t, actual, expected, rtol ) {
-	var delta;
-	var tol;
+function isApprox( t, actual, expected, ulp ) {
 	var i;
 
 	t.strictEqual( actual.length, expected.length, 'returns expected value' );
 	for ( i = 0; i < expected.length; i++ ) {
-		if ( actual[ i ] === expected[ i ] ) {
-			t.strictEqual( actual[ i ], expected[ i ], 'returns expected value' );
-		} else {
-			delta = abs( actual[ i ] - expected[ i ] );
-			tol = rtol * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. actual: '+actual[ i ]+'. expected: '+expected[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( actual[ i ], expected[ i ], ulp ), true, 'returns expected value' );
 	}
 }
 
@@ -84,6 +75,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=1, sy=1)', opts
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var ox;
 	var oy;
 	var xe;
@@ -93,6 +85,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=1, sy=1)', opts
 	var y;
 	var i;
 
+	ULP = 1;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -120,8 +113,8 @@ tape( 'the function applies a modified Givens plane rotation (sx=1, sy=1)', opts
 		x = new Float32Array( xbuf );
 		y = new Float32Array( ybuf );
 		out = srotm( N[ i ], x, 1, ox[ i ], y, 1, oy[ i ], param );
-		isApprox( t, x, xe[ i ], 5.0 );
-		isApprox( t, y, ye[ i ], 5.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -132,6 +125,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=2, sy=-2)', opt
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var ox;
 	var oy;
 	var xe;
@@ -141,6 +135,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=2, sy=-2)', opt
 	var y;
 	var i;
 
+	ULP = 1;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -168,8 +163,8 @@ tape( 'the function applies a modified Givens plane rotation (sx=2, sy=-2)', opt
 		x = new Float32Array( xbuf );
 		y = new Float32Array( ybuf );
 		out = srotm( N[ i ], x, 2, ox[ i ], y, -2, oy[ i ], param );
-		isApprox( t, x, xe[ i ], 10.0 );
-		isApprox( t, y, ye[ i ], 10.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -180,6 +175,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=-2, sy=1)', opt
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var ox;
 	var oy;
 	var xe;
@@ -189,6 +185,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=-2, sy=1)', opt
 	var y;
 	var i;
 
+	ULP = 2;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -216,8 +213,8 @@ tape( 'the function applies a modified Givens plane rotation (sx=-2, sy=1)', opt
 		x = new Float32Array( xbuf );
 		y = new Float32Array( ybuf );
 		out = srotm( N[ i ], x, -2, ox[ i ], y, 1, oy[ i ], param );
-		isApprox( t, x, xe[ i ], 10.0 );
-		isApprox( t, y, ye[ i ], 10.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -228,6 +225,7 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', opts, function tes
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var ox;
 	var oy;
 	var xe;
@@ -237,6 +235,7 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', opts, function tes
 	var y;
 	var i;
 
+	ULP = 1;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -264,8 +263,8 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', opts, function tes
 		x = new Float32Array( xbuf );
 		y = new Float32Array( ybuf );
 		out = srotm( N[ i ], x, -1, ox[ i ], y, -2, oy[ i ], param );
-		isApprox( t, x, xe[ i ], 4.0 );
-		isApprox( t, y, ye[ i ], 4.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -273,10 +272,13 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', opts, function tes
 
 tape( 'the function applies a plane rotation', opts, function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 0
@@ -311,8 +313,8 @@ tape( 'the function applies a plane rotation', opts, function test( t ) {
 		10.0 // 2
 	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -347,18 +349,21 @@ tape( 'the function applies a plane rotation', opts, function test( t ) {
 		10.0
 	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports an `x` stride', opts, function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 0
@@ -394,8 +399,8 @@ tape( 'the function supports an `x` stride', opts, function test( t ) {
 		10.0
 	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -430,18 +435,21 @@ tape( 'the function supports an `x` stride', opts, function test( t ) {
 		10.0
 	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports an `x` offset', opts, function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0,
@@ -465,8 +473,8 @@ tape( 'the function supports an `x` offset', opts, function test( t ) {
 	xe = new Float32Array( [ 1.0, -16.0, -21.0, 4.0, 5.0 ] );
 	ye = new Float32Array( [ 10.0, 7.0, 14.0, 9.0, 10.0 ] );
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 1
@@ -501,8 +509,8 @@ tape( 'the function supports an `x` offset', opts, function test( t ) {
 		10.0
 	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 2
@@ -537,18 +545,21 @@ tape( 'the function supports an `x` offset', opts, function test( t ) {
 		10.0
 	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports a `y` stride', opts, function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 0
@@ -583,8 +594,8 @@ tape( 'the function supports a `y` stride', opts, function test( t ) {
 		16.0  // 2
 	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -619,18 +630,21 @@ tape( 'the function supports a `y` stride', opts, function test( t ) {
 		10.0
 	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports a `y` offset', opts, function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 0
@@ -654,8 +668,8 @@ tape( 'the function supports a `y` offset', opts, function test( t ) {
 	xe = new Float32Array( [ -20.0, -25.0, 3.0, 4.0, 5.0 ] );
 	ye = new Float32Array( [ 6.0, 9.0, 8.0, 13.0, 10.0 ] );
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -690,8 +704,8 @@ tape( 'the function supports a `y` offset', opts, function test( t ) {
 		10.0
 	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -726,8 +740,8 @@ tape( 'the function supports a `y` offset', opts, function test( t ) {
 		2.0  // 0
 	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
@@ -778,10 +792,13 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function leav
 
 tape( 'the function supports complex access patterns', opts, function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		0.6, // 1
@@ -808,8 +825,8 @@ tape( 'the function supports complex access patterns', opts, function test( t ) 
 	xe = new Float32Array( [ -0.9, -0.8, -0.5, 0.8, 0.9, -0.3, -0.4 ] );
 	ye = new Float32Array( [ 1.7, -0.9, 0.5, 0.7, -0.6, 0.2, 0.8 ] );
 
-	isApprox( t, x, xe, 5.0 );
-	isApprox( t, y, ye, 5.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/base/srotm/test/test.srotm.js
+++ b/lib/node_modules/@stdlib/blas/base/srotm/test/test.srotm.js
@@ -444,7 +444,7 @@ tape( 'the function supports a negative `x` stride', function test( t ) {
 	]);
 	ye = new Float32Array([
 		6.0,  // 0
-		2.0, // 1
+		2.0,  // 1
 		8.0,
 		9.0,
 		10.0

--- a/lib/node_modules/@stdlib/blas/base/srotm/test/test.srotm.js
+++ b/lib/node_modules/@stdlib/blas/base/srotm/test/test.srotm.js
@@ -23,8 +23,7 @@
 var tape = require( 'tape' );
 var Float32Array = require( '@stdlib/array/float32' );
 var scopy = require( '@stdlib/blas/base/scopy' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var srotm = require( './../lib/srotm.js' );
 
 
@@ -37,22 +36,14 @@ var srotm = require( './../lib/srotm.js' );
 * @param {Object} t - test object
 * @param {Collection} actual - actual values
 * @param {Collection} expected - expected values
-* @param {number} rtol - relative tolerance
+* @param {NonNegativeInteger} ulp - maximum allowed ULP difference
 */
-function isApprox( t, actual, expected, rtol ) {
-	var delta;
-	var tol;
+function isApprox( t, actual, expected, ulp ) {
 	var i;
 
 	t.strictEqual( actual.length, expected.length, 'returns expected value' );
 	for ( i = 0; i < expected.length; i++ ) {
-		if ( actual[ i ] === expected[ i ] ) {
-			t.strictEqual( actual[ i ], expected[ i ], 'returns expected value' );
-		} else {
-			delta = abs( actual[ i ] - expected[ i ] );
-			tol = rtol * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. actual: '+actual[ i ]+'. expected: '+expected[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( actual[ i ], expected[ i ], ulp ), true, 'returns expected value' );
 	}
 }
 
@@ -75,6 +66,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=1, sy=1)', func
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var N;
@@ -82,6 +74,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=1, sy=1)', func
 	var y;
 	var i;
 
+	ULP = 1;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -105,8 +98,8 @@ tape( 'the function applies a modified Givens plane rotation (sx=1, sy=1)', func
 		x = new Float32Array( xbuf );
 		y = new Float32Array( ybuf );
 		out = srotm( N[ i ], x, 1, y, 1, param );
-		isApprox( t, x, xe[ i ], 5.0 );
-		isApprox( t, y, ye[ i ], 5.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -117,6 +110,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=2, sy=-2)', fun
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var N;
@@ -124,6 +118,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=2, sy=-2)', fun
 	var y;
 	var i;
 
+	ULP = 1;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -147,8 +142,8 @@ tape( 'the function applies a modified Givens plane rotation (sx=2, sy=-2)', fun
 		x = new Float32Array( xbuf );
 		y = new Float32Array( ybuf );
 		out = srotm( N[ i ], x, 2, y, -2, param );
-		isApprox( t, x, xe[ i ], 10.0 );
-		isApprox( t, y, ye[ i ], 10.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -159,6 +154,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=-2, sy=1)', fun
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var N;
@@ -166,6 +162,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=-2, sy=1)', fun
 	var y;
 	var i;
 
+	ULP = 2;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -189,8 +186,8 @@ tape( 'the function applies a modified Givens plane rotation (sx=-2, sy=1)', fun
 		x = new Float32Array( xbuf );
 		y = new Float32Array( ybuf );
 		out = srotm( N[ i ], x, -2, y, 1, param );
-		isApprox( t, x, xe[ i ], 10.0 );
-		isApprox( t, y, ye[ i ], 10.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -201,6 +198,7 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', function test( t )
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var N;
@@ -208,6 +206,7 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', function test( t )
 	var y;
 	var i;
 
+	ULP = 1;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -231,8 +230,8 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', function test( t )
 		x = new Float32Array( xbuf );
 		y = new Float32Array( ybuf );
 		out = srotm( N[ i ], x, -1, y, -2, param );
-		isApprox( t, x, xe[ i ], 4.0 );
-		isApprox( t, y, ye[ i ], 4.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -240,10 +239,13 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', function test( t )
 
 tape( 'the function applies a plane rotation', function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 0
@@ -263,23 +265,23 @@ tape( 'the function applies a plane rotation', function test( t ) {
 
 	srotm( 3, x, 2, y, 2, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-18.0, // 0
 		2.0,
 		-24.0, // 1
 		4.0,
 		-30.0  // 2
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		2.0, // 0
 		7.0,
 		6.0, // 1
 		9.0,
 		10.0 // 2
-	] );
+	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -299,33 +301,36 @@ tape( 'the function applies a plane rotation', function test( t ) {
 
 	srotm( 2, x, 3, y, 3, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		6.0, // 0
 		2.0,
 		3.0,
 		9.0, // 1
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		-1.0, // 0
 		7.0,
 		8.0,
 		-4.0, // 1
 		10.0
-	] );
+	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports an `x` stride', function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 0
@@ -345,23 +350,23 @@ tape( 'the function supports an `x` stride', function test( t ) {
 
 	srotm( 2, x, 2, y, 1, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-17.0, // 0
 		2.0,
 		-18.0, // 1
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		8.0,  // 0
 		13.0, // 1
 		8.0,
 		9.0,
 		10.0
-	] );
+	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -381,33 +386,36 @@ tape( 'the function supports an `x` stride', function test( t ) {
 
 	srotm( 2, x, 3, y, 1, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-18.0, // 0
 		2.0,
 		3.0,
 		-21.0, // 1
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		2.0, // 0
 		8.0, // 1
 		8.0,
 		9.0,
 		10.0
-	] );
+	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports a negative `x` stride', function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 1
@@ -427,23 +435,23 @@ tape( 'the function supports a negative `x` stride', function test( t ) {
 
 	srotm( 2, x, -2, y, 1, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-21.0, // 1
 		2.0,
 		-18.0, // 0
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		6.0,  // 0
 		2.0, // 1
 		8.0,
 		9.0,
 		10.0
-	] );
+	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 2
@@ -463,33 +471,36 @@ tape( 'the function supports a negative `x` stride', function test( t ) {
 
 	srotm( 3, x, -2, y, 1, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		8.0, // 2
 		2.0,
 		7.0, // 1
 		4.0,
 		6.0  // 0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		-5.0, // 0
 		-3.0, // 1
 		-1.0, // 2
 		9.0,
 		10.0
-	] );
+	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports a `y` stride', function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 0
@@ -509,23 +520,23 @@ tape( 'the function supports a `y` stride', function test( t ) {
 
 	srotm( 3, x, 1, y, 2, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-17.0, // 0
 		-22.0, // 1
 		-27.0, // 2
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		8.0,  // 0
 		7.0,
 		12.0, // 1
 		9.0,
 		16.0  // 2
-	] );
+	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -545,33 +556,36 @@ tape( 'the function supports a `y` stride', function test( t ) {
 
 	srotm( 2, x, 1, y, 3, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-18.0, // 0
 		-27.0, // 1
 		3.0,
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		2.0, // 0
 		7.0,
 		8.0,
 		4.0, // 1
 		10.0
-	] );
+	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports a negative `y` stride', function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 0
@@ -591,23 +605,23 @@ tape( 'the function supports a negative `y` stride', function test( t ) {
 
 	srotm( 2, x, 1, y, -2, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		8.0, // 0
 		6.0, // 1
 		3.0,
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		-2.0, // 1
 		7.0,
 		-1.0, // 0
 		9.0,
 		10.0
-	] );
+	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -627,23 +641,23 @@ tape( 'the function supports a negative `y` stride', function test( t ) {
 
 	srotm( 3, x, 1, y, -2, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-30.0, // 0
 		-24.0, // 1
 		-18.0, // 2
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		6.0, // 2
 		7.0,
 		4.0, // 1
 		9.0,
 		2.0  // 0
-	] );
+	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
@@ -694,10 +708,13 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function leav
 
 tape( 'the function supports complex access patterns', function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		0.6, // 1
@@ -724,8 +741,8 @@ tape( 'the function supports complex access patterns', function test( t ) {
 	xe = new Float32Array( [ -0.9, -0.8, -0.5, 0.8, 0.9, -0.3, -0.4 ] );
 	ye = new Float32Array( [ 1.7, -0.9, 0.5, 0.7, -0.6, 0.2, 0.8 ] );
 
-	isApprox( t, x, xe, 5.0 );
-	isApprox( t, y, ye, 5.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/base/srotm/test/test.srotm.native.js
+++ b/lib/node_modules/@stdlib/blas/base/srotm/test/test.srotm.native.js
@@ -24,8 +24,7 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var Float32Array = require( '@stdlib/array/float32' );
 var scopy = require( '@stdlib/blas/base/scopy' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -46,22 +45,14 @@ var opts = {
 * @param {Object} t - test object
 * @param {Collection} actual - actual values
 * @param {Collection} expected - expected values
-* @param {number} rtol - relative tolerance
+* @param {NonNegativeInteger} ulp - maximum allowed ULP difference
 */
-function isApprox( t, actual, expected, rtol ) {
-	var delta;
-	var tol;
+function isApprox( t, actual, expected, ulp ) {
 	var i;
 
 	t.strictEqual( actual.length, expected.length, 'returns expected value' );
 	for ( i = 0; i < expected.length; i++ ) {
-		if ( actual[ i ] === expected[ i ] ) {
-			t.strictEqual( actual[ i ], expected[ i ], 'returns expected value' );
-		} else {
-			delta = abs( actual[ i ] - expected[ i ] );
-			tol = rtol * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. actual: '+actual[ i ]+'. expected: '+expected[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( actual[ i ], expected[ i ], ulp ), true, 'returns expected value' );
 	}
 }
 
@@ -84,6 +75,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=1, sy=1)', opts
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var N;
@@ -91,6 +83,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=1, sy=1)', opts
 	var y;
 	var i;
 
+	ULP = 1;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -115,8 +108,8 @@ tape( 'the function applies a modified Givens plane rotation (sx=1, sy=1)', opts
 		x = new Float32Array( xbuf );
 		y = new Float32Array( ybuf );
 		out = srotm( N[ i ], x, 1, y, 1, param );
-		isApprox( t, x, xe[ i ], 5.0 );
-		isApprox( t, y, ye[ i ], 5.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -127,6 +120,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=2, sy=-2)', opt
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var N;
@@ -134,6 +128,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=2, sy=-2)', opt
 	var y;
 	var i;
 
+	ULP = 1;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -158,8 +153,8 @@ tape( 'the function applies a modified Givens plane rotation (sx=2, sy=-2)', opt
 		x = new Float32Array( xbuf );
 		y = new Float32Array( ybuf );
 		out = srotm( N[ i ], x, 2, y, -2, param );
-		isApprox( t, x, xe[ i ], 10.0 );
-		isApprox( t, y, ye[ i ], 10.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -170,6 +165,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=-2, sy=1)', opt
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var N;
@@ -177,6 +173,7 @@ tape( 'the function applies a modified Givens plane rotation (sx=-2, sy=1)', opt
 	var y;
 	var i;
 
+	ULP = 2;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -201,8 +198,8 @@ tape( 'the function applies a modified Givens plane rotation (sx=-2, sy=1)', opt
 		x = new Float32Array( xbuf );
 		y = new Float32Array( ybuf );
 		out = srotm( N[ i ], x, -2, y, 1, param );
-		isApprox( t, x, xe[ i ], 10.0 );
-		isApprox( t, y, ye[ i ], 10.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -213,6 +210,7 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', opts, function tes
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var N;
@@ -220,6 +218,7 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', opts, function tes
 	var y;
 	var i;
 
+	ULP = 1;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -244,8 +243,8 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', opts, function tes
 		x = new Float32Array( xbuf );
 		y = new Float32Array( ybuf );
 		out = srotm( N[ i ], x, -1, y, -2, param );
-		isApprox( t, x, xe[ i ], 4.0 );
-		isApprox( t, y, ye[ i ], 4.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -253,10 +252,13 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', opts, function tes
 
 tape( 'the function applies a plane rotation', opts, function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 0
@@ -276,23 +278,23 @@ tape( 'the function applies a plane rotation', opts, function test( t ) {
 
 	srotm( 3, x, 2, y, 2, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-18.0, // 0
 		2.0,
 		-24.0, // 1
 		4.0,
 		-30.0  // 2
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		2.0, // 0
 		7.0,
 		6.0, // 1
 		9.0,
 		10.0 // 2
-	] );
+	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -312,33 +314,36 @@ tape( 'the function applies a plane rotation', opts, function test( t ) {
 
 	srotm( 2, x, 3, y, 3, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		6.0, // 0
 		2.0,
 		3.0,
 		9.0, // 1
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		-1.0, // 0
 		7.0,
 		8.0,
 		-4.0, // 1
 		10.0
-	] );
+	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports an `x` stride', opts, function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 0
@@ -358,23 +363,23 @@ tape( 'the function supports an `x` stride', opts, function test( t ) {
 
 	srotm( 2, x, 2, y, 1, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-17.0, // 0
 		2.0,
 		-18.0, // 1
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		8.0,  // 0
 		13.0, // 1
 		8.0,
 		9.0,
 		10.0
-	] );
+	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -394,33 +399,36 @@ tape( 'the function supports an `x` stride', opts, function test( t ) {
 
 	srotm( 2, x, 3, y, 1, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-18.0, // 0
 		2.0,
 		3.0,
 		-21.0, // 1
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		2.0, // 0
 		8.0, // 1
 		8.0,
 		9.0,
 		10.0
-	] );
+	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports a negative `x` stride', opts, function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 1
@@ -440,23 +448,23 @@ tape( 'the function supports a negative `x` stride', opts, function test( t ) {
 
 	srotm( 2, x, -2, y, 1, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-21.0, // 1
 		2.0,
 		-18.0, // 0
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		6.0,  // 0
 		2.0, // 1
 		8.0,
 		9.0,
 		10.0
-	] );
+	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 2
@@ -476,33 +484,36 @@ tape( 'the function supports a negative `x` stride', opts, function test( t ) {
 
 	srotm( 3, x, -2, y, 1, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		8.0, // 2
 		2.0,
 		7.0, // 1
 		4.0,
 		6.0  // 0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		-5.0, // 0
 		-3.0, // 1
 		-1.0, // 2
 		9.0,
 		10.0
-	] );
+	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports a `y` stride', opts, function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 0
@@ -522,23 +533,23 @@ tape( 'the function supports a `y` stride', opts, function test( t ) {
 
 	srotm( 3, x, 1, y, 2, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-17.0, // 0
 		-22.0, // 1
 		-27.0, // 2
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		8.0,  // 0
 		7.0,
 		12.0, // 1
 		9.0,
 		16.0  // 2
-	] );
+	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -558,33 +569,36 @@ tape( 'the function supports a `y` stride', opts, function test( t ) {
 
 	srotm( 2, x, 1, y, 3, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-18.0, // 0
 		-27.0, // 1
 		3.0,
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		2.0, // 0
 		7.0,
 		8.0,
 		4.0, // 1
 		10.0
-	] );
+	]);
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports a negative `y` stride', opts, function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		1.0, // 0
@@ -604,23 +618,23 @@ tape( 'the function supports a negative `y` stride', opts, function test( t ) {
 
 	srotm( 2, x, 1, y, -2, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		8.0, // 0
 		6.0, // 1
 		3.0,
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		-2.0, // 1
 		7.0,
 		-1.0, // 0
 		9.0,
 		10.0
-	] );
+	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	x = new Float32Array([
 		1.0, // 0
@@ -640,23 +654,23 @@ tape( 'the function supports a negative `y` stride', opts, function test( t ) {
 
 	srotm( 3, x, 1, y, -2, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-30.0, // 0
 		-24.0, // 1
 		-18.0, // 2
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		6.0, // 2
 		7.0,
 		4.0, // 1
 		9.0,
 		2.0  // 0
-	] );
+	]);
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
@@ -707,10 +721,13 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function leav
 
 tape( 'the function supports complex access patterns', opts, function test( t ) {
 	var param;
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
+
+	ULP = 0;
 
 	x = new Float32Array([
 		0.6, // 1
@@ -737,8 +754,8 @@ tape( 'the function supports complex access patterns', opts, function test( t ) 
 	xe = new Float32Array( [ -0.9, -0.8, -0.5, 0.8, 0.9, -0.3, -0.4 ] );
 	ye = new Float32Array( [ 1.7, -0.9, 0.5, 0.7, -0.6, 0.2, 0.8 ] );
 
-	isApprox( t, x, xe, 5.0 );
-	isApprox( t, y, ye, 5.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/base/srotm/test/test.srotm.native.js
+++ b/lib/node_modules/@stdlib/blas/base/srotm/test/test.srotm.native.js
@@ -457,7 +457,7 @@ tape( 'the function supports a negative `x` stride', opts, function test( t ) {
 	]);
 	ye = new Float32Array([
 		6.0,  // 0
-		2.0, // 1
+		2.0,  // 1
 		8.0,
 		9.0,
 		10.0


### PR DESCRIPTION
Progresses #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for `blas/base/srotm` from the old EPS/relative-tolerance idiom (a hand-rolled `isApprox` helper computing `tol = rtol * EPS * abs( expected )` and comparing against `delta = abs( actual - expected )`) to ULP-based assertions using `@stdlib/number/float32/base/assert/is-almost-same-value` (`isAlmostSameValuef`), per the tracking issue.
-   applies the conversion to all four test files (`test.srotm.js`, `test.srotm.native.js`, `test.ndarray.js`, `test.ndarray.native.js`).
-   tightens each test body's ULP bound to the minimum integer value that keeps the fixtures passing, determined empirically via `@stdlib/number/float32/base/ulp-difference`:
    -   `(sx=1, sy=1)` / `(sx=2, sy=-2)` / `(sx=-1, sy=-2)` loops: `ULP = 1`
    -   `(sx=-2, sy=1)` loop: `ULP = 2`
    -   all remaining test bodies (plane rotation, strides, offsets, complex access patterns): `ULP = 0` (exact match)
-   the full suite was run twice at the final bounds to confirm determinism (no FMA/arch flakiness).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No new dependency was added to `package.json`; `@stdlib/number/float32/base/assert/is-almost-same-value` resolves via the monorepo workspace like other packages' test-only requires (consistent with already-converted packages such as `blas/base/drotm`).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, following the conversion idiom established by prior ULP-migration PRs in this repository (e.g., `blas/base/drotm`, `blas/base/dzasum`).

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AgocwH5yKykupJhp1yNkKo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgocwH5yKykupJhp1yNkKo)_