### PR TITLE
test: migrate `stats/base/dists/beta/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/beta/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/stdev/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -96,10 +95,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the standard deviation of a beta distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -108,13 +105,7 @@ tape( 'the function returns the standard deviation of a beta distribution', func
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/stdev/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -105,10 +104,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 
 tape( 'the function returns the standard deviation of a beta distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -117,13 +114,7 @@ tape( 'the function returns the standard deviation of a beta distribution', opts
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/beta/stdev` from relative tolerance testing to ULP difference testing.
-   replaces the `delta`/`tol` comparisons in `test/test.js` and `test/test.native.js` with `@stdlib/assert/is-almost-same-value`, adds the corresponding `require`, and removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` imports.
-   uses a ULP bound of `2` in both `test/test.js` and `test/test.native.js`. This is the measured minimum over the full 1000-case Python fixture set: a bound of `1` fails for one case (`alpha: 7.512224992944586`, `beta: 16.738584643513867`), while `2` passes for all cases. The suite was run twice at the final bound to confirm determinism.
-   makes no changes outside of the two test files.

Note on the native tests: the JavaScript and C implementations perform an identical sequence of operations (`sqrt( ( alpha * beta ) / ( alpha + beta + 1.0 ) ) / ( alpha + beta )`) with a correctly rounded `sqrt`, and the compiled C implementation was verified to return bit-identical results to the JavaScript implementation across all 1000 fixture cases, giving the same measured minimum of `2`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, which selected the package, mirrored the conversion idiom used in already-migrated packages, and measured the minimum passing ULP bound.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Yzm1pYd69FheDzXXPPnR4

---
_Generated by [Claude Code](https://claude.ai/code/session_017Yzm1pYd69FheDzXXPPnR4)_