### PR TITLE
test: migrate `stats/base/dists/frechet/pdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/pdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -142,9 +141,7 @@ tape( 'if provided a nonpositive `s`, the created function always returns `NaN`'
 tape( 'the created function evaluates the pdf for `x` given large `alpha`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
 	var pdf;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -157,13 +154,7 @@ tape( 'the created function evaluates the pdf for `x` given large `alpha`', func
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( alpha[i], s[i], 0.0 );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 150.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. m: 0. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 221 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -171,9 +162,7 @@ tape( 'the created function evaluates the pdf for `x` given large `alpha`', func
 tape( 'the created function evaluates the pdf for `x` given large `s`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
 	var pdf;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -186,13 +175,7 @@ tape( 'the created function evaluates the pdf for `x` given large `s`', function
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( alpha[i], s[i], 0.0 );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 16 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -200,9 +183,7 @@ tape( 'the created function evaluates the pdf for `x` given large `s`', function
 tape( 'the created function evaluates the pdf for `x` given large `alpha` and `s`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
 	var pdf;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -215,13 +196,7 @@ tape( 'the created function evaluates the pdf for `x` given large `alpha` and `s
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( alpha[i], s[i], 0.0 );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1200.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1514 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/pdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -138,8 +137,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', opts, functio
 tape( 'the function evaluates the pdf for `x` given large `alpha`', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -151,13 +148,7 @@ tape( 'the function evaluates the pdf for `x` given large `alpha`', opts, functi
 	s = largeShape.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[ i ], alpha[ i ], s[ i ], 0.0 );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', s: '+s[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 150.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. s: '+s[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 221 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -165,8 +156,6 @@ tape( 'the function evaluates the pdf for `x` given large `alpha`', opts, functi
 tape( 'the function evaluates the pdf for `x` given large `s`', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -178,13 +167,7 @@ tape( 'the function evaluates the pdf for `x` given large `s`', opts, function t
 	s = largeScale.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[ i ], alpha[ i ], s[ i ], 0.0 );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', s: '+s[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. s: '+s[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 16 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -192,8 +175,6 @@ tape( 'the function evaluates the pdf for `x` given large `s`', opts, function t
 tape( 'the function evaluates the pdf for `x` given large `alpha` and `s`', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -205,13 +186,7 @@ tape( 'the function evaluates the pdf for `x` given large `alpha` and `s`', opts
 	s = bothLarge.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[ i ], alpha[ i ], s[ i ], 0.0 );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', s: '+s[ i ]+', m: 0, y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1200.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. s: '+s[ i ]+'. y: '+y+'. m: 0. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1514 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/pdf/test/test.pdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( './../lib' );
 
 
@@ -129,8 +128,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', function test
 tape( 'the function evaluates the pdf for `x` given large `alpha`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -142,13 +139,7 @@ tape( 'the function evaluates the pdf for `x` given large `alpha`', function tes
 	s = largeShape.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], alpha[i], s[i], 0.0 );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 150.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 221 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -156,8 +147,6 @@ tape( 'the function evaluates the pdf for `x` given large `alpha`', function tes
 tape( 'the function evaluates the pdf for `x` given large `s`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -169,13 +158,7 @@ tape( 'the function evaluates the pdf for `x` given large `s`', function test( t
 	s = largeScale.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], alpha[i], s[i], 0.0 );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 16 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -183,8 +166,6 @@ tape( 'the function evaluates the pdf for `x` given large `s`', function test( t
 tape( 'the function evaluates the pdf for `x` given large `alpha` and `s`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var x;
 	var y;
@@ -196,13 +177,7 @@ tape( 'the function evaluates the pdf for `x` given large `alpha` and `s`', func
 	s = bothLarge.s;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], alpha[i], s[i], 0.0 );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1200.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. s: '+s[i]+'. y: '+y+'. m: 0. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1514 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/frechet/pdf` from relative tolerance testing to ULP difference testing, replacing the `delta`/`tol` comparisons in the Julia fixture loops with `isAlmostSameValue( y, expected[ i ], N )` assertions.
-   updates `test/test.pdf.js`, `test/test.factory.js`, and `test/test.native.js`. Only test files are changed; no implementation, documentation, or fixture changes.

The ULP bounds are the measured minimums over the full fixture sets (each set has 1000 values); one lower and the corresponding fixture set fails:

| Fixture | Previous tolerance | ULP bound | Minimum? |
| --- | --- | --- | --- |
| `large_shape.json` | `150.0 * EPS * abs( expected[ i ] )` | `221` | yes (`220` fails) |
| `large_scale.json` | `40.0 * EPS * abs( expected[ i ] )` | `16` | yes (`15` fails) |
| `both_large.json` | `1200.0 * EPS * abs( expected[ i ] )` | `1514` | yes (`1513` fails) |

The native add-on was built locally so that `test/test.native.js` actually ran rather than being skipped. The C implementation returns bit-identical values to the JavaScript implementation for every fixture value, so `test/test.native.js` uses the same bounds as the JavaScript tests.

`make test TESTS_FILTER=".*/stats/base/dists/frechet/pdf/.*"` passes (3024 assertions per file, no skips), and was run twice at the final bounds with identical results. `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/frechet/pdf/.*"` is clean.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The idiom mirrors the already-migrated sibling package `stats/base/dists/frechet/logpdf`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, which performed the mechanical test migration, measured the minimum ULP bounds against the fixture sets, and verified the tests and linting locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZsaqt7D1H1iv4pZRWRtRZ)_