### PR TITLE
test: migrate `stats/incr/pcorrdist` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/pcorrdist/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/pcorrdist/test/test.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var incrpcorrdist = require( './../lib' );
 
 
@@ -100,8 +99,6 @@ tape( 'the function returns an accumulator function (known means)', function tes
 tape( 'the accumulator function incrementally computes a sample correlation distance', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var acc;
 	var x;
 	var y;
@@ -124,13 +121,7 @@ tape( 'the accumulator function incrementally computes a sample correlation dist
 
 	for ( i = 0; i < x.length; i++ ) {
 		actual = acc( x[ i ], y[ i ] );
-		if ( actual === expected[ i ] ) {
-			t.strictEqual( actual, expected[ i ], 'returns expected result. x: '+x[i]+'. y: '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - actual );
-			tol = 3.7 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'x: '+x[i]+'. y: '+y[i]+'. expected: '+expected[i]+'. actual: '+actual+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -138,8 +129,6 @@ tape( 'the accumulator function incrementally computes a sample correlation dist
 tape( 'the accumulator function incrementally computes a sample correlation distance (known means)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var acc;
 	var x;
 	var y;
@@ -162,13 +151,7 @@ tape( 'the accumulator function incrementally computes a sample correlation dist
 
 	for ( i = 0; i < x.length; i++ ) {
 		actual = acc( x[ i ], y[ i ] );
-		if ( actual === expected[ i ] ) {
-			t.strictEqual( actual, expected[ i ], 'returns expected result. x: '+x[i]+'. y: '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - actual );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'x: '+x[i]+'. y: '+y[i]+'. expected: '+expected[i]+'. actual: '+actual+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite of `stats/incr/pcorrdist` from the old EPS/relative-tolerance idiom to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352
-   replaces the two fixture-loop test blocks, which previously computed an ad hoc relative-error tolerance (`3.7 * EPS * abs( expected[i] )` and `EPS * abs( expected[i] )`) guarded by an exact-match fast path, with `t.strictEqual( isAlmostSameValue( actual, expected[ i ], N ), true, 'returns expected value' )`
-   the tightest ULP bound was found agentically (starting high, then lowering until failure, and confirming the minimum passes deterministically across two consecutive runs):
    -   `the accumulator function incrementally computes a sample correlation distance`: **1 ULP**
    -   `the accumulator function incrementally computes a sample correlation distance (known means)`: **1 ULP**
    -   (confirmed `0` ULP fails for both blocks, so `1` is the tight minimum)
-   only the test file was changed; no dependency additions to `package.json` were required (mirrors prior-art conversions in the same family, e.g. `stats/incr/mvmr`)

## Related Issues

This pull request has the following related issues:

-   #11352

## Questions

No.

## Other

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code as part of an automated, scheduled ULP-migration task, mirroring the established conversion pattern from prior PRs against #11352.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5yGGGunAyCUZS3tXx8Tys