### PR TITLE
test: migrate `blas/base/drot` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/drot/test/test.drot.js
+++ b/lib/node_modules/@stdlib/blas/base/drot/test/test.drot.js
@@ -23,8 +23,7 @@
 var tape = require( 'tape' );
 var Float64Array = require( '@stdlib/array/float64' );
 var dcopy = require( '@stdlib/blas/base/dcopy' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var drot = require( './../lib/drot.js' );
 
 
@@ -37,22 +36,14 @@ var drot = require( './../lib/drot.js' );
 * @param {Object} t - test object
 * @param {Collection} actual - actual values
 * @param {Collection} expected - expected values
-* @param {number} rtol - relative tolerance
+* @param {NonNegativeInteger} ulp - maximum allowed ULP difference
 */
-function isApprox( t, actual, expected, rtol ) {
-	var delta;
-	var tol;
+function isApprox( t, actual, expected, ulp ) {
 	var i;
 
 	t.strictEqual( actual.length, expected.length, 'returns expected value' );
 	for ( i = 0; i < expected.length; i++ ) {
-		if ( actual[ i ] === expected[ i ] ) {
-			t.strictEqual( actual[ i ], expected[ i ], 'returns expected value' );
-		} else {
-			delta = abs( actual[ i ] - expected[ i ] );
-			tol = rtol * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. actual: '+actual[ i ]+'. expected: '+expected[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual[ i ], expected[ i ], ulp ), true, 'returns expected value' );
 	}
 }
 
@@ -74,6 +65,7 @@ tape( 'the function applies a plane rotation (sx=1, sy=1)', function test( t ) {
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var N;
@@ -81,6 +73,7 @@ tape( 'the function applies a plane rotation (sx=1, sy=1)', function test( t ) {
 	var y;
 	var i;
 
+	ULP = 5;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -103,8 +96,8 @@ tape( 'the function applies a plane rotation (sx=1, sy=1)', function test( t ) {
 		x = new Float64Array( xbuf );
 		y = new Float64Array( ybuf );
 		out = drot( N[ i ], x, 1, y, 1, 0.8, 0.6 );
-		isApprox( t, x, xe[ i ], 6.0 );
-		isApprox( t, y, ye[ i ], 6.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -114,6 +107,7 @@ tape( 'the function applies a plane rotation (sx=2, sy=-2)', function test( t ) 
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var N;
@@ -121,6 +115,7 @@ tape( 'the function applies a plane rotation (sx=2, sy=-2)', function test( t ) 
 	var y;
 	var i;
 
+	ULP = 21;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -143,8 +138,8 @@ tape( 'the function applies a plane rotation (sx=2, sy=-2)', function test( t ) 
 		x = new Float64Array( xbuf );
 		y = new Float64Array( ybuf );
 		out = drot( N[ i ], x, 2, y, -2, 0.8, 0.6 );
-		isApprox( t, x, xe[ i ], 20.0 );
-		isApprox( t, y, ye[ i ], 20.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -154,6 +149,7 @@ tape( 'the function applies a plane rotation (sx=-2, sy=1)', function test( t ) 
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var N;
@@ -161,6 +157,7 @@ tape( 'the function applies a plane rotation (sx=-2, sy=1)', function test( t ) 
 	var y;
 	var i;
 
+	ULP = 21;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -183,8 +180,8 @@ tape( 'the function applies a plane rotation (sx=-2, sy=1)', function test( t ) 
 		x = new Float64Array( xbuf );
 		y = new Float64Array( ybuf );
 		out = drot( N[ i ], x, -2, y, 1, 0.8, 0.6 );
-		isApprox( t, x, xe[ i ], 20.0 );
-		isApprox( t, y, ye[ i ], 20.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -194,6 +191,7 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', function test( t )
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var N;
@@ -201,6 +199,7 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', function test( t )
 	var y;
 	var i;
 
+	ULP = 5;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -223,19 +222,21 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', function test( t )
 		x = new Float64Array( xbuf );
 		y = new Float64Array( ybuf );
 		out = drot( N[ i ], x, -1, y, -2, 0.8, 0.6 );
-		isApprox( t, x, xe[ i ], 4.0 );
-		isApprox( t, y, ye[ i ], 4.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function supports an `x` stride', function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 2;
 	x = new Float64Array([
 		1.0, // 0
 		2.0,
@@ -256,8 +257,8 @@ tape( 'the function supports an `x` stride', function test( t ) {
 	xe = new Float64Array( [ 4.4, 2.0, 6.6, 4.0, 5.0 ] );
 	ye = new Float64Array( [ 4.2, 3.8, 8.0, 9.0, 10.0 ] );
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
@@ -335,11 +336,13 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function leav
 });
 
 tape( 'the function supports negative strides', function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 21;
 	x = new Float64Array([
 		0.6,  // 3
 		0.1,
@@ -364,18 +367,20 @@ tape( 'the function supports negative strides', function test( t ) {
 	xe = new Float64Array( [ 0.9, 0.1, -0.22, 0.8, 0.18, -0.3, -0.02 ] );
 	ye = new Float64Array( [ 0.64, -1.26, 0.54, 0.2, -0.6, 0.2, 0.8 ] );
 
-	isApprox( t, x, xe, 20.0 );
-	isApprox( t, y, ye, 20.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports complex access patterns', function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 5;
 	x = new Float64Array([
 		0.6, // 1
 		0.1, // 0
@@ -400,8 +405,8 @@ tape( 'the function supports complex access patterns', function test( t ) {
 	xe = new Float64Array( [ 0.78, 0.26, -0.5, 0.8, 0.9, -0.3, -0.4 ] );
 	ye = new Float64Array( [ 0.04, -0.9, 0.18, 0.7, -0.6, 0.2, 0.8 ] );
 
-	isApprox( t, x, xe, 5.0 );
-	isApprox( t, y, ye, 5.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/base/drot/test/test.drot.native.js
+++ b/lib/node_modules/@stdlib/blas/base/drot/test/test.drot.native.js
@@ -24,8 +24,7 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var Float64Array = require( '@stdlib/array/float64' );
 var dcopy = require( '@stdlib/blas/base/dcopy' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -46,22 +45,14 @@ var opts = {
 * @param {Object} t - test object
 * @param {Collection} actual - actual values
 * @param {Collection} expected - expected values
-* @param {number} rtol - relative tolerance
+* @param {NonNegativeInteger} ulp - maximum allowed ULP difference
 */
-function isApprox( t, actual, expected, rtol ) {
-	var delta;
-	var tol;
+function isApprox( t, actual, expected, ulp ) {
 	var i;
 
 	t.strictEqual( actual.length, expected.length, 'returns expected value' );
 	for ( i = 0; i < expected.length; i++ ) {
-		if ( actual[ i ] === expected[ i ] ) {
-			t.strictEqual( actual[ i ], expected[ i ], 'returns expected value' );
-		} else {
-			delta = abs( actual[ i ] - expected[ i ] );
-			tol = rtol * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. actual: '+actual[ i ]+'. expected: '+expected[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual[ i ], expected[ i ], ulp ), true, 'returns expected value' );
 	}
 }
 
@@ -83,6 +74,7 @@ tape( 'the function applies a plane rotation (sx=1, sy=1)', opts, function test(
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var N;
@@ -90,6 +82,7 @@ tape( 'the function applies a plane rotation (sx=1, sy=1)', opts, function test(
 	var y;
 	var i;
 
+	ULP = 5;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -112,8 +105,8 @@ tape( 'the function applies a plane rotation (sx=1, sy=1)', opts, function test(
 		x = new Float64Array( xbuf );
 		y = new Float64Array( ybuf );
 		out = drot( N[ i ], x, 1, y, 1, 0.8, 0.6 );
-		isApprox( t, x, xe[ i ], 6.0 );
-		isApprox( t, y, ye[ i ], 6.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -123,6 +116,7 @@ tape( 'the function applies a plane rotation (sx=2, sy=-2)', opts, function test
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var N;
@@ -130,6 +124,7 @@ tape( 'the function applies a plane rotation (sx=2, sy=-2)', opts, function test
 	var y;
 	var i;
 
+	ULP = 21;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -152,8 +147,8 @@ tape( 'the function applies a plane rotation (sx=2, sy=-2)', opts, function test
 		x = new Float64Array( xbuf );
 		y = new Float64Array( ybuf );
 		out = drot( N[ i ], x, 2, y, -2, 0.8, 0.6 );
-		isApprox( t, x, xe[ i ], 20.0 );
-		isApprox( t, y, ye[ i ], 20.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -163,6 +158,7 @@ tape( 'the function applies a plane rotation (sx=-2, sy=1)', opts, function test
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var N;
@@ -170,6 +166,7 @@ tape( 'the function applies a plane rotation (sx=-2, sy=1)', opts, function test
 	var y;
 	var i;
 
+	ULP = 21;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -192,8 +189,8 @@ tape( 'the function applies a plane rotation (sx=-2, sy=1)', opts, function test
 		x = new Float64Array( xbuf );
 		y = new Float64Array( ybuf );
 		out = drot( N[ i ], x, -2, y, 1, 0.8, 0.6 );
-		isApprox( t, x, xe[ i ], 20.0 );
-		isApprox( t, y, ye[ i ], 20.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -203,6 +200,7 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', opts, function tes
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var N;
@@ -210,6 +208,7 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', opts, function tes
 	var y;
 	var i;
 
+	ULP = 5;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -232,19 +231,21 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', opts, function tes
 		x = new Float64Array( xbuf );
 		y = new Float64Array( ybuf );
 		out = drot( N[ i ], x, -1, y, -2, 0.8, 0.6 );
-		isApprox( t, x, xe[ i ], 4.0 );
-		isApprox( t, y, ye[ i ], 4.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function supports an `x` stride', opts, function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 2;
 	x = new Float64Array([
 		1.0, // 0
 		2.0,
@@ -265,8 +266,8 @@ tape( 'the function supports an `x` stride', opts, function test( t ) {
 	xe = new Float64Array( [ 4.4, 2.0, 6.6, 4.0, 5.0 ] );
 	ye = new Float64Array( [ 4.2, 3.8, 8.0, 9.0, 10.0 ] );
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
@@ -344,11 +345,13 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function leav
 });
 
 tape( 'the function supports negative strides', opts, function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 21;
 	x = new Float64Array([
 		0.6,  // 3
 		0.1,
@@ -373,18 +376,20 @@ tape( 'the function supports negative strides', opts, function test( t ) {
 	xe = new Float64Array( [ 0.9, 0.1, -0.22, 0.8, 0.18, -0.3, -0.02 ] );
 	ye = new Float64Array( [ 0.64, -1.26, 0.54, 0.2, -0.6, 0.2, 0.8 ] );
 
-	isApprox( t, x, xe, 20.0 );
-	isApprox( t, y, ye, 20.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports complex access patterns', opts, function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 5;
 	x = new Float64Array([
 		0.6, // 1
 		0.1, // 0
@@ -409,8 +414,8 @@ tape( 'the function supports complex access patterns', opts, function test( t ) 
 	xe = new Float64Array( [ 0.78, 0.26, -0.5, 0.8, 0.9, -0.3, -0.4 ] );
 	ye = new Float64Array( [ 0.04, -0.9, 0.18, 0.7, -0.6, 0.2, 0.8 ] );
 
-	isApprox( t, x, xe, 5.0 );
-	isApprox( t, y, ye, 5.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/base/drot/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/drot/test/test.ndarray.js
@@ -23,8 +23,7 @@
 var tape = require( 'tape' );
 var Float64Array = require( '@stdlib/array/float64' );
 var dcopy = require( '@stdlib/blas/base/dcopy' ).ndarray;
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var drot = require( './../lib/ndarray.js' );
 
 
@@ -37,22 +36,14 @@ var drot = require( './../lib/ndarray.js' );
 * @param {Object} t - test object
 * @param {Collection} actual - actual values
 * @param {Collection} expected - expected values
-* @param {number} rtol - relative tolerance
+* @param {NonNegativeInteger} ulp - maximum allowed ULP difference
 */
-function isApprox( t, actual, expected, rtol ) {
-	var delta;
-	var tol;
+function isApprox( t, actual, expected, ulp ) {
 	var i;
 
 	t.strictEqual( actual.length, expected.length, 'returns expected value' );
 	for ( i = 0; i < expected.length; i++ ) {
-		if ( actual[ i ] === expected[ i ] ) {
-			t.strictEqual( actual[ i ], expected[ i ], 'returns expected value' );
-		} else {
-			delta = abs( actual[ i ] - expected[ i ] );
-			tol = rtol * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. actual: '+actual[ i ]+'. expected: '+expected[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual[ i ], expected[ i ], ulp ), true, 'returns expected value' );
 	}
 }
 
@@ -74,6 +65,7 @@ tape( 'the function applies a plane rotation (sx=1, sy=1)', function test( t ) {
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var ox;
@@ -83,6 +75,7 @@ tape( 'the function applies a plane rotation (sx=1, sy=1)', function test( t ) {
 	var y;
 	var i;
 
+	ULP = 5;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -108,8 +101,8 @@ tape( 'the function applies a plane rotation (sx=1, sy=1)', function test( t ) {
 		x = new Float64Array( xbuf );
 		y = new Float64Array( ybuf );
 		out = drot( N[ i ], x, 1, ox[ i ], y, 1, oy[ i ], 0.8, 0.6 );
-		isApprox( t, x, xe[ i ], 6.0 );
-		isApprox( t, y, ye[ i ], 6.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -119,6 +112,7 @@ tape( 'the function applies a plane rotation (sx=2, sy=-2)', function test( t ) 
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var ox;
@@ -128,6 +122,7 @@ tape( 'the function applies a plane rotation (sx=2, sy=-2)', function test( t ) 
 	var y;
 	var i;
 
+	ULP = 21;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -153,8 +148,8 @@ tape( 'the function applies a plane rotation (sx=2, sy=-2)', function test( t ) 
 		x = new Float64Array( xbuf );
 		y = new Float64Array( ybuf );
 		out = drot( N[ i ], x, 2, ox[ i ], y, -2, oy[ i ], 0.8, 0.6 );
-		isApprox( t, x, xe[ i ], 20.0 );
-		isApprox( t, y, ye[ i ], 20.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -164,6 +159,7 @@ tape( 'the function applies a plane rotation (sx=-2, sy=1)', function test( t ) 
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var ox;
@@ -173,6 +169,7 @@ tape( 'the function applies a plane rotation (sx=-2, sy=1)', function test( t ) 
 	var y;
 	var i;
 
+	ULP = 21;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -197,8 +194,8 @@ tape( 'the function applies a plane rotation (sx=-2, sy=1)', function test( t ) 
 		x = new Float64Array( xbuf );
 		y = new Float64Array( ybuf );
 		out = drot( N[ i ], x, -2, ox[ i ], y, 1, oy[ i ], 0.8, 0.6 );
-		isApprox( t, x, xe[ i ], 20.0 );
-		isApprox( t, y, ye[ i ], 20.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -208,6 +205,7 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', function test( t )
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var ox;
@@ -217,6 +215,7 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', function test( t )
 	var y;
 	var i;
 
+	ULP = 5;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -242,19 +241,21 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', function test( t )
 		x = new Float64Array( xbuf );
 		y = new Float64Array( ybuf );
 		out = drot( N[ i ], x, -1, ox[ i ], y, -2, oy[ i ], 0.8, 0.6 );
-		isApprox( t, x, xe[ i ], 4.0 );
-		isApprox( t, y, ye[ i ], 4.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function supports an `x` stride', function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 2;
 	x = new Float64Array([
 		1.0, // 0
 		2.0,
@@ -275,18 +276,20 @@ tape( 'the function supports an `x` stride', function test( t ) {
 	xe = new Float64Array( [ 4.4, 2.0, 6.6, 4.0, 5.0 ] );
 	ye = new Float64Array( [ 4.2, 3.8, 8.0, 9.0, 10.0 ] );
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports an `x` offset', function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 2;
 	x = new Float64Array([
 		1.0,
 		2.0, // 0
@@ -307,18 +310,20 @@ tape( 'the function supports an `x` offset', function test( t ) {
 	xe = new Float64Array( [ 1.0, 5.2, 6.6, 4.0, 5.0 ] );
 	ye = new Float64Array( [ 3.6, 3.8, 8.0, 9.0, 10.0 ] );
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports a `y` stride', function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 0;
 	x = new Float64Array([
 		1.0, // 0
 		2.0, // 1
@@ -339,18 +344,20 @@ tape( 'the function supports a `y` stride', function test( t ) {
 	xe = new Float64Array( [ -1.0, -3.0, -5.0, 4.0, 5.0 ] );
 	ye = new Float64Array( [ 1.0, 2.0, 2.0, 4.0, 3.0 ] );
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports a `y` offset', function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 1;
 	x = new Float64Array([
 		1.0, // 0
 		2.0, // 1
@@ -371,8 +378,8 @@ tape( 'the function supports a `y` offset', function test( t ) {
 	xe = new Float64Array( [ 5.6, 7.0, 3.0, 4.0, 5.0 ] );
 	ye = new Float64Array( [ 6.0, 7.0, 5.8, 6.0, 10.0 ] );
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
@@ -418,11 +425,13 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function leav
 });
 
 tape( 'the function supports negative strides', function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 21;
 	x = new Float64Array([
 		0.6,  // 3
 		0.1,
@@ -447,18 +456,20 @@ tape( 'the function supports negative strides', function test( t ) {
 	xe = new Float64Array( [ 0.9, 0.1, -0.22, 0.8, 0.18, -0.3, -0.02 ] );
 	ye = new Float64Array( [ 0.64, -1.26, 0.54, 0.2, -0.6, 0.2, 0.8 ] );
 
-	isApprox( t, x, xe, 20.0 );
-	isApprox( t, y, ye, 20.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports complex access patterns', function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 5;
 	x = new Float64Array([
 		0.6, // 1
 		0.1, // 0
@@ -483,8 +494,8 @@ tape( 'the function supports complex access patterns', function test( t ) {
 	xe = new Float64Array( [ 0.78, 0.26, -0.5, 0.8, 0.9, -0.3, -0.4 ] );
 	ye = new Float64Array( [ 0.04, -0.9, 0.18, 0.7, -0.6, 0.2, 0.8 ] );
 
-	isApprox( t, x, xe, 5.0 );
-	isApprox( t, y, ye, 5.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/base/drot/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/drot/test/test.ndarray.native.js
@@ -24,8 +24,7 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var Float64Array = require( '@stdlib/array/float64' );
 var dcopy = require( '@stdlib/blas/base/dcopy' ).ndarray;
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -46,22 +45,14 @@ var opts = {
 * @param {Object} t - test object
 * @param {Collection} actual - actual values
 * @param {Collection} expected - expected values
-* @param {number} rtol - relative tolerance
+* @param {NonNegativeInteger} ulp - maximum allowed ULP difference
 */
-function isApprox( t, actual, expected, rtol ) {
-	var delta;
-	var tol;
+function isApprox( t, actual, expected, ulp ) {
 	var i;
 
 	t.strictEqual( actual.length, expected.length, 'returns expected value' );
 	for ( i = 0; i < expected.length; i++ ) {
-		if ( actual[ i ] === expected[ i ] ) {
-			t.strictEqual( actual[ i ], expected[ i ], 'returns expected value' );
-		} else {
-			delta = abs( actual[ i ] - expected[ i ] );
-			tol = rtol * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. actual: '+actual[ i ]+'. expected: '+expected[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual[ i ], expected[ i ], ulp ), true, 'returns expected value' );
 	}
 }
 
@@ -83,6 +74,7 @@ tape( 'the function applies a plane rotation (sx=1, sy=1)', opts, function test(
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var ox;
@@ -92,6 +84,7 @@ tape( 'the function applies a plane rotation (sx=1, sy=1)', opts, function test(
 	var y;
 	var i;
 
+	ULP = 5;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -117,8 +110,8 @@ tape( 'the function applies a plane rotation (sx=1, sy=1)', opts, function test(
 		x = new Float64Array( xbuf );
 		y = new Float64Array( ybuf );
 		out = drot( N[ i ], x, 1, ox[ i ], y, 1, oy[ i ], 0.8, 0.6 );
-		isApprox( t, x, xe[ i ], 6.0 );
-		isApprox( t, y, ye[ i ], 6.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -128,6 +121,7 @@ tape( 'the function applies a plane rotation (sx=2, sy=-2)', opts, function test
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var ox;
@@ -137,6 +131,7 @@ tape( 'the function applies a plane rotation (sx=2, sy=-2)', opts, function test
 	var y;
 	var i;
 
+	ULP = 21;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -162,8 +157,8 @@ tape( 'the function applies a plane rotation (sx=2, sy=-2)', opts, function test
 		x = new Float64Array( xbuf );
 		y = new Float64Array( ybuf );
 		out = drot( N[ i ], x, 2, ox[ i ], y, -2, oy[ i ], 0.8, 0.6 );
-		isApprox( t, x, xe[ i ], 20.0 );
-		isApprox( t, y, ye[ i ], 20.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -173,6 +168,7 @@ tape( 'the function applies a plane rotation (sx=-2, sy=1)', opts, function test
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var ox;
@@ -182,6 +178,7 @@ tape( 'the function applies a plane rotation (sx=-2, sy=1)', opts, function test
 	var y;
 	var i;
 
+	ULP = 21;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -206,8 +203,8 @@ tape( 'the function applies a plane rotation (sx=-2, sy=1)', opts, function test
 		x = new Float64Array( xbuf );
 		y = new Float64Array( ybuf );
 		out = drot( N[ i ], x, -2, ox[ i ], y, 1, oy[ i ], 0.8, 0.6 );
-		isApprox( t, x, xe[ i ], 20.0 );
-		isApprox( t, y, ye[ i ], 20.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
@@ -217,6 +214,7 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', opts, function tes
 	var xbuf;
 	var ybuf;
 	var out;
+	var ULP;
 	var xe;
 	var ye;
 	var ox;
@@ -226,6 +224,7 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', opts, function tes
 	var y;
 	var i;
 
+	ULP = 5;
 	N = [ 0, 1, 2, 4 ];
 
 	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
@@ -251,19 +250,21 @@ tape( 'the function applies a plane rotation (sx=-1, sy=-2)', opts, function tes
 		x = new Float64Array( xbuf );
 		y = new Float64Array( ybuf );
 		out = drot( N[ i ], x, -1, ox[ i ], y, -2, oy[ i ], 0.8, 0.6 );
-		isApprox( t, x, xe[ i ], 4.0 );
-		isApprox( t, y, ye[ i ], 4.0 );
+		isApprox( t, x, xe[ i ], ULP );
+		isApprox( t, y, ye[ i ], ULP );
 		t.strictEqual( out, y, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function supports an `x` stride', opts, function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 2;
 	x = new Float64Array([
 		1.0, // 0
 		2.0,
@@ -284,18 +285,20 @@ tape( 'the function supports an `x` stride', opts, function test( t ) {
 	xe = new Float64Array( [ 4.4, 2.0, 6.6, 4.0, 5.0 ] );
 	ye = new Float64Array( [ 4.2, 3.8, 8.0, 9.0, 10.0 ] );
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports an `x` offset', opts, function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 2;
 	x = new Float64Array([
 		1.0,
 		2.0, // 0
@@ -316,18 +319,20 @@ tape( 'the function supports an `x` offset', opts, function test( t ) {
 	xe = new Float64Array( [ 1.0, 5.2, 6.6, 4.0, 5.0 ] );
 	ye = new Float64Array( [ 3.6, 3.8, 8.0, 9.0, 10.0 ] );
 
-	isApprox( t, x, xe, 2.0 );
-	isApprox( t, y, ye, 2.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports a `y` stride', opts, function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 0;
 	x = new Float64Array([
 		1.0, // 0
 		2.0, // 1
@@ -348,18 +353,20 @@ tape( 'the function supports a `y` stride', opts, function test( t ) {
 	xe = new Float64Array( [ -1.0, -3.0, -5.0, 4.0, 5.0 ] );
 	ye = new Float64Array( [ 1.0, 2.0, 2.0, 4.0, 3.0 ] );
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports a `y` offset', opts, function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 1;
 	x = new Float64Array([
 		1.0, // 0
 		2.0, // 1
@@ -380,8 +387,8 @@ tape( 'the function supports a `y` offset', opts, function test( t ) {
 	xe = new Float64Array( [ 5.6, 7.0, 3.0, 4.0, 5.0 ] );
 	ye = new Float64Array( [ 6.0, 7.0, 5.8, 6.0, 10.0 ] );
 
-	isApprox( t, x, xe, 1.0 );
-	isApprox( t, y, ye, 1.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
@@ -427,11 +434,13 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function leav
 });
 
 tape( 'the function supports negative strides', opts, function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 21;
 	x = new Float64Array([
 		0.6,  // 3
 		0.1,
@@ -456,18 +465,20 @@ tape( 'the function supports negative strides', opts, function test( t ) {
 	xe = new Float64Array( [ 0.9, 0.1, -0.22, 0.8, 0.18, -0.3, -0.02 ] );
 	ye = new Float64Array( [ 0.64, -1.26, 0.54, 0.2, -0.6, 0.2, 0.8 ] );
 
-	isApprox( t, x, xe, 20.0 );
-	isApprox( t, y, ye, 20.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });
 
 tape( 'the function supports complex access patterns', opts, function test( t ) {
+	var ULP;
 	var xe;
 	var ye;
 	var x;
 	var y;
 
+	ULP = 5;
 	x = new Float64Array([
 		0.6, // 1
 		0.1, // 0
@@ -492,8 +503,8 @@ tape( 'the function supports complex access patterns', opts, function test( t ) 
 	xe = new Float64Array( [ 0.78, 0.26, -0.5, 0.8, 0.9, -0.3, -0.4 ] );
 	ye = new Float64Array( [ 0.04, -0.9, 0.18, 0.7, -0.6, 0.2, 0.8 ] );
 
-	isApprox( t, x, xe, 5.0 );
-	isApprox( t, y, ye, 5.0 );
+	isApprox( t, x, xe, ULP );
+	isApprox( t, y, ye, ULP );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `blas/base/drot` from relative tolerance testing to ULP difference testing, replacing the `rtol * EPS * abs( expected )` comparisons in the `isApprox` helper with `@stdlib/assert/is-almost-same-value`. The idiom mirrors the already-migrated sibling package `blas/base/drotm`.

Files changed: `test/test.drot.js`, `test/test.drot.native.js`, `test/test.ndarray.js`, and `test/test.ndarray.native.js`. No non-test files are modified, and no test fixtures, expected values, or test cases were added, removed, or altered.

Each `ULP` constant is the **measured minimum** for its fixture set. Bounds were determined by computing, for every compared element, the smallest `n` for which `isAlmostSameValue( actual, expected, n )` returns `true`, and taking the per-test maximum. Each bound was then verified to be minimal by confirming that the test fails at `ULP - 1`.

`test/test.drot.js` and `test/test.drot.native.js`:

| Test | ULP | Previous `rtol` |
| --- | --- | --- |
| applies a plane rotation (sx=1, sy=1) | 5 | 6.0 |
| applies a plane rotation (sx=2, sy=-2) | 21 | 20.0 |
| applies a plane rotation (sx=-2, sy=1) | 21 | 20.0 |
| applies a plane rotation (sx=-1, sy=-2) | 5 | 4.0 |
| supports an `x` stride | 2 | 2.0 |
| supports negative strides | 21 | 20.0 |
| supports complex access patterns | 5 | 5.0 |

`test/test.ndarray.js` and `test/test.ndarray.native.js`:

| Test | ULP | Previous `rtol` |
| --- | --- | --- |
| applies a plane rotation (sx=1, sy=1) | 5 | 6.0 |
| applies a plane rotation (sx=2, sy=-2) | 21 | 20.0 |
| applies a plane rotation (sx=-2, sy=1) | 21 | 20.0 |
| applies a plane rotation (sx=-1, sy=-2) | 5 | 4.0 |
| supports an `x` stride | 2 | 2.0 |
| supports an `x` offset | 2 | 2.0 |
| supports a `y` stride | 0 | 1.0 |
| supports a `y` offset | 1 | 1.0 |
| supports negative strides | 21 | 20.0 |
| supports complex access patterns | 5 | 5.0 |

Tests using exact assertions (`t.deepEqual`) were left unchanged.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

The `21` ULP bounds are driven by a single element in each of those fixture sets. For the `(sx=2, sy=-2)` case, the last rotated `x` element is `0.8*(-0.4) + 0.6*0.5`, which is subject to catastrophic cancellation: the computed value is `-0.020000000000000073` against an expected literal of `-0.02`. The previous relative tolerance (`20 * EPS * abs( expected )`) permitted roughly 25 ULP at that magnitude, so `21` is a tightening rather than a relaxation, but reviewers may prefer a different treatment of that fixture.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The bounds above were measured against the JavaScript implementations. The native test files use the same bounds, matching the convention in the already-migrated `blas/base/drotm` and `blas/base/srotm`. The native add-on could not be built locally (`gfortran` is unavailable in the environment used to author this change), so the native bounds are unverified locally and rely on CI. Marked as a draft for that reason.

The JavaScript test suite was run twice at the final bounds with identical results (326 assertions in `test.drot.js`, 360 in `test.ndarray.js`, all passing), confirming determinism.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code. The migration follows the idiom established in the already-migrated `blas/base/drotm`, and the ULP bounds were measured empirically rather than guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXfLRBopGnbspYy9pzBY29

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXfLRBopGnbspYy9pzBY29)_