### PR TITLE
test: migrate `stats/base/dists/laplace/quantile` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/quantile/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/quantile/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -133,8 +132,6 @@ tape( 'if provided a nonpositive `b`, the created function always returns `NaN`'
 tape( 'the created function evaluates the quantile function at `p` given positive `mu`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var i;
@@ -149,13 +146,7 @@ tape( 'the created function evaluates the quantile function at `p` given positiv
 		quantile = factory( mu[i], b[i] );
 		y = quantile( p[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu: '+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -164,8 +155,6 @@ tape( 'the created function evaluates the quantile function at `p` given positiv
 tape( 'the created function evaluates the quantile function at `p` given negative `mu`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var i;
@@ -180,13 +169,7 @@ tape( 'the created function evaluates the quantile function at `p` given negativ
 		quantile = factory( mu[i], b[i] );
 		y = quantile( p[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -195,8 +178,6 @@ tape( 'the created function evaluates the quantile function at `p` given negativ
 tape( 'the created function evaluates the quantile function at `p` given large variance ( = large `b`)', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var i;
@@ -211,13 +192,7 @@ tape( 'the created function evaluates the quantile function at `p` given large v
 		quantile = factory( mu[i], b[i] );
 		y = quantile( p[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu: '+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/quantile/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/quantile/test/test.native.js
@@ -24,10 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -103,8 +102,6 @@ tape( 'if provided a nonpositive `b`, the function returns `NaN`', opts, functio
 
 tape( 'the function evaluates the quantile function at `p` given positive `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var i;
@@ -118,13 +115,7 @@ tape( 'the function evaluates the quantile function at `p` given positive `mu`',
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], mu[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 500.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -132,8 +123,6 @@ tape( 'the function evaluates the quantile function at `p` given positive `mu`',
 
 tape( 'the function evaluates the quantile function at `p` given negative `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var i;
@@ -147,13 +136,7 @@ tape( 'the function evaluates the quantile function at `p` given negative `mu`',
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], mu[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 500.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -161,8 +144,6 @@ tape( 'the function evaluates the quantile function at `p` given negative `mu`',
 
 tape( 'the function evaluates the quantile function at `p` given large variance ( = large `b` )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var i;
@@ -176,13 +157,7 @@ tape( 'the function evaluates the quantile function at `p` given large variance 
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], mu[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 500.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/quantile/test/test.quantile.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/quantile/test/test.quantile.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var quantile = require( './../lib' );
 
 
@@ -94,8 +93,6 @@ tape( 'if provided a nonpositive `b`, the function returns `NaN`', function test
 
 tape( 'the function evaluates the quantile function at `p` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var i;
@@ -109,13 +106,7 @@ tape( 'the function evaluates the quantile function at `p` given positive `mu`',
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], mu[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -123,8 +114,6 @@ tape( 'the function evaluates the quantile function at `p` given positive `mu`',
 
 tape( 'the function evaluates the quantile function at `p` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var i;
@@ -138,13 +127,7 @@ tape( 'the function evaluates the quantile function at `p` given negative `mu`',
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], mu[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -152,8 +135,6 @@ tape( 'the function evaluates the quantile function at `p` given negative `mu`',
 
 tape( 'the function evaluates the quantile function at `p` given large variance ( = large `b` )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var i;
@@ -167,13 +148,7 @@ tape( 'the function evaluates the quantile function at `p` given large variance 
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], mu[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of  #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for stats/base/dists/laplace/quantile from relative tolerance (EPS/delta/tol) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
-   updates test/test.quantile.js, test/test.factory.js, and test/test.native.js. No other files are changed.
-   removes the now-unused EPS and abs imports and the corresponding delta/tol variable declarations from each file.
-   the ULP bound was verified directly against the fixture data using a script that computes the actual ULP distance between computed and expected values for every input across all three fixtures (positive_mean, negative_mean, large_variance). Verified minimum: 1 for every block, in both JS and native — confirmed by running the verification against both implementations. Notably, test.native.js previously used a 500.0*EPS tolerance despite the verified minimum being 1; the original tolerance appears to have been overly conservative padding rather than reflecting an actual precision requirement.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
