### PR TITLE
test: migrate `stats/base/dists/levy/cdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/levy/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/cdf/test/test.cdf.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( './../lib' );
 
 
@@ -105,8 +104,6 @@ tape( 'if provided a nonpositive `c`, the function returns `NaN`', function test
 
 tape( 'the function evaluates the cdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var i;
@@ -119,28 +116,18 @@ tape( 'the function evaluates the cdf for `x` given positive `mu`', function tes
 	c = positiveMean.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var i;
 	var x;
 	var y;
-
-	tol = EPS;
 
 	expected = negativeMean.expected;
 	x = negativeMean.x;
@@ -148,21 +135,13 @@ tape( 'the function evaluates the cdf for `x` given negative `mu`', function tes
 	c = negativeMean.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given large variance ( = large `b` )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var i;
@@ -175,13 +154,7 @@ tape( 'the function evaluates the cdf for `x` given large variance ( = large `b`
 	c = largeVariance.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/cdf/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -155,9 +154,7 @@ tape( 'if provided a nonpositive `c`, the created function always returns `NaN`'
 
 tape( 'the created function evaluates the cdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var mu;
 	var c;
 	var i;
@@ -171,22 +168,14 @@ tape( 'the created function evaluates the cdf for `x` given positive `mu`', func
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( mu[i], c[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var mu;
 	var c;
 	var i;
@@ -200,22 +189,14 @@ tape( 'the created function evaluates the cdf for `x` given negative `mu`', func
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( mu[i], c[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given large variance ( = large `b`)', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var mu;
 	var c;
 	var i;
@@ -229,13 +210,7 @@ tape( 'the created function evaluates the cdf for `x` given large variance ( = l
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( mu[i], c[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/cdf/test/test.native.js
@@ -24,10 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -114,8 +113,6 @@ tape( 'if provided a nonpositive `c`, the function returns `NaN`', opts, functio
 
 tape( 'the function evaluates the cdf for `x` given a positive `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var c;
@@ -128,23 +125,13 @@ tape( 'the function evaluates the cdf for `x` given a positive `mu`', opts, func
 	c = positiveMean.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[ i ], mu[ i ], c[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + ', mu: ' + mu[ i ] + ', c: ' + c[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-
-			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. mu: ' + mu[ i ] + '. c: ' + c[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given a negative `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var c;
@@ -157,21 +144,13 @@ tape( 'the function evaluates the cdf for `x` given a negative `mu`', opts, func
 	c = negativeMean.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[ i ], mu[ i ], c[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + ', mu: ' + mu[ i ] + ', c: ' + c[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. mu: ' + mu[ i ] + '. c: ' + c[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given a large variance ( = large `b` )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var c;
@@ -184,15 +163,7 @@ tape( 'the function evaluates the cdf for `x` given a large variance ( = large `
 	c = largeVariance.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[ i ], mu[ i ], c[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + ', mu: ' + mu[ i ] + ', c: ' + c[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-
-			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. mu: ' + mu[ i ] + '. c: ' + c[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of  #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-  migrates the test suite for stats/base/dists/levy/cdf from relative tolerance (EPS/delta/tol) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
-   updates test/test.cdf.js, test/test.factory.js, and test/test.native.js. No other files are changed.
-   removes the now-unused EPS and abs imports and the corresponding delta/tol variable declarations from each file.
-   the ULP bound was verified directly against the fixture data using a script that computes the actual ULP distance between computed and expected values for every input across all three fixtures (positive_mean, negative_mean, large_variance). Verified minimum: 1 for every block, in both JS and native.
-   test.native.js previously carried a "NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations..." comment on two of its three blocks, with tolerances of 2.0*EPS (vs. 1.0*EPS for JS on the same blocks). I verified with the same script that native produces bit-identical results to JS and the fixture data across all three blocks (no ULP divergence at all), so I removed those two comments along with the tolerance logic they were attached to, since they no longer reflect actual behavior. Happy to keep them if there's a reason to expect divergence under different build/compiler conditions not captured by my local verification.
-   also removed a dead `tol = EPS;` line in test.cdf.js's "negative mean" block that was immediately overwritten inside the loop on every iteration and had no effect on test behavior.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
