### PR TITLE
test: migrate `stats/base/dists/invgamma/pdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -163,11 +162,9 @@ tape( 'if provided `alpha <= 0`, the created function always returns `NaN`', fun
 
 tape( 'the created function evaluates the pdf for `x` given large `alpha` and `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
 	var pdf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -179,24 +176,16 @@ tape( 'the created function evaluates the pdf for `x` given large `alpha` and `b
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( alpha[ i ], beta[ i ] );
 		y = pdf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the pdf for `x` given a large shape parameter `alpha`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
 	var pdf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -208,24 +197,16 @@ tape( 'the created function evaluates the pdf for `x` given a large shape parame
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( alpha[ i ], beta[ i ] );
 		y = pdf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the pdf for `x` given a large scale parameter `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
 	var pdf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -237,13 +218,7 @@ tape( 'the created function evaluates the pdf for `x` given a large scale parame
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( alpha[ i ], beta[ i ] );
 		y = pdf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 26 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/test/test.native.js
@@ -24,10 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -125,10 +124,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 
 tape( 'the function evaluates the pdf for `x` given large `alpha` and `beta`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -139,23 +136,15 @@ tape( 'the function evaluates the pdf for `x` given large `alpha` and `beta`', o
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[ i ], alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 130.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given large shape parameter `alpha`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -166,23 +155,15 @@ tape( 'the function evaluates the pdf for `x` given large shape parameter `alpha
 	beta = largeShape.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[ i ], alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 70.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given large scale parameter `beta`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -193,13 +174,7 @@ tape( 'the function evaluates the pdf for `x` given large scale parameter `beta`
 	beta = largeRate.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[ i ], alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 75.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 26 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/test/test.pdf.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( './../lib' );
 
 
@@ -116,10 +115,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function evaluates the pdf for `x` given large `alpha` and `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -130,23 +127,15 @@ tape( 'the function evaluates the pdf for `x` given large `alpha` and `beta`', f
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[ i ], alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given large shape parameter `alpha`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -157,23 +146,15 @@ tape( 'the function evaluates the pdf for `x` given large shape parameter `alpha
 	beta = largeShape.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[ i ], alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given large scale parameter `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -184,13 +165,7 @@ tape( 'the function evaluates the pdf for `x` given large scale parameter `beta`
 	beta = largeRate.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[ i ], alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 26 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/invgamma/pdf` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `abs`/`delta`/`tol` comparison in `test/test.pdf.js`, `test/test.factory.js`, and `test/test.native.js` with `isAlmostSameValue( y, expected[ i ], N )`, adding the `@stdlib/assert/is-almost-same-value` require in place of `@stdlib/math/base/special/abs`.
-   uses the **minimum required** ULP value at each assertion site. `@stdlib/constants/float64/eps` was only used to compute `tol` in these files, so its require is removed along with the `delta`/`tol` declarations.

The ULP bounds were measured against the full fixture set rather than guessed. Per fixture, the maximum observed ULP difference between the returned value and the Julia-generated expected value is:

| Fixture | Previous tolerance (JS) | Previous tolerance (native) | ULP bound | Measured max ULP difference |
| --- | --- | --- | --- | --- |
| `both_large` | `EPS * abs( expected[i] )` | `130.0 * EPS * abs( expected[i] )` | `0` | `0` |
| `large_shape` | `EPS * abs( expected[i] )` | `70.0 * EPS * abs( expected[i] )` | `0` | `0` |
| `large_rate` | `20.0 * EPS * abs( expected[i] )` | `75.0 * EPS * abs( expected[i] )` | `26` | `26` |

The same three bounds apply to `test/test.pdf.js`, `test/test.factory.js`, and `test/test.native.js`; the JS and C implementations produce bit-identical results over these fixtures, so no JS-vs-C divergence handling is required.

Notes on the bounds:

-   `large_rate` is tight: lowering it from `26` to `25` produces an assertion failure in each of the three files.
-   Every value in the `both_large` and `large_shape` fixtures (1000 each) is returned bit-for-bit equal to the expected value by all three code paths, so `0` is the minimum. This is also what the previous code effectively asserted for those fixtures, since every case took the `y === expected[ i ]` exact-equality branch and the tolerance branch never executed.
-   Both the JS and C implementations are built from stdlib's own portable `ln`, `exp`, and `gammaln` routines rather than the platform libm, so the `0` bounds are not expected to be platform-sensitive.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed:

-   `make test TESTS_FILTER=".*/stats/base/dists/invgamma/pdf/.*"` passes: 3019 + 3022 + 3 + 3019 assertions, 0 failures. The native add-on was built locally with `node-gyp`, so `test/test.native.js` was actually executed rather than skipped.
-   The suite was run twice at the final ULP values with identical results, to rule out non-determinism.
-   `make eslint-tests TESTS_FILTER=".*/stats/base/dists/invgamma/pdf/.*"` is clean.
-   Only the three test files are modified; no source, documentation, or fixture changes.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, running unattended as a scheduled task. It studied #11352 and the already-merged conversions in this family (`stats/base/dists/betaprime/pdf`, `stats/base/dists/logistic/pdf`) to match the established idiom, measured the ULP bounds empirically against the full fixture set, and verified tightness by confirming that lower values fail. Opened as a draft for human review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD8zNuJJzSBnEuU4gtBkwc

---
_Generated by [Claude Code](https://claude.ai/code/session_01RD8zNuJJzSBnEuU4gtBkwc)_