### PR TITLE
docs: improve doctests for ndarray instances in `ndarray/fill-by`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/fill-by/README.md
+++ b/lib/node_modules/@stdlib/ndarray/fill-by/README.md
@@ -42,7 +42,6 @@ Fills an input [ndarray][@stdlib/ndarray/ctor] according to a callback function.
 
 ```javascript
 var zeros = require( '@stdlib/ndarray/zeros' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 
 function fcn( value ) {
     return value + 10.0;
@@ -53,13 +52,10 @@ var x = zeros( [ 3, 1, 2 ], {
 });
 
 var y = fillBy( x, fcn );
-// returns <ndarray>
+// returns <ndarray>[ [ [ 10.0, 10.0 ] ], [ [ 10.0, 10.0 ] ], [ [ 10.0, 10.0 ] ] ]
 
 var bool = ( y === x );
 // returns true
-
-var arr = ndarray2array( y );
-// returns [ [ [ 10.0, 10.0 ] ], [ [ 10.0, 10.0 ] ], [ [ 10.0, 10.0 ] ] ]
 ```
 
 The function accepts the following arguments:
@@ -74,7 +70,6 @@ To set the callback function execution context, provide a `thisArg`.
 
 ```javascript
 var zeros = require( '@stdlib/ndarray/zeros' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 
 function fcn( value ) {
     return value + this.factor;
@@ -88,10 +83,7 @@ var ctx = {
     'factor': 10.0
 };
 var y = fillBy( x, fcn, ctx );
-// returns <ndarray>
-
-var arr = ndarray2array( y );
-// returns [ [ [ 10.0, 10.0 ] ], [ [ 10.0, 10.0 ] ], [ [ 10.0, 10.0 ] ] ]
+// returns <ndarray>[ [ [ 10.0, 10.0 ] ], [ [ 10.0, 10.0 ] ], [ [ 10.0, 10.0 ] ] ]
 ```
 
 The callback function is provided the following arguments:


### PR DESCRIPTION
Progresses #9329

## Description

This pull request:

- Updates doctest output annotations in `@stdlib/ndarray/fill-by` usage examples to use compact `<ndarray>[ ... ]` notation.
- Removes the now-unused `@stdlib/ndarray/to-array` imports and explicit conversions.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

### AI Assistance

- [x] Yes
- [ ] No

AI assistance was used during development and PR preparation. I manually reviewed the final diff and validation results.