### PR TITLE
test: migrate `stats/base/dists/geometric/pmf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/pmf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/pmf/test/test.factory.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -136,9 +135,7 @@ tape( 'if provided a `p` outside of `[0,1]`, the created function always returns
 
 tape( 'the created function evaluates the pmf for `x` given small `p`', function test( t ) {
 	var expected;
-	var delta;
 	var pmf;
-	var tol;
 	var i;
 	var p;
 	var x;
@@ -150,22 +147,14 @@ tape( 'the created function evaluates the pmf for `x` given small `p`', function
 	for ( i = 0; i < x.length; i++ ) {
 		pmf = factory( p[i] );
 		y = pmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pmf for `x` given large `p`', function test( t ) {
 	var expected;
-	var delta;
 	var pmf;
-	var tol;
 	var p;
 	var x;
 	var y;
@@ -177,13 +166,7 @@ tape( 'the function evaluates the pmf for `x` given large `p`', function test( t
 	for ( i = 0; i < x.length; i++ ) {
 		pmf = factory( p[i] );
 		y = pmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/pmf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/pmf/test/test.native.js
@@ -22,10 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -105,8 +104,6 @@ tape( 'if provided a success probability `p` outside of `[0,1]`, the function al
 
 tape( 'the function evaluates the pmf for `x` given small parameter `p`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var p;
 	var y;
@@ -117,21 +114,13 @@ tape( 'the function evaluates the pmf for `x` given small parameter `p`', opts, 
 	p = smallP.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. p:'+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pmf for `x` given large parameter `p`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var p;
 	var y;
@@ -142,13 +131,7 @@ tape( 'the function evaluates the pmf for `x` given large parameter `p`', opts, 
 	p = largeP.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/pmf/test/test.pmf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/pmf/test/test.pmf.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pmf = require( './../lib' );
 
 
@@ -96,8 +95,6 @@ tape( 'if provided a success probability `p` outside of `[0,1]`, the function al
 
 tape( 'the function evaluates the pmf for `x` given small parameter `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var p;
 	var y;
@@ -108,21 +105,13 @@ tape( 'the function evaluates the pmf for `x` given small parameter `p`', functi
 	p = smallP.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. p:'+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pmf for `x` given large parameter `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var p;
 	var y;
@@ -133,13 +122,7 @@ tape( 'the function evaluates the pmf for `x` given large parameter `p`', functi
 	p = largeP.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the tests for `@stdlib/stats/base/dists/geometric/pmf` from computed EPS-based relative tolerance comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   Replaces the `if ( y === expected[i] ) { ... } else { delta/tol ... }` fixture-loop branches in `test/test.pmf.js`, `test/test.factory.js`, and `test/test.native.js` with a single `t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );` assertion.
-   Drops the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**Final ULP constants (identical in all three test files, one per fixture block):**

| Fixture | Previous tolerance | Final ULP bound | Measured max ULP difference |
| --- | --- | --- | --- |
| `small_p.json` | `2.0 * EPS * abs( expected[i] )` | `2` | 2 |
| `large_p.json` | `1.5 * EPS * abs( expected[i] )` | `2` | 2 |

The bounds were tightened empirically rather than assumed. The maximum ULP difference between the implementation and the Julia fixtures was measured over the entire fixture set (1000 values per fixture, 2000 values total) for both the main export and the `factory` path, which agree exactly. `2` is the tightest integer that passes: at `1`, each fixture set fails with exactly 31 failing assertions.

The error distribution is tight and dominated by exact agreement:

| Fixture | 0 ULP | 1 ULP | 2 ULP |
| --- | --- | --- | --- |
| `small_p.json` | 866 | 122 | 12 |
| `large_p.json` | 851 | 130 | 19 |

The suite was run twice at the final bound to confirm determinism, with no FMA/arch-dependent variation:

-   `test/test.pmf.js`: 2013/2013 assertions passing on both runs.
-   `test/test.factory.js`: 2017/2017 assertions passing on both runs.
-   `test/test.js`: 3/3 assertions passing on both runs.
-   `test/test.native.js`: skipped (the native add-on is not built in this environment), so its bounds mirror the JS ones, consistent with the same-family precedent noted below.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves a part of #11352

## Questions

> Any questions for reviewers of this pull request?

One thing worth a reviewer's eye:

1.  `test/test.native.js` could not be executed here because the native add-on is not built, so its ULP values are the measured JS ones rather than independently measured against the C implementation. The C implementation (`src/main.c`) mirrors the JS one exactly, computing `p * pow( 1-p, x )` via `stdlib_base_pow`, so bit-identical results are expected; every already-converted package I checked (`betaprime/pdf`, `invgamma/logpdf`, `logistic/pdf`) also uses identical values across the JS and native test files. Still worth a reviewer confirming against a build with the add-on compiled.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the three test files are modified; no source, fixture, docs, or manifest changes.
-   The idiom mirrors the same-family precedent in `stats/base/dists/betaprime/pdf` (#15011) and `stats/base/dists/logistic/pdf` (#15024): an inline ULP literal per fixture block rather than a shared named constant, `isAlmostSameValue` required immediately after `tape`, and the assertion message normalized to `'returns expected value'`.
-   Verification note: `make install-node-modules` could not complete in this environment because the reachable npm registry snapshot does not contain `es-object-atoms@^1.1.2`, which a transitive dependency requires. Tests and linting were therefore run against a dependency tree installed with that package pinned to `1.1.1`. The pre-commit hooks ran and passed on this commit: the filename lint, the repo's own ESLint configuration for tests (`etc/eslint/.eslintrc.tests.js`, including the local `eslint-plugin-stdlib` rules) with no findings on the three changed files, and `commitlint` with 0 problems and 0 warnings. Two checks could not execute for environment reasons unrelated to this diff: `editorconfig-checker` downloads a release binary from GitHub, which this session's network scoping blocks, so EditorConfig compliance (LF endings, UTF-8, tabs, no trailing whitespace, final newline) was verified manually instead and `git diff --check` is clean; and the pre-push production license check requires a fully installed `node_modules` tree, which cannot be built here. This diff adds no dependencies — it removes two internal `@stdlib` requires and adds one.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task. It selected the package, studied the idiom used by already-merged conversions, applied the conversion, measured the minimum ULP bounds empirically against the fixtures, and ran the tests and linter.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013z7jZwwtZ7e4DTsaX2DDu5

---
_Generated by [Claude Code](https://claude.ai/code/session_013z7jZwwtZ7e4DTsaX2DDu5)_