### PR TITLE
feat: add float16 dtype support to `ndarray/broadcast-scalar-like`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/broadcast-scalar-like/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/broadcast-scalar-like/benchmark/benchmark.js
@@ -80,6 +80,30 @@ bench( format( '%s:dtype=float32', pkg ), function benchmark( b ) {
 	b.end();
 });
 
+bench( format( '%s:dtype=float16', pkg ), function benchmark( b ) {
+	var x;
+	var o;
+	var i;
+
+	x = empty( [ 2, 2 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		o = broadcastScalarLike( x, i, {
+			'dtype': 'float16'
+		});
+		if ( typeof o !== 'object' ) {
+			b.fail( 'should return an ndarray' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( o ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
 bench( format( '%s:dtype=complex128', pkg ), function benchmark( b ) {
 	var x;
 	var o;

--- a/lib/node_modules/@stdlib/ndarray/broadcast-scalar-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/broadcast-scalar-like/docs/types/index.d.ts
@@ -21,7 +21,7 @@
 /// <reference types="@stdlib/types"/>
 
 import { ComplexLike } from '@stdlib/types/complex';
-import { ndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, complex128ndarray, complex64ndarray, genericndarray, boolndarray, Shape, DataType, Order, Float64DataType, Float32DataType, Complex128DataType, Complex64DataType, BooleanDataType, Int32DataType, Int16DataType, Int8DataType, Uint32DataType, Uint16DataType, Uint8DataType, Uint8cDataType, GenericDataType } from '@stdlib/types/ndarray';
+import { ndarray, float64ndarray, float32ndarray, float16ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, complex128ndarray, complex64ndarray, genericndarray, boolndarray, Shape, DataType, Order, Float64DataType, Float32DataType, Float16DataType, Complex128DataType, Complex64DataType, BooleanDataType, Int32DataType, Int16DataType, Int8DataType, Uint32DataType, Uint16DataType, Uint8DataType, Uint8cDataType, GenericDataType } from '@stdlib/types/ndarray';
 
 /**
 * Interface defining function options.
@@ -71,6 +71,16 @@ interface Float32Options extends BaseOptions {
 	* Output array data type.
 	*/
 	dtype: Float32DataType;
+}
+
+/**
+* Interface defining function options.
+*/
+interface Float16Options extends BaseOptions {
+	/**
+	* Output array data type.
+	*/
+	dtype: Float16DataType;
 }
 
 /**
@@ -270,6 +280,48 @@ declare function broadcastScalarLike( x: float32ndarray, value: number, options?
 * // returns <ndarray>
 */
 declare function broadcastScalarLike( x: ndarray, value: number, options: Float32Options ): float32ndarray;
+
+/**
+* Broadcasts a scalar value to an ndarray having the same shape and data type as a provided input ndarray.
+*
+* @param x - input ndarray
+* @param value - scalar value
+* @param options - function options
+* @returns ndarray
+*
+* @example
+* var empty = require( '@stdlib/ndarray/empty' );
+*
+* var x = empty( [ 2, 2 ], {
+*     'dtype': 'float16'
+* });
+* // returns <ndarray>
+*
+* var out = broadcastScalarLike( x, 1.0 );
+* // returns <ndarray>
+*/
+declare function broadcastScalarLike( x: float16ndarray, value: number, options?: BaseOptions ): float16ndarray;
+
+/**
+* Broadcasts a scalar value to an ndarray having the same shape and data type as a provided input ndarray.
+*
+* @param x - input ndarray
+* @param value - scalar value
+* @param options - function options
+* @returns ndarray
+*
+* @example
+* var empty = require( '@stdlib/ndarray/empty' );
+*
+* var x = empty( [ 2, 2 ] );
+* // returns <ndarray>
+*
+* var out = broadcastScalarLike( x, 1.0, {
+*     'dtype': 'float16'
+* });
+* // returns <ndarray>
+*/
+declare function broadcastScalarLike( x: ndarray, value: number, options: Float16Options ): float16ndarray;
 
 /**
 * Broadcasts a scalar value to an ndarray having the same shape and data type as a provided input ndarray.

--- a/lib/node_modules/@stdlib/ndarray/broadcast-scalar-like/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/broadcast-scalar-like/docs/types/test.ts
@@ -34,6 +34,7 @@ import broadcastScalarLike = require( './index' );
 
 	broadcastScalarLike( x, 1.0, { 'dtype': 'float64' } ); // $ExpectType float64ndarray
 	broadcastScalarLike( x, 1.0, { 'dtype': 'float32' } ); // $ExpectType float32ndarray
+	broadcastScalarLike( x, 1.0, { 'dtype': 'float16' } ); // $ExpectType float16ndarray
 	broadcastScalarLike( x, 1.0, { 'dtype': 'complex128' } ); // $ExpectType complex128ndarray
 	broadcastScalarLike( x, 1.0, { 'dtype': 'complex64' } ); // $ExpectType complex64ndarray
 	broadcastScalarLike( x, true, { 'dtype': 'bool' } ); // $ExpectType boolndarray

--- a/lib/node_modules/@stdlib/ndarray/broadcast-scalar-like/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/broadcast-scalar-like/test/test.js
@@ -23,6 +23,7 @@
 var tape = require( 'tape' );
 var Float64Array = require( '@stdlib/array/float64' );
 var Float32Array = require( '@stdlib/array/float32' );
+var Float16Array = require( '@stdlib/array/float16' );
 var Int32Array = require( '@stdlib/array/int32' );
 var Uint32Array = require( '@stdlib/array/uint32' );
 var Int16Array = require( '@stdlib/array/int16' );
@@ -319,6 +320,29 @@ tape( 'the function returns an ndarray having the same shape and data type as a 
 	t.end();
 });
 
+tape( 'the function returns an ndarray having the same shape and data type as a provided ndarray (default, float16)', function test( t ) {
+	var expected;
+	var arr;
+	var x;
+
+	x = empty( [ 2, 2 ], {
+		'dtype': 'float16'
+	});
+	arr = broadcastScalarLike( x, 1.0 );
+	expected = new Float16Array( [ 1.0 ] );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float16', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float16Array ), true, 'returns expected value' );
+	t.deepEqual( getData( arr ), expected, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+	t.strictEqual( numel( arr ), 4, 'returns expected value' );
+	t.deepEqual( ndarray2array( arr ), [ [ 1.0, 1.0 ], [ 1.0, 1.0 ] ], 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function returns an ndarray having the same shape and data type as a provided ndarray (default, complex128)', function test( t ) {
 	var expected;
 	var arr;
@@ -465,6 +489,29 @@ tape( 'the function returns an ndarray having the specified data type (dtype=flo
 	t.strictEqual( String( getDType( arr ) ), 'float32', 'returns expected value' );
 	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( getData( arr ), Float32Array ), true, 'returns expected value' );
+	t.deepEqual( getData( arr ), expected, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+	t.strictEqual( numel( arr ), 4, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns an ndarray having the specified data type (dtype=float16)', function test( t ) {
+	var expected;
+	var arr;
+	var x;
+
+	x = empty( [ 2, 2 ] );
+
+	arr = broadcastScalarLike( x, 1.0, {
+		'dtype': 'float16'
+	});
+	expected = new Float16Array( [ 1.0 ] );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float16', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float16Array ), true, 'returns expected value' );
 	t.deepEqual( getData( arr ), expected, 'returns expected value' );
 	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
 	t.strictEqual( numel( arr ), 4, 'returns expected value' );


### PR DESCRIPTION
Progresses #14240

## Description

> What is the purpose of this pull request?

This pull request:

-  add float16 dtype support to ndarray/broadcast-scalar-like

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #14240

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
