### PR TITLE
test: migrate `stats/base/dists/normal/quantile` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -153,9 +152,7 @@ tape( 'if `sigma` equals `0`, the created function evaluates a degenerate distri
 tape( 'the created function evaluates the quantile for `x` given parameters `mu` and `sigma`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -168,13 +165,7 @@ tape( 'the created function evaluates the quantile for `x` given parameters `mu`
 	for ( i = 0; i < x.length; i++ ) {
 		quantile = factory( mu[i], sigma[i] );
 		y = quantile( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2100.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1024 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -122,9 +121,7 @@ tape( 'if provided `sigma` equals `0`, the function evaluates a degenerate distr
 
 tape( 'the function evaluates the quantile for `x` given parameters `mu` and `sigma`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -136,13 +133,7 @@ tape( 'the function evaluates the quantile for `x` given parameters `mu` and `si
 	sigma = data.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = quantile( x[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2100.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1024 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/test/test.quantile.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/test/test.quantile.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var quantile = require( './../lib' );
 
 
@@ -113,9 +112,7 @@ tape( 'if provided `sigma` equals `0`, the function evaluates a degenerate distr
 
 tape( 'the function evaluates the quantile for `x` given parameters `mu` and `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -127,13 +124,7 @@ tape( 'the function evaluates the quantile for `x` given parameters `mu` and `si
 	sigma = data.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = quantile( x[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2100.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1024 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/normal/quantile` from relative tolerance testing to ULP difference testing, per #11352.
-   removes the `abs` and `EPS` imports along with the `delta`/`tol` computations from the fixture loops in `test/test.quantile.js`, `test/test.factory.js`, and `test/test.native.js`, replacing them with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 1024 ), true, 'returns expected value' );`.

### ULP bound

All three files use a bound of **1024 ULP**, which is the **measured minimum**.

The package has a single fixture (`test/fixtures/r/data.json`, 1000 points). The maximum observed ULP difference over the full fixture set is `1024` for the main, factory, and native implementations alike (the worst case being `x = 0.5935935935935935`, `mu = -7`, `sigma = 29.6`). The bound was tightened empirically: at `1023` each of the three files reports exactly one failing assertion, and at `1024` all pass. The native add-on was built locally so that `test/test.native.js` was actually exercised rather than skipped; the C implementation agrees with the JS implementation on every fixture value, so no separate bound is required.

The previous tolerance was `2100.0 * EPS * abs( expected[ i ] )`, so the new bound is a tightening.

The suite was run twice at the final bound with identical results (4057 assertions, all passing), confirming determinism.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Only the three test files are modified; no source, documentation, or fixture changes.

The pre-commit `editorconfig-checker` hook could not run in this environment because the checker binary is downloaded from a GitHub release that this sandbox cannot reach. The relevant rules (LF line endings, UTF-8, tab indentation, no trailing whitespace, final newline) were verified manually against `.editorconfig` instead. `make lint-javascript-tests` passes cleanly for the package.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. The ULP bound was determined empirically by measuring the maximum ULP difference across the full fixture set and then bisecting to confirm the minimum passing value.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1uMqViBMp6d36XsPu1bQR

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1uMqViBMp6d36XsPu1bQR)_