### PR TITLE
test: migrate `stats/base/dists/arcsine/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/stdev/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -72,8 +71,6 @@ tape( 'if provided `a >= b`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function returns the standard deviation of an arcsine distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -84,13 +81,7 @@ tape( 'the function returns the standard deviation of an arcsine distribution', 
 	b = data.b;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/stdev/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -81,8 +80,6 @@ tape( 'if provided `a >= b`, the function returns `NaN`', opts, function test( t
 
 tape( 'the function returns the standard deviation of an arcsine distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -93,13 +90,7 @@ tape( 'the function returns the standard deviation of an arcsine distribution', 
 	b = data.b;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for stats/base/dists/arcsine/stdev from relative tolerance (EPS/delta/tol) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
-   updates test/test.js and test/test.native.js. No other files are changed.
-   removes the now-unused EPS and abs imports and the corresponding delta/tol variable declarations from each file.
-   the ULP bound was verified directly against the fixture data using a script that computes the actual ULP distance between computed and expected values for every input. Verified minimum: 1 (identical across JS and native implementations, confirmed by running the same verification against both).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
