### PR TITLE
docs: fix return annotation

### DIFF
--- a/lib/node_modules/@stdlib/number/float64/base/ulp-difference/src/main.c
+++ b/lib/node_modules/@stdlib/number/float64/base/ulp-difference/src/main.c
@@ -51,7 +51,7 @@ static uint64_t monotone_key( const uint64_t word ) {
 *
 * @example
 * double d = stdlib_base_float64_ulp_difference( 0.0 / 0.0, 1.0 );
-* // returns 0.0/0.0
+* // returns NaN
 */
 double stdlib_base_float64_ulp_difference( const double x, const double y ) {
 	stdlib_base_float64_ulp_difference_word_t ux;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   provides follow-up fixes for commits merged to `develop` between `56c8136` (2026-09-07 02:21 PT) and `b5e2b90` (2026-09-07 04:49 PT). All 25 commits in the window were reviewed for typos, bugs, and style guide violations; one issue was found.

**`number/float64/base/ulp-difference`**

-   b5e2b90 (ulp-difference C impl): NaN example annotation in src/main.c says `// returns 0.0/0.0` — every other package spells this `// returns NaN`, including this package's own lib/main.js; only float32's sibling shares the mistake. Fixed to `// returns NaN`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** The commit window was reviewed by independent passes for (1) stdlib style guide compliance (new packages compared file-by-file against established reference packages; mechanical refactors checked for internal consistency across all variants) and (2) bugs in the introduced code (the new C `ulp-difference` implementation was compiled and cross-checked against the JS implementation over 324 value pairs; all new BLAS package test suites and migrated ULP-based test suites were executed; every new TSDoc example was run and its documented output verified; migrated ULP tolerances were recomputed against fixture data and confirmed to equal measured maxima). Anything requiring interpretation or judgment (subjective style preferences, tightened-but-correct tolerances, tool-generated doc ordering) was deliberately excluded. The pre-existing identical annotation in `number/float32/base/ulp-difference/src/main.c` was left untouched, as it falls outside the reviewed commit window.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by an automated Claude Code review of the last 24 hours of commits merged to `develop`; the review, the fix, and this PR description were AI-generated and are pending human audit.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lji3yvLBJaThLCZFnCYNUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lji3yvLBJaThLCZFnCYNUY)_