### PR TITLE
test: migrate `lapack/base/dladiv` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/lapack/base/dladiv/test/test.dladiv.js
+++ b/lib/node_modules/@stdlib/lapack/base/dladiv/test/test.dladiv.js
@@ -23,8 +23,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var Float64Array = require( '@stdlib/array/float64' );
 var dladiv = require( './../lib' );
 
@@ -60,8 +59,7 @@ tape( 'the function has an arity of 6', function test( t ) {
 });
 
 tape( 'the function computes a complex quotient (tested against fixtures)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -80,31 +78,18 @@ tape( 'the function computes a complex quotient (tested against fixtures)', func
 	qim = data.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, Q );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (different component scales)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -123,31 +108,18 @@ tape( 'the function computes a complex quotient (different component scales)', f
 	qim = componentScales1.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, Q );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (different component scales)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -166,31 +138,18 @@ tape( 'the function computes a complex quotient (different component scales)', f
 	qim = componentScales2.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, Q );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (different imaginary component scales)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -209,31 +168,18 @@ tape( 'the function computes a complex quotient (different imaginary component s
 	qim = imaginaryComponentScales.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, Q );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (real imaginary component scales)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -252,31 +198,18 @@ tape( 'the function computes a complex quotient (real imaginary component scales
 	qim = realComponentScales.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, Q );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (large negative imaginary components)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -295,31 +228,18 @@ tape( 'the function computes a complex quotient (large negative imaginary compon
 	qim = largeNegativeImaginaryComponents.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, Q );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (large negative real components)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -338,31 +258,18 @@ tape( 'the function computes a complex quotient (large negative real components)
 	qim = largeNegativeRealComponents.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, Q );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (large positive imaginary components)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -381,31 +288,18 @@ tape( 'the function computes a complex quotient (large positive imaginary compon
 	qim = largePositiveImaginaryComponents.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, Q );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (large positive real components)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -424,31 +318,18 @@ tape( 'the function computes a complex quotient (large positive real components)
 	qim = largePositiveRealComponents.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, Q );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (tiny negative imaginary components)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -467,30 +348,18 @@ tape( 'the function computes a complex quotient (tiny negative imaginary compone
 	qim = tinyNegativeImaginaryComponents.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, Q );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (tiny negative real components)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -509,31 +378,18 @@ tape( 'the function computes a complex quotient (tiny negative real components)'
 	qim = tinyNegativeRealComponents.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, Q );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (tiny positive imaginary components)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -552,31 +408,18 @@ tape( 'the function computes a complex quotient (tiny positive imaginary compone
 	qim = tinyPositiveImaginaryComponents.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, Q );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (tiny positive real components)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -595,24 +438,12 @@ tape( 'the function computes a complex quotient (tiny positive real components)'
 	qim = tinyPositiveRealComponents.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, Q );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/lapack/base/dladiv/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/dladiv/test/test.ndarray.js
@@ -23,8 +23,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var Float64Array = require( '@stdlib/array/float64' );
 var dladiv = require( './../lib/ndarray.js' );
 
@@ -60,8 +59,7 @@ tape( 'the function has an arity of 8', function test( t ) {
 });
 
 tape( 'the function computes a complex quotient (tested against fixtures)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -80,31 +78,18 @@ tape( 'the function computes a complex quotient (tested against fixtures)', func
 	qim = data.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, 0, Q, 0 );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (different component scales)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -123,31 +108,18 @@ tape( 'the function computes a complex quotient (different component scales)', f
 	qim = componentScales1.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, 0, Q, 0 );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (different component scales)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -166,31 +138,18 @@ tape( 'the function computes a complex quotient (different component scales)', f
 	qim = componentScales2.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, 0, Q, 0 );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (different imaginary component scales)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -209,31 +168,18 @@ tape( 'the function computes a complex quotient (different imaginary component s
 	qim = imaginaryComponentScales.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, 0, Q, 0 );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (real imaginary component scales)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -252,31 +198,18 @@ tape( 'the function computes a complex quotient (real imaginary component scales
 	qim = realComponentScales.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, 0, Q, 0 );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (large negative imaginary components)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -295,31 +228,18 @@ tape( 'the function computes a complex quotient (large negative imaginary compon
 	qim = largeNegativeImaginaryComponents.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, 0, Q, 0 );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (large negative real components)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -338,31 +258,18 @@ tape( 'the function computes a complex quotient (large negative real components)
 	qim = largeNegativeRealComponents.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, 0, Q, 0 );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (large positive imaginary components)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -381,31 +288,18 @@ tape( 'the function computes a complex quotient (large positive imaginary compon
 	qim = largePositiveImaginaryComponents.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, 0, Q, 0 );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (large positive real components)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -424,31 +318,18 @@ tape( 'the function computes a complex quotient (large positive real components)
 	qim = largePositiveRealComponents.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, 0, Q, 0 );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (tiny negative imaginary components)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -467,31 +348,18 @@ tape( 'the function computes a complex quotient (tiny negative imaginary compone
 	qim = tinyNegativeImaginaryComponents.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, 0, Q, 0 );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (tiny negative real components)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -510,31 +378,18 @@ tape( 'the function computes a complex quotient (tiny negative real components)'
 	qim = tinyNegativeRealComponents.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, 0, Q, 0 );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (tiny positive imaginary components)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -553,31 +408,18 @@ tape( 'the function computes a complex quotient (tiny positive imaginary compone
 	qim = tinyPositiveImaginaryComponents.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, 0, Q, 0 );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex quotient (tiny positive real components)', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -596,31 +438,18 @@ tape( 'the function computes a complex quotient (tiny positive real components)'
 	qim = tinyPositiveRealComponents.qim;
 	P = new Float64Array( 1 );
 	Q = new Float64Array( 1 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, 0, Q, 0 );
-
-		if ( P[ 0 ] === qre[ i ] ) {
-			t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 0 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 0 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 0 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 0 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 0 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 0 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 0 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function supports array offsets', function test( t ) {
-	var delta;
-	var tol;
+	var ULP;
 	var re1;
 	var im1;
 	var re2;
@@ -639,24 +468,12 @@ tape( 'the function supports array offsets', function test( t ) {
 	qim = data.qim;
 	P = new Float64Array( 3 );
 	Q = new Float64Array( 3 );
+	ULP = 0;
 
 	for ( i = 0; i < re1.length; i++ ) {
 		dladiv( re1[ i ], im1[ i ], re2[ i ], im2[ i ], P, 1, Q, 2 );
-
-		if ( P[ 1 ] === qre[ i ] ) {
-			t.strictEqual( P[ 1 ], qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( P[ 1 ] - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. real: '+P[ 1 ]+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( Q[ 2 ] === qim[ i ] ) {
-			t.strictEqual( Q[ 2 ], qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( Q[ 2 ] - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re1[i]+' + '+im1[i]+'i. y: '+re2[i]+' + '+im2[i]+'i. imag: '+Q[ 2 ]+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( P[ 1 ], qre[ i ], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( Q[ 2 ], qim[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the test suite for `lapack/base/dladiv` from relative-tolerance testing (a computed `delta`/`tol` pair derived from `@stdlib/constants/float64/eps`) to ULP difference testing via `@stdlib/assert/is-almost-same-value`, per the guidance in #11352.
-   Replaces, in both `test/test.dladiv.js` and `test/test.ndarray.js`, the old idiom present in every fixture-based test body:

    ```javascript
    if ( P[ 0 ] === qre[ i ] ) {
    	t.strictEqual( P[ 0 ], qre[ i ], 'returns expected real component' );
    } else {
    	delta = abs( P[ 0 ] - qre[ i ] );
    	tol = EPS * abs( qre[ i ] );
    	t.ok( delta <= tol, 'within tolerance. ...' );
    }
    ```

    with

    ```javascript
    t.strictEqual( isAlmostSameValue( P[ 0 ], qre[ i ], ULP ), true, 'returns expected value' );
    ```

    using a single named `ULP` constant declared at the top of each test body, mirroring the pattern used in already-converted packages such as `lapack/base/dlapy2` and `blas/base/drot`.
-   Determines the tightest possible bound by computing the exact ULP difference (via `@stdlib/number/float64/base/ulp-difference`) between the package's own output and the expected values across all 13 fixture files (500 cases each, both real and imaginary components) in both test files. Every case is an **exact** match (0 ULP difference), so `ULP` is set to `0` throughout.
-   Incidentally fixes a latent bug in `test/test.ndarray.js` (one block, "tiny negative imaginary components") where `delta` was read without being reassigned in the real-component branch, so a stale value from a prior loop iteration was compared instead. This class of bug is naturally eliminated by the mechanical migration to `isAlmostSameValue`, which always recomputes from the current values.

### Verification

-   `make test TESTS_FILTER=".*/lapack/base/dladiv/.*"` passes (13003 / 14003 / 5 assertions across `test.dladiv.js`, `test.ndarray.js`, and `test.js`, respectively), run three times to confirm determinism (no FMA/arch flakiness).
-   `npx eslint` on the changed files reports no issues.
-   Only the two test files were changed; no new dependency was introduced (`@stdlib/assert/is-almost-same-value` is already used elsewhere in the codebase and required no `package.json` change).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, run as an unattended agent by a stdlib maintainer to systematically work through issue #11352. The candidate package was selected programmatically, the tightest ULP bound was determined by exhaustively measuring the actual ULP difference between computed and expected fixture values (rather than trial-and-error), and all changes were verified against the package's test suite (run three times for determinism) and `eslint` before this PR was opened.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md