### PR TITLE
chore: fix EditorConfig lint errors

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-math/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-math/examples/index.js
@@ -36,17 +36,17 @@ result = linter.verify( code, {
 });
 console.log( result );
 /* =>
-    [
-        {
-            'ruleId': 'no-builtin-math',
-            'severity': 2,
-            'message': 'Use the package `@stdlib/math/base/special/sqrt` instead of `Math.sqrt`',
-            'line': 1,
-            'column': 9,
-            'nodeType': 'MemberExpression',
-            'source': 'var y = Math.sqrt( 9.0 );',
-            'endLine': 1,
-            'endColumn': 18
-        }
-    ]
+	[
+		{
+			'ruleId': 'no-builtin-math',
+			'severity': 2,
+			'message': 'Use the package `@stdlib/math/base/special/sqrt` instead of `Math.sqrt`',
+			'line': 1,
+			'column': 9,
+			'nodeType': 'MemberExpression',
+			'source': 'var y = Math.sqrt( 9.0 );',
+			'endLine': 1,
+			'endColumn': 18
+		}
+	]
 */


### PR DESCRIPTION
Resolves #15088.

## Description

This pull request:

-   re-indents lines 39–51 of `lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-math/examples/index.js` with tabs instead of spaces.

The `/* => ... */` example-output block used 4-space indentation, while `.editorconfig` sets `indent_style = tab` for `[*.{js,js.txt}]`. Each level is replaced by one tab at the same depth (4→1, 8→2, 12→3), so the rendered block is unchanged in structure.

Verified with `editorconfig-checker` against the repository's own `.editorconfig`:

```
BEFORE  before.js:
          39-51: wrong indentation type (spaces instead of tabs)
        1 errors found

AFTER   (no output, exit 0)
```

That matches the workflow error in the issue exactly. I also confirmed the change is whitespace-only: `diff <(tr -d ' \t' < before.js) <(tr -d ' \t' < after.js)` is empty.

## Related Issues

This pull request has the following related issues:

-   #15088

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

I used an AI assistant to locate the flagged lines and apply the re-indentation, then verified the result myself by running `editorconfig-checker` against the repository's `.editorconfig` on both the original and the patched file, and by confirming the diff is whitespace-only.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md