### PR TITLE
test: migrate `stats/base/dists/hypergeometric/skewness` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/skewness/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/skewness/test/test.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var skewness = require( './../lib' );
 
 
@@ -119,8 +118,6 @@ tape( 'if provided an `n` which is not a nonnegative integer, the function retur
 
 tape( 'the function returns the skewness of a hypergeometric distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var N;
 	var K;
 	var n;
@@ -133,13 +130,7 @@ tape( 'the function returns the skewness of a hypergeometric distribution', func
 	n = data.n;
 	for ( i = 0; i < n.length; i++ ) {
 		y = skewness( N[i], K[i], n[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'N: '+N[i]+', K: '+K[i]+', n: '+n[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. N: '+N[i]+'. K: '+K[i]+'. n: '+n[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/skewness/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/skewness/test/test.native.js
@@ -22,10 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -87,8 +86,6 @@ tape( 'if provided an `n` which is not a nonnegative integer, the function retur
 
 tape( 'the function returns the skewness of a hypergeometric distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var N;
 	var K;
 	var n;
@@ -101,13 +98,7 @@ tape( 'the function returns the skewness of a hypergeometric distribution', opts
 	n = data.n;
 	for ( i = 0; i < n.length; i++ ) {
 		y = skewness( N[i], K[i], n[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'N: '+N[i]+', K: '+K[i]+', n: '+n[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. N: '+N[i]+'. K: '+K[i]+'. n: '+n[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/hypergeometric/skewness` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `delta`/`tol`/`EPS` tolerance arithmetic in `test/test.js` and `test/test.native.js` with `isAlmostSameValue( y, expected[ i ], 1 )`, adding the `@stdlib/assert/is-almost-same-value` require and dropping the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

Only the two test files are changed; no source, fixture, or package metadata was touched.

### ULP bound

The final ULP constant is **1** for both `test/test.js` and `test/test.native.js`, and this is the measured minimum:

-   Over the full 100-value Julia fixture set (`test/fixtures/julia/data.json`), 66 values are bit-for-bit exact and the remaining 34 differ by exactly 1 ULP. The maximum observed ULP difference is therefore 1, for both the JavaScript and the native (C addon) implementations.
-   Tightening to `0` fails 34 of the 120 assertions in `test/test.js`, confirming 1 is the minimum bound which passes.
-   The suite was run twice at the final bound with the native addon built locally; both runs were green and identical (`test.js`: 120/120, `test.native.js`: 108/108), so there is no FMA/arch-dependent flakiness at this bound.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Opened as a draft.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated, unattended run over #11352. The ULP bound was measured empirically against the fixture set rather than guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132ozAreeH8GYagxGFNNVvX

---
_Generated by [Claude Code](https://claude.ai/code/session_0132ozAreeH8GYagxGFNNVvX)_