### PR TITLE
fix(create-issue): fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/create-issue/lib/query.js
+++ b/lib/node_modules/@stdlib/_tools/github/create-issue/lib/query.js
@@ -22,6 +22,7 @@
 
 var logger = require( 'debug' );
 var string2buffer = require( '@stdlib/buffer/from-string' );
+var isnan = require( '@stdlib/assert/is-nan' ).isPrimitive;
 var getOpts = require( './options.js' );
 var getData = require( './data.js' );
 var request = require( './request.js' );
@@ -84,7 +85,9 @@ function query( slug, title, options, clbk ) {
 		info = ratelimit( response.headers );
 		debug( 'Rate limit: %d', info.limit );
 		debug( 'Rate limit remaining: %d', info.remaining );
-		debug( 'Rate limit reset: %s', (new Date( info.reset*1000 )).toISOString() );
+		if ( !isnan( info.reset ) ) {
+			debug( 'Rate limit reset: %s', (new Date( info.reset*1000 )).toISOString() );
+		}
 
 		if ( error ) {
 			return clbk( error, null, info );

--- a/lib/node_modules/@stdlib/_tools/github/create-issue/test/test.query.js
+++ b/lib/node_modules/@stdlib/_tools/github/create-issue/test/test.query.js
@@ -72,6 +72,33 @@ tape( 'the function returns an error to a provided callback if an error is encou
 	}
 });
 
+tape( 'the function returns an error to a provided callback if an error is encountered when creating an issue (missing rate limit info)', function test( t ) {
+	var query;
+	var opts;
+
+	query = proxyquire( './../lib/query.js', {
+		'./request.js': request
+	});
+
+	opts = getOpts();
+	query( 'beep/boop', 'Big bug.', opts, done );
+
+	function request( opts, data, clbk ) {
+		setTimeout( onTimeout, 0 );
+		function onTimeout() {
+			clbk( new Error( 'beep' ), {
+				'headers': {}
+			});
+		}
+	}
+
+	function done( error ) {
+		t.ok( error instanceof Error, 'error instance' );
+		t.strictEqual( error.message, 'beep' );
+		t.end();
+	}
+});
+
 tape( 'the function returns an error to a provided callback if an error is encountered when creating an issue (rate limit info)', function test( t ) {
 	var query;
 	var opts;


### PR DESCRIPTION
This is a small, targeted change to .../_tools/github/create-issue/lib/query.js, .../_tools/github/create-issue/test/test.query.js that resolves the reported issue without touching anything unrelated.

The checks evaluated by the fork CI gate passed. This excludes skipped checks and checks filtered out for fork-only conditions.

Fixes #11784.
