### PR TITLE
test: migrate `stats/base/dists/gumbel/mean` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mean/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mean = require( './../lib' );
 
 
@@ -76,9 +75,7 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', function t
 
 tape( 'the function returns the mean of a Gumbel distribution', function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -89,13 +86,7 @@ tape( 'the function returns the mean of a Gumbel distribution', function test( t
 	for ( i = 0; i < mu.length; i++ ) {
 		y = mean( mu[i], beta[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mean/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -85,9 +84,7 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', opts, func
 
 tape( 'the function returns the mean of a Gumbel distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var beta;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -97,14 +94,8 @@ tape( 'the function returns the mean of a Gumbel distribution', opts, function t
 	beta = data.beta;
 	for ( i = 0; i < mu.length; i++ ) {
 		y = mean( mu[i], beta[i] );
-		if ( expected[i] !== null) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 50.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+		if ( expected[i] !== null ) {
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/gumbel/mean` from computed relative-tolerance comparisons (`delta = abs( y - expected[ i ] )` / `tol = 2.0 * EPS * abs( expected[ i ] )`, asserted via `t.ok( delta <= tol, ... )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to `test/test.js` and `test/test.native.js` (one fixture block in each).
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from both test files, along with the `delta` and `tol` variable declarations and the redundant `y === expected[ i ]` exact-match branch.

The `if ( expected[i] !== null )` guard is retained, matching the migration of the sibling packages `stats/base/dists/gumbel/median` and `stats/base/dists/gumbel/variance`.

Only test files are changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| Fixture block | Fixture | Previous tolerance | ULP bound |
| --- | --- | --- | :-: |
| mean of a Gumbel distribution (`test.js`) | `julia/data.json` | `2.0 * EPS * abs( expected[ i ] )` | `0` |
| mean of a Gumbel distribution (`test.native.js`) | `julia/data.json` | `50.0 * EPS * abs( expected[ i ] )` | `0` |

`0` is the minimum integer `N` such that `isAlmostSameValue( y, expected[ i ], N )` holds for every entry in the fixture, and it is also the floor of the ULP scale, so no tighter bound exists. Starting from a high bound and tightening, the measured maximum ULP difference over the 100 fixture values is exactly `0`: every returned value is bit-identical to the Julia reference. This was confirmed independently of the test harness by evaluating `@stdlib/number/float64/base/ulp-difference` over the full fixture set.

The native add-on was built locally (`make install-node-addons NODE_ADDONS_PATTERN="stats/base/dists/gumbel/mean"`) so that `test/test.native.js` actually executed rather than being skipped. The C implementation was measured independently against the same fixtures and also yields a maximum ULP difference of `0`, so `test.native.js` uses the same bound as the JavaScript tests. This is expected given that both implementations evaluate the same expression, `mu + ( beta * GAMMA )`; the measurement additionally rules out any FMA-contraction difference on this platform.

The full package suite (`make test TESTS_FILTER=".*/stats/base/dists/gumbel/mean/.*"`) was run twice at the final bound with identical results: `test.js` 110/110 passing and `test.native.js` 110/110 passing, no skips and no failures on both runs.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

`make lint-javascript-files` applies the general (non-test) ESLint configuration to files under `test/`, so it reports pre-existing `no-restricted-syntax` errors for the `function test( t ) {...}` expressions passed to `tape`. These are unrelated to this change and reproduce identically on unmodified, already-migrated files such as `stats/base/dists/gumbel/median/test/test.js`. Linting with the test configuration, `eslint -c etc/eslint/.eslintrc.tests.js`, reports no problems for either changed file.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously converted packages in the same family to match the established idiom, performed the conversion, and determined the minimum passing ULP bound empirically over the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExF6HEfpeMaRawViScqFqT

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExF6HEfpeMaRawViScqFqT)_