### PR TITLE
test: migrate `stats/incr/mskewness` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/mskewness/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/mskewness/test/test.js
@@ -74,7 +74,6 @@ tape( 'the accumulator function computes a moving corrected sample skewness incr
 	var expected;
 	var actual;
 	var data;
-	var ULP;
 	var acc;
 	var i;
 	var N;
@@ -92,14 +91,13 @@ tape( 'the accumulator function computes a moving corrected sample skewness incr
 	];
 
 	acc = incrmskewness( 5 );
-	ULP = 1;
 
 	for ( i = 0; i < N; i++ ) {
 		actual = acc( data[ i ] );
 		if ( expected[ i ] === null ) {
 			t.strictEqual( actual, expected[i], 'returns expected value for index '+i );
 		} else {
-			t.strictEqual( isAlmostSameValue( actual, expected[ i ], ULP ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 

--- a/lib/node_modules/@stdlib/stats/incr/mskewness/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/mskewness/test/test.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var incrmskewness = require( './../lib' );
 
@@ -74,10 +73,9 @@ tape( 'the function returns an accumulator function', function test( t ) {
 tape( 'the accumulator function computes a moving corrected sample skewness incrementally', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
+	var ULP;
 	var acc;
-	var tol;
 	var i;
 	var N;
 
@@ -94,15 +92,14 @@ tape( 'the accumulator function computes a moving corrected sample skewness incr
 	];
 
 	acc = incrmskewness( 5 );
+	ULP = 1;
 
 	for ( i = 0; i < N; i++ ) {
 		actual = acc( data[ i ] );
 		if ( expected[ i ] === null ) {
 			t.strictEqual( actual, expected[i], 'returns expected value for index '+i );
 		} else {
-			delta = abs( actual - expected[ i ] );
-			tol = 1.5 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+actual+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tol: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( actual, expected[ i ], ULP ), true, 'returns expected value' );
 		}
 	}
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite of `stats/incr/mskewness` from the old EPS/relative-tolerance idiom to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352
-   replaces the fixture-loop test block, which previously computed an ad hoc relative-error tolerance (`1.5 * EPS * abs( expected[i] )`), with `t.strictEqual( isAlmostSameValue( actual, expected[ i ], ULP ), true, 'returns expected value' )`
-   the tightest ULP bound was found agentically (starting high, then lowering until failure, and confirming the minimum passes deterministically across two consecutive runs):
    -   `the accumulator function computes a moving corrected sample skewness incrementally`: **1 ULP**
    -   (confirmed `0` ULP fails, so `1` is the tight minimum)
-   only the test file was changed; no dependency additions to `package.json` were required (mirrors prior-art conversions in the same family, e.g. `stats/incr/pcorrdist`, `stats/incr/pcorrdistmat`)

## Related Issues

This pull request has the following related issues:

-   #11352

## Questions

No.

## Other

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code as part of an automated, scheduled ULP-migration task, mirroring the established conversion pattern from prior PRs against #11352.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LzRJkRng6ssh3h5KCtY3y

---
_Generated by [Claude Code](https://claude.ai/code/session_014LzRJkRng6ssh3h5KCtY3y)_