### PR TITLE
test: migrate `stats/base/dists/planck/kurtosis` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/planck/kurtosis/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/kurtosis/test/test.js
@@ -22,8 +22,7 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var kurtosis = require( './../lib' );
 
 
@@ -61,8 +60,6 @@ tape( 'if provided a shape parameter `lambda` which is nonpositive, the function
 tape( 'the function returns the excess kurtosis of a Planck distribution', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var y;
 
@@ -70,13 +67,7 @@ tape( 'the function returns the excess kurtosis of a Planck distribution', funct
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = kurtosis( lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'lambda: '+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/kurtosis/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/kurtosis/test/test.native.js
@@ -23,8 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -70,8 +69,6 @@ tape( 'if provided a shape parameter `lambda` which is nonpositive, the function
 tape( 'the function returns the excess kurtosis of a Planck distribution', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var y;
 
@@ -79,13 +76,7 @@ tape( 'the function returns the excess kurtosis of a Planck distribution', opts,
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = kurtosis( lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'lambda: '+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite of `stats/base/dists/planck/kurtosis` from the old EPS/relative-tolerance idiom to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352
-   replaces the fixture-loop test block, which previously computed an ad hoc relative-error tolerance (`1.0 * EPS * abs( expected[i] )`) guarded by an exact-match fast path, with `t.strictEqual( isAlmostSameValue( actual, expected[ i ], N ), true, 'returns expected value' )`
-   the tightest ULP bound was found agentically (starting high, then lowering until failure, and confirming the minimum passes deterministically across multiple consecutive runs):
    -   `the function returns the excess kurtosis of a Planck distribution`: **1 ULP** (across 1005 assertions from the `test/fixtures/python/data.json` fixture set)
    -   confirmed `0` ULP fails (100/1005 assertions fail), so `1` is the tight minimum
-   applied the identical change to `test/test.native.js`
-   only the test files were changed; no dependency additions to `package.json` were required (mirrors prior-art conversions in the same family, e.g. `stats/base/dists/bernoulli/kurtosis`)

## Related Issues

This pull request has the following related issues:

-   #11352

## Questions

No.

## Other

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code as part of an automated, scheduled ULP-migration task, mirroring the established conversion pattern from prior PRs against #11352.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126j9dpF9U4PP8GGvvya6H3

---
_Generated by [Claude Code](https://claude.ai/code/session_0126j9dpF9U4PP8GGvvya6H3)_