### PR TITLE
test: migrate `stats/base/dists/cosine/pdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/test/test.factory.js
@@ -183,7 +183,7 @@ tape( 'the created function evaluates the pdf for `x` given positive `mu`', func
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( mu[i], s[i] );
 		y = pdf( x[i] );
-		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
+		if ( expected[i] !== null && !( expected[i] === 0.0 && y < EPS ) ) {
 			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
@@ -206,7 +206,7 @@ tape( 'the created function evaluates the pdf for `x` given negative `mu`', func
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( mu[i], s[i] );
 		y = pdf( x[i] );
-		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
+		if ( expected[i] !== null && !( expected[i] === 0.0 && y < EPS ) ) {
 			t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 		}
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/test/test.factory.js
@@ -22,7 +22,7 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -169,9 +169,7 @@ tape( 'if `s` equals `0`, the created function evaluates a degenerate distributi
 
 tape( 'the created function evaluates the pdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var pdf;
-	var tol;
 	var mu;
 	var s;
 	var x;
@@ -186,13 +184,7 @@ tape( 'the created function evaluates the pdf for `x` given positive `mu`', func
 		pdf = factory( mu[i], s[i] );
 		y = pdf( x[i] );
 		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -200,9 +192,7 @@ tape( 'the created function evaluates the pdf for `x` given positive `mu`', func
 
 tape( 'the created function evaluates the pdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var pdf;
-	var tol;
 	var mu;
 	var s;
 	var x;
@@ -217,13 +207,7 @@ tape( 'the created function evaluates the pdf for `x` given negative `mu`', func
 		pdf = factory( mu[i], s[i] );
 		y = pdf( x[i] );
 		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 4.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -231,9 +215,7 @@ tape( 'the created function evaluates the pdf for `x` given negative `mu`', func
 
 tape( 'the created function evaluates the pdf for `x` given large variance ( = large `s`)', function test( t ) {
 	var expected;
-	var delta;
 	var pdf;
-	var tol;
 	var mu;
 	var s;
 	var x;
@@ -248,13 +230,7 @@ tape( 'the created function evaluates the pdf for `x` given large variance ( = l
 		pdf = factory( mu[i], s[i] );
 		y = pdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/test/test.native.js
@@ -148,7 +148,7 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', opts, functi
 	s = positiveMean.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], s[i] );
-		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
+		if ( expected[i] !== null && !( expected[i] === 0.0 && y < EPS ) ) {
 			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
@@ -169,7 +169,7 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', opts, functi
 	s = negativeMean.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], s[i] );
-		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
+		if ( expected[i] !== null && !( expected[i] === 0.0 && y < EPS ) ) {
 			t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 		}
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/test/test.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -136,8 +136,6 @@ tape( 'if provided `s` equal to `0`, the function evaluates a degenerate distrib
 
 tape( 'the function evaluates the pdf for `x` given positive `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -151,13 +149,7 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', opts, functi
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -165,8 +157,6 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', opts, functi
 
 tape( 'the function evaluates the pdf for `x` given negative `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -180,13 +170,7 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', opts, functi
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 4.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -194,8 +178,6 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', opts, functi
 
 tape( 'the function evaluates the pdf for `x` given large variance ( = large `s` )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -209,13 +191,7 @@ tape( 'the function evaluates the pdf for `x` given large variance ( = large `s`
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/test/test.pdf.js
@@ -22,7 +22,7 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -127,8 +127,6 @@ tape( 'if provided `s` equal to `0`, the function evaluates a degenerate distrib
 
 tape( 'the function evaluates the pdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -142,13 +140,7 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', function tes
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -156,8 +148,6 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', function tes
 
 tape( 'the function evaluates the pdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -171,13 +161,7 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', function tes
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 4.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -185,8 +169,6 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', function tes
 
 tape( 'the function evaluates the pdf for `x` given large variance ( = large `s` )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -200,13 +182,7 @@ tape( 'the function evaluates the pdf for `x` given large variance ( = large `s`
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/test/test.pdf.js
@@ -139,7 +139,7 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', function tes
 	s = positiveMean.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], s[i] );
-		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
+		if ( expected[i] !== null && !( expected[i] === 0.0 && y < EPS ) ) {
 			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
@@ -160,7 +160,7 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', function tes
 	s = negativeMean.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], s[i] );
-		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
+		if ( expected[i] !== null && !( expected[i] === 0.0 && y < EPS ) ) {
 			t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 		}
 	}


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/cosine/pdf` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `abs`/`delta`/`tol` comparison in `test/test.pdf.js`, `test/test.factory.js`, and `test/test.native.js` with `isAlmostSameValue( y, expected[ i ], N )`, adding the `@stdlib/assert/is-almost-same-value` require in place of `@stdlib/math/base/special/abs`.
-   uses the **minimum required** ULP value at each assertion site. The pre-existing fixture guards (including the `expected[i] === 0.0 && y < EPS` check) are left untouched, so `@stdlib/constants/float64/eps` remains required.

The ULP bounds were measured against the full fixture set rather than guessed. Per fixture, the maximum observed ULP difference between the returned value and the Julia-generated expected value is:

| Fixture | Previous tolerance | ULP bound | Measured max ULP difference |
| --- | --- | --- | --- |
| `positive_mean` | `3.0 * EPS * abs( expected[i] )` | `0` | `0` |
| `negative_mean` | `4.0 * EPS * abs( expected[i] )` | `4` | `4` |
| `large_variance` | `3.0 * EPS * abs( expected[i] )` | `2` | `2` |

The same three bounds apply to `test/test.pdf.js`, `test/test.factory.js`, and `test/test.native.js`; the JS and C implementations produce bit-identical results over these fixtures, so no JS-vs-C divergence handling is required.

Notes on the bounds:

-   `negative_mean` and `large_variance` are tight: lowering them to `3` and `1` respectively produces 9 assertion failures.
-   Every `expected` value in the `positive_mean` fixture is exactly `0.0` (the sampled `x` values all fall outside the distribution's support), and each is skipped by the pre-existing `expected[i] === 0.0 && y < EPS` guard. No assertion in that test executes, so `0` is both the minimum and behavior-preserving: under the previous code, `tol` evaluated to `0.0` there, which likewise required exact equality.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed:

-   `make test TESTS_FILTER=".*/stats/base/dists/cosine/pdf/.*"` passes: 1054 + 1057 + 3 + 1054 assertions, 0 failures. The native add-on was built locally with `node-gyp`, so `test/test.native.js` was actually executed rather than skipped.
-   The suite was run twice at the final ULP values with identical results, to rule out non-determinism.
-   ESLint is clean for all three files under `etc/eslint/.eslintrc.tests.js`.
-   Only the three test files are modified; no source, documentation, or fixture changes.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, running unattended as a scheduled task. It studied #11352 and the already-merged conversions in this family (`stats/base/dists/cosine/cdf`, `stats/base/dists/logistic/pdf`) to match the established idiom, measured the ULP bounds empirically against the full fixture set, and verified tightness by confirming that lower values fail. Opened as a draft for human review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DH913xWZTC1PD9SV1uKidH

---
_Generated by [Claude Code](https://claude.ai/code/session_01DH913xWZTC1PD9SV1uKidH)_