### PR TITLE
test: migrate `stats/base/dists/gamma/mode` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/mode/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/mode/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mode = require( './../lib' );
 
 
@@ -96,10 +95,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the mode of a gamma distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -108,13 +105,7 @@ tape( 'the function returns the mode of a gamma distribution', function test( t 
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = mode( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/mode/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/mode/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -105,10 +104,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 
 tape( 'the function returns the mode of a gamma distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -117,13 +114,7 @@ tape( 'the function returns the mode of a gamma distribution', opts, function te
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = mode( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates `stats/base/dists/gamma/mode` from relative tolerance testing to ULP difference testing in `test/test.js` and `test/test.native.js`.
-   Adds the `@stdlib/assert/is-almost-same-value` import and removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` imports, along with the `delta` and `tol` locals.
-   Replaces the `if ( y === expected[i] ) { ... } else { t.ok( delta <= tol, ... ); }` branch in the fixture loop with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );`.

**Final ULP constant: `1`** (same value in both `test/test.js` and `test/test.native.js`).

This is the measured minimum. Starting from `64` and tightening, `1` is the smallest integer bound that passes across the full 200-value Julia fixture set:

-   At `1` ULP: 214/214 assertions pass in `test/test.js` and 214/214 in `test/test.native.js`.
-   At `0` ULP: 49 of the 200 fixture assertions fail, so the bound cannot be tightened further.

The suite was run twice at the final bound (with the native add-on built, so `test/test.native.js` was not skipped) and produced identical results both times. The JavaScript and C implementations both evaluate `( alpha-1.0 ) / beta`, which involves only correctly rounded IEEE-754 subtraction and division with no opportunity for FMA contraction, so the same bound applies to both.

Only the two test files are changed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The conversion mirrors the idiom used in previously merged conversions in the same family, e.g. `stats/base/dists/gamma/skewness` (e134bfc0b) and `stats/base/dists/weibull/mean` (74233c562).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task. It selected the package, studied prior merged conversions in the same family to match the established idiom, applied the migration, and determined the minimum ULP bound empirically by running the package test suite.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3J3Zzc2TfxMUXXuybyiwu

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3J3Zzc2TfxMUXXuybyiwu)_