### PR TITLE
bench: bound seed growth in `factory` benchmark

### DIFF
--- a/lib/node_modules/@stdlib/random/base/mt19937/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/mt19937/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );


### PR DESCRIPTION
Resolves #{{TODO: add issue number}}.

## Description

This pull request:

-   fixes the `factory:seed=<integer>` benchmark in `@stdlib/random/base/mt19937` so it no longer crashes the nightly `random_benchmarks` job.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/34173224406 (`random_benchmarks`, develop).

**Symptom:** `RangeError: invalid option. `seed` option must be a positive integer less than or equal to the maximum unsigned 32-bit integer. Option: `4295022904`.` thrown from `benchmark.factory.js`, aborting the job.

**Root cause:** the `factory:seed=<integer>` benchmark accumulates the seed across iterations (`opts.seed += i`). That is a triangular-number sum (`1 + Σi`), which deterministically exceeds `UINT32_MAX` (4294967295) once the loop passes roughly 92700 iterations — reproduced locally, and it throws at the exact seed value (`4295022904`) reported in the failing run. This is unrelated to any specific `develop` commit; it reproduces on every SHA once the benchmark harness's iteration count crosses that threshold, which is why it fails on schedule rather than on a particular push.

**Fix:** assign a bounded, always-valid seed per iteration (`opts.seed = i + 1`) instead of accumulating. This matches the pattern already used by the sibling `factory:seed=<array>` benchmark two blocks below in the same file (`opts.seed[ 0 ] = i + 1;`), so the change is a one-line, in-idiom fix rather than a new approach.

## Related Issues

No.

## Questions

No.

## Other

**Validation:**
-   Reproduced the original failure locally by replaying the old loop logic directly against `@stdlib/random/base/mt19937`'s `factory`: it throws at `i = 92682`, `seed = 4295022904` — the exact value from the failing run.
-   Replayed the fixed loop logic (200,000 iterations, well past the overflow threshold): completes with no error.
-   Full lint/build tooling (`make lint-javascript-benchmarks`) was not runnable in this sandbox (no top-level `node_modules` installed); the diff is a single line that mirrors the existing sibling benchmark's exact style in the same file, so no formatting/lint drift is expected.
-   Reviewed by three independent automated reviewers: correctness (confirmed the fix eliminates the unbounded accumulation and preserves a distinct, valid seed per iteration), regression scope (confirmed the change is isolated to this one file/benchmark and does not touch the `factory`/`main` implementation, tests, or docs), and style/conventions (confirmed the replacement matches the sibling `seed=<array>` benchmark's idiom and existing indentation exactly). All three approved with no blocking findings.

**Reviewer notes (non-blocking):**
-   The identical accumulation pattern (`opts.seed += i;`) exists in the same-named benchmark across roughly 40 sibling `@stdlib/random/base/*` packages (e.g. `beta`, `uniform`, `normal`, `minstd-shuffle`, ...). None of those failed in this observation window, but each will hit the same overflow once its own benchmark run crosses ~92700 iterations. Fixing all of them is out of scope for this CI-failure fix (would cascade well beyond the reported failure); worth a dedicated follow-up sweep.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated CI-failure investigation and fix routine; the failure was reproduced locally against the actual `mt19937` factory before and after the change, and the fix was independently reviewed by three automated reviewer passes before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiQ7xQp83BfogoNxDNvNW8

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiQ7xQp83BfogoNxDNvNW8)_