### PR TITLE
test: migrate `stats/incr/nanmstdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nanmstdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmstdev/test/test.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var randu = require( '@stdlib/random/base/randu' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var incrnanmstdev = require( './../lib' );
 
 
@@ -196,9 +195,7 @@ tape( 'the accumulator function computes a moving corrected sample standard devi
 tape( 'if not provided an input value, the accumulator function returns the current corrected sample standard deviation', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
-	var tol;
 	var acc;
 	var i;
 
@@ -213,19 +210,15 @@ tape( 'if not provided an input value, the accumulator function returns the curr
 
 	expected = sqrt( 19.0 );
 	actual = acc();
-	delta = abs( actual - expected );
-	tol = EPS * expected;
 
-	t.strictEqual( delta < tol, true, 'expected: '+expected+'. actual: '+actual+'. tol: '+tol+'. delta: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( actual, expected, 0 ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if not provided an input value, the accumulator function returns the current corrected sample standard deviation (known mean)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
-	var tol;
 	var acc;
 	var i;
 
@@ -240,10 +233,8 @@ tape( 'if not provided an input value, the accumulator function returns the curr
 
 	expected = sqrt( 12.666666666666666 );
 	actual = acc();
-	delta = abs( actual - expected );
-	tol = EPS * expected;
 
-	t.strictEqual( delta < tol, true, 'expected: '+expected+'. actual: '+actual+'. tol: '+tol+'. delta: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( actual, expected, 0 ), true, 'returns expected value' );
 	t.end();
 });
 


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/incr/nanmstdev` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `abs`/`delta`/`tol` comparison in `test/test.js` with `isAlmostSameValue( actual, expected, N )`, adding the `@stdlib/assert/is-almost-same-value` require in place of `@stdlib/math/base/special/abs`.
-   uses the **minimum required** ULP value at each assertion site. `@stdlib/constants/float64/eps` was only used to compute `tol` in this file, so its require is removed along with the `delta`/`tol` declarations.

The package has a single test file and no `test/test.native.js`, so only `test/test.js` is touched.

The ULP bounds were measured rather than guessed. Both converted assertion sites were instrumented to report the smallest ULP value for which `isAlmostSameValue` returns `true`:

| Assertion site | Previous tolerance | ULP bound | Measured minimum |
| --- | --- | --- | --- |
| unknown mean, `expected = sqrt( 19.0 )` | `EPS * expected` | `0` | `0` |
| known mean, `expected = sqrt( 12.666666666666666 )` | `EPS * expected` | `0` | `0` |

Notes on the bounds:

-   Both accumulator results are returned bit-for-bit equal to the expected value, so `0` is the minimum possible value and the bounds cannot be tightened further.
-   This matches what the previous code effectively asserted: `delta` evaluated to `0` at both sites, so the `delta < tol` comparison was already testing exact equality in practice.
-   This mirrors the already-merged conversion for the sibling accumulator `stats/incr/mvmr` (#15005), which uses `0` at the two structurally identical assertion sites.
-   The remaining exact comparisons in this file (`t.deepEqual` over `sqrt(...)` sequences, `t.strictEqual( acc(), sqrt( 0.5 ) )`, `null`/`0.0`/NaN-handling checks) were already exact and are left unchanged.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed:

-   `make test TESTS_FILTER=".*/stats/incr/nanmstdev/.*"` passes: 273 assertions, 0 failures.
-   The suite was run twice at the final ULP values with identical results, to rule out non-determinism.
-   ESLint is clean for the modified file under the repository's flat configuration (`eslint.flat.config.js`), matching the baseline for the already-converted `stats/incr/mvmr/test/test.js`.
-   Only `test/test.js` is modified; no source, documentation, benchmark, or fixture changes.

One environment caveat, noted for transparency: the `lint-editorconfig-files` pre-commit step could not run in the sandbox, because the `editorconfig-checker` npm wrapper downloads its binary from a GitHub release outside the repositories this session can reach. The applicable EditorConfig rules for `*.js` (`end_of_line = lf`, `charset = utf-8`, `trim_trailing_whitespace = true`, `insert_final_newline = true`, `indent_style = tab`) were instead verified directly against the modified file: LF endings, ASCII/UTF-8, no trailing whitespace, a final newline, and tab-only indentation.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, running unattended as a scheduled task. It studied #11352 and the already-merged conversions in this family (`stats/incr/mvmr`, `stats/incr/nancovariance`) to match the established idiom, measured the ULP bounds empirically at each assertion site, and confirmed that `0` is the floor. Opened as a draft for human review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9XJSL3BdYv1zsYPSNAfH

---
_Generated by [Claude Code](https://claude.ai/code/session_014P9XJSL3BdYv1zsYPSNAfH)_