### PR TITLE
test: migrate `stats/base/dists/planck/entropy` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/planck/entropy/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/entropy/test/test.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var entropy = require( './../lib' );
 
 
@@ -61,8 +60,6 @@ tape( 'if provided a shape parameter `lambda` which is nonpositive, the function
 tape( 'the function returns the differential entropy of a Planck distribution', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var y;
 
@@ -70,13 +67,7 @@ tape( 'the function returns the differential entropy of a Planck distribution', 
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'lambda: '+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/entropy/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/entropy/test/test.native.js
@@ -22,10 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -70,8 +69,6 @@ tape( 'if provided a shape parameter `lambda` which is nonpositive, the function
 tape( 'the function returns the differential entropy of a Planck distribution', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var y;
 
@@ -79,13 +76,7 @@ tape( 'the function returns the differential entropy of a Planck distribution', 
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'lambda: '+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/planck/entropy` from computed relative-tolerance comparisons (`delta = abs( y - expected[ i ] )` / `tol = 2.0 * EPS * abs( expected[ i ] )`, asserted via `t.ok( delta <= tol, ... )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to `test/test.js` and `test/test.native.js` (one fixture block in each).
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from both test files, along with the `delta` and `tol` variable declarations and the redundant `y === expected[ i ]` exact-match branch.

Only test files are changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| Fixture block | Fixture | Previous tolerance | ULP bound |
| --- | --- | --- | :-: |
| differential entropy of a Planck distribution (`test.js`) | `python/data.json` | `2.0 * EPS * abs( expected[ i ] )` | `2` |
| differential entropy of a Planck distribution (`test.native.js`) | `python/data.json` | `2.0 * EPS * abs( expected[ i ] )` | `2` |

`2` is the minimum integer `N` such that `isAlmostSameValue( y, expected[ i ], N )` holds for every entry in the fixture. Starting from a high bound and tightening, the measured maximum ULP difference over the 1000 fixture values is exactly `2`, attained at `lambda = 11.719271917838153` (returned `0.00010347859430123839` versus the SciPy reference `0.00010347859430123842`). This was confirmed independently of the test harness by evaluating `@stdlib/number/float64/base/ulp-difference` over the full fixture set, and re-confirmed from the opposite direction by temporarily setting the bound to `1`, which fails 8 of the 1000 assertions.

The native add-on was built locally (`make install-node-addons NODE_ADDONS_PATTERN="stats/base/dists/planck/entropy"`) so that `test/test.native.js` actually executed rather than being skipped. The C implementation was measured independently against the same fixtures and also yields a maximum ULP difference of `2`, at the same fixture index, so `test.native.js` uses the same bound as the JavaScript tests. The measurement additionally rules out any FMA-contraction difference on this platform.

The full package suite (`make test TESTS_FILTER=".*/stats/base/dists/planck/entropy/.*"`) was run twice at the final bound with identical results: `test.js` 1005/1005 passing and `test.native.js` 1005/1005 passing, no skips and no failures on both runs.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Linting with the test configuration (`make eslint-tests TESTS_FILTER=".*/stats/base/dists/planck/entropy/.*"`) reports no problems for either changed file. Note that `make eslint-files` applies the general (non-test) ESLint configuration to files under `test/`, so it reports pre-existing `no-restricted-syntax` errors for the `function test( t ) {...}` expressions passed to `tape`; those are unrelated to this change and reproduce identically on unmodified, already-migrated files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously converted packages in the same family to match the established idiom, performed the conversion, and determined the minimum passing ULP bound empirically over the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBqLNjZu4rBxpGimEgk5bb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBqLNjZu4rBxpGimEgk5bb)_