### PR TITLE
test: migrate `simulate/iter/sawtooth-wave` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/simulate/iter/sawtooth-wave/test/test.js
+++ b/lib/node_modules/@stdlib/simulate/iter/sawtooth-wave/test/test.js
@@ -22,11 +22,10 @@
 
 var tape = require( 'tape' );
 var proxyquire = require( 'proxyquire' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var iteratorSymbol = require( '@stdlib/symbol/iterator' );
 var tan = require( '@stdlib/math/base/special/tan' );
 var atan = require( '@stdlib/math/base/special/atan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var HALF_PI = require( '@stdlib/constants/float64/half-pi' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var iterSawtoothWave = require( './../lib' );
@@ -103,8 +102,6 @@ tape( 'the function throws an error if provided an invalid option', function tes
 tape( 'the function returns an iterator protocol-compliant object which generates a sawtooth wave', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var it;
 	var i;
 
@@ -165,13 +162,7 @@ tape( 'the function returns an iterator protocol-compliant object which generate
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -179,9 +170,7 @@ tape( 'the function returns an iterator protocol-compliant object which generate
 tape( 'the function supports specifying the waveform period', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var it;
 	var i;
 
@@ -245,13 +234,7 @@ tape( 'the function supports specifying the waveform period', function test( t )
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -259,9 +242,7 @@ tape( 'the function supports specifying the waveform period', function test( t )
 tape( 'the function supports specifying the wave amplitude', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var it;
 	var i;
 
@@ -326,13 +307,7 @@ tape( 'the function supports specifying the wave amplitude', function test( t ) 
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -340,9 +315,7 @@ tape( 'the function supports specifying the wave amplitude', function test( t ) 
 tape( 'the function supports specifying the phase offset (left shift)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var it;
 	var i;
 
@@ -407,13 +380,7 @@ tape( 'the function supports specifying the phase offset (left shift)', function
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -421,9 +388,7 @@ tape( 'the function supports specifying the phase offset (left shift)', function
 tape( 'the function supports specifying the phase offset (left shift; mod)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var it;
 	var i;
 
@@ -488,13 +453,7 @@ tape( 'the function supports specifying the phase offset (left shift; mod)', fun
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -502,9 +461,7 @@ tape( 'the function supports specifying the phase offset (left shift; mod)', fun
 tape( 'the function supports specifying the phase offset (right shift)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var it;
 	var i;
 
@@ -569,13 +526,7 @@ tape( 'the function supports specifying the phase offset (right shift)', functio
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -583,9 +534,7 @@ tape( 'the function supports specifying the phase offset (right shift)', functio
 tape( 'the function supports specifying the phase offset (right shift; mod)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var it;
 	var i;
 
@@ -650,13 +599,7 @@ tape( 'the function supports specifying the phase offset (right shift; mod)', fu
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -664,9 +607,7 @@ tape( 'the function supports specifying the phase offset (right shift; mod)', fu
 tape( 'the function supports limiting the number of iterations', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var it;
 	var i;
 
@@ -702,13 +643,7 @@ tape( 'the function supports limiting the number of iterations', function test( 
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of https://github.com/stdlib-js/stdlib/issues/11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `simulate/iter/sawtooth-wave` from relative tolerance testing to ULP difference testing, as described in #11352.
-   replaces the `delta`/`tol` comparison blocks in `test/test.js` with `t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, N ), true, 'returns expected value' );`, adds the `@stdlib/assert/is-almost-same-value` import, and removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` imports.

ULP bounds used, tightened to the measured minimum for each test case:

| Test | ULP |
| ---- | --- |
| generates a sawtooth wave (default) | `0` |
| supports specifying the waveform period | `0` |
| supports specifying the wave amplitude | `0` |
| supports specifying the phase offset (left shift) | `0` |
| supports specifying the phase offset (left shift; mod) | `0` |
| supports specifying the phase offset (right shift) | `0` |
| supports specifying the phase offset (right shift; mod) | `0` |
| supports limiting the number of iterations | `1` |

All values except one are bit-for-bit exact, and thus use a bound of `0` ULP. The `iter` test case requires `1` ULP, as the returned value `-0.5000000000000001` differs from the expected literal `-0.5` by exactly one ULP; lowering that bound to `0` causes the assertion to fail, confirming `1` is the minimum. The suite (240 assertions) was run twice at the final bounds with identical results.

The package has no `test/test.native.js`, so no native test file required updating.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Only `lib/node_modules/@stdlib/simulate/iter/sawtooth-wave/test/test.js` is modified. `make test TESTS_FILTER=".*/simulate/iter/sawtooth-wave/.*"` passes (240/240), and ESLint reports no problems for the modified file.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated, unattended migration task. The ULP bounds were measured empirically by running the test suite rather than estimated.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqqdPYJ7b95CKX13XpdtDH

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqqdPYJ7b95CKX13XpdtDH)_