### PR TITLE
test: migrate `stats/base/dists/triangular/entropy` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/entropy/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/entropy/test/test.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var entropy = require( './../lib' );
 
 
@@ -73,8 +72,6 @@ tape( 'if provided parameters not satisfying `a <= c <= b`, the function returns
 
 tape( 'the function returns the differential entropy of a triangular distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var c;
@@ -87,13 +84,7 @@ tape( 'the function returns the differential entropy of a triangular distributio
 	c = data.c;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/entropy/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/entropy/test/test.native.js
@@ -22,10 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -82,8 +81,6 @@ tape( 'if provided parameters not satisfying `a <= c <= b`, the function returns
 
 tape( 'the function returns the differential entropy of a triangular distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var c;
@@ -96,13 +93,7 @@ tape( 'the function returns the differential entropy of a triangular distributio
 	c = data.c;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/triangular/entropy` from computed relative-tolerance comparisons (`delta = abs( y - expected[ i ] )` / `tol = N * EPS * abs( expected[ i ] )`, asserted via `t.ok( delta <= tol, ... )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to `test/test.js` and `test/test.native.js` (one fixture block in each).
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from both test files, along with the `delta` and `tol` variable declarations and the redundant `y === expected[ i ]` exact-match branch.

Only test files are changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| Fixture block | Fixture | Previous tolerance | ULP bound |
| --- | --- | --- | :-: |
| differential entropy of a triangular distribution (`test.js`) | `julia/data.json` | `1.0 * EPS * abs( expected[ i ] )` | `0` |
| differential entropy of a triangular distribution (`test.native.js`) | `julia/data.json` | `3.0 * EPS * abs( expected[ i ] )` | `0` |

`0` is the minimum integer `N` such that `isAlmostSameValue( y, expected[ i ], N )` holds for every entry in the fixture, and, being the smallest representable bound, it cannot be tightened further. Starting from a high bound and tightening, the measured maximum ULP difference over the 500 fixture values is exactly `0`; the JavaScript implementation reproduces all 500 Julia reference values bit-for-bit. This was confirmed independently of the test harness by searching, for each fixture entry, for the smallest `N` satisfying `isAlmostSameValue( y, expected[ i ], N )`, and cross-checked with a direct `y === expected[ i ]` count (500/500 exact).

The C implementation was measured independently against the same fixtures and also reproduces all 500 reference values bit-for-bit, so `test.native.js` uses the same bound as the JavaScript tests. Because the add-on could not be built in this environment (see below), the C measurement was performed by compiling `src/main.c` together with its transitive C dependencies (`math/base/assert/is-nan`, `math/base/special/ln`, `number/float64/base/get-high-word`, `number/float64/base/set-high-word`) into a standalone harness and feeding it the fixture inputs as exact IEEE-754 bit patterns, comparing the returned bit patterns against the fixture expectations. The measurement additionally rules out any FMA-contraction difference on this platform.

`test/test.js` was run twice at the final bound with identical results: 509/509 passing on both runs, no failures. `test/test.native.js` is skipped in this environment because the native add-on is not built; the equivalence of the C results to the fixtures was established separately, as described above.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

Yes — one, concerning verification coverage rather than the change itself.

This PR was authored in an environment where `make install-node-modules` fails: npm cannot resolve `es-object-atoms@^1.1.2` (a transitive dependency; the registry publishes only up to `1.1.1`). As a consequence:

-   `make test TESTS_FILTER=...` could not be used. `tape` was installed out-of-tree and the two test files were executed directly with `node`, which exercises the same assertions.
-   `make install-node-addons` could not be run, so `test/test.native.js` reports `0` tests (skipped) rather than executing. The standalone C harness described above is what establishes the native bound.
-   The repository's ESLint configuration could not be run, since the stdlib ESLint plugins are not installed. The diff was instead matched line-for-line against the already-merged conversions in the same family (`stats/base/dists/triangular/kurtosis`, and `stats/base/dists/planck/entropy`), and checked for unused requires and trailing whitespace.

Reviewers may therefore wish to confirm `make test` and `make eslint-tests` locally before merging.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The resulting assertion matches the idiom used by the already-migrated sibling package `stats/base/dists/triangular/kurtosis`, which uses the same `0` ULP bound over the same style of Julia fixtures in both its `test.js` and `test.native.js`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously converted packages in the same family to match the established idiom, performed the conversion, and determined the minimum passing ULP bound empirically over the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E23UzKHXbbRguYxmjVtppY


---
_Generated by [Claude Code](https://claude.ai/code/session_01E23UzKHXbbRguYxmjVtppY)_