### PR TITLE
test: migrate `stats/base/dists/triangular/cdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/cdf/test/test.cdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( './../lib' );
 
 
@@ -88,8 +87,6 @@ tape( 'if provided parameters not satisfying `a <= c <= b`, the function returns
 
 tape( 'the function evaluates the cdf for `x` given a small range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -104,21 +101,13 @@ tape( 'the function evaluates the cdf for `x` given a small range `b - a`', func
 	c = smallRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given a medium range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -133,21 +122,13 @@ tape( 'the function evaluates the cdf for `x` given a medium range `b - a`', fun
 	c = mediumRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given a large range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -162,13 +143,7 @@ tape( 'the function evaluates the cdf for `x` given a large range `b - a`', func
 	c = largeRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/cdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -156,9 +155,7 @@ tape( 'if provided parameters not satisfying `a <= c <= b`, the created function
 
 tape( 'the created function evaluates the cdf for `x` given a small range `b - a`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -174,22 +171,14 @@ tape( 'the created function evaluates the cdf for `x` given a small range `b - a
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( a[i], b[i], c[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given a medium range `b - a`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -205,22 +194,14 @@ tape( 'the created function evaluates the cdf for `x` given a medium range `b - 
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( a[i], b[i], c[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given a large range `b - a`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -236,13 +217,7 @@ tape( 'the created function evaluates the cdf for `x` given a large range `b - a
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( a[i], b[i], c[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/cdf/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -97,8 +96,6 @@ tape( 'if provided parameters not satisfying `a <= c <= b`, the function returns
 
 tape( 'the function evaluates the cdf for `x` given a small range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -113,21 +110,13 @@ tape( 'the function evaluates the cdf for `x` given a small range `b - a`', opts
 	c = smallRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given a medium range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -142,21 +131,13 @@ tape( 'the function evaluates the cdf for `x` given a medium range `b - a`', opt
 	c = mediumRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given a large range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -171,13 +152,7 @@ tape( 'the function evaluates the cdf for `x` given a large range `b - a`', opts
 	c = largeRange.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], a[i], b[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/triangular/cdf` from computed relative-tolerance comparisons (`delta = abs( y - expected[ i ] )` / `tol = 1.0 * EPS * abs( expected[ i ] )`, asserted via `t.ok( delta <= tol, ... )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to `test/test.cdf.js`, `test/test.factory.js`, and `test/test.native.js` (three fixture blocks in each).
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from all three test files, along with the `delta` and `tol` variable declarations and the redundant `y === expected[ i ]` exact-match branch.

Only test files are changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| Fixture block | Fixture | Previous tolerance | ULP bound |
| --- | --- | --- | :-: |
| small range `b - a` (`test.cdf.js`, `test.factory.js`, `test.native.js`) | `julia/small_range.json` | `1.0 * EPS * abs( expected[ i ] )` | `0` |
| medium range `b - a` (`test.cdf.js`, `test.factory.js`, `test.native.js`) | `julia/medium_range.json` | `1.0 * EPS * abs( expected[ i ] )` | `0` |
| large range `b - a` (`test.cdf.js`, `test.factory.js`, `test.native.js`) | `julia/large_range.json` | `1.0 * EPS * abs( expected[ i ] )` | `0` |

`0` is the minimum integer `N` such that `isAlmostSameValue( y, expected[ i ], N )` holds for every entry in each fixture, and, being the smallest representable bound, it cannot be tightened further. Starting from a high bound and tightening, the measured maximum ULP difference over the 3000 fixture values (1000 per range) is exactly `0`; both the main function and the function returned by `factory` reproduce all 3000 Julia reference values bit-for-bit. This was confirmed independently of the test harness by searching, for each fixture entry, for the smallest `N` satisfying `isAlmostSameValue( y, expected[ i ], N )`.

The C implementation was measured the same way and also reproduces all 3000 reference values bit-for-bit, so `test.native.js` uses the same bound as the JavaScript tests. In addition to the in-harness measurement, `src/main.c` was compiled together with its transitive C dependencies into a standalone program which was fed the fixture inputs as exact IEEE-754 bit patterns; the returned bit patterns matched the fixture expectations exactly, which additionally rules out any FMA-contraction difference on this platform.

The native add-on was built locally (`make install-node-addons`), so `test/test.native.js` executes rather than being skipped. The full suite was run twice at the final bound with identical results both times: `9049` assertions passing across `test.js` (3), `test.cdf.js` (3012), `test.factory.js` (3022), and `test.native.js` (3012); no failures and no skipped tests. `make eslint-tests TESTS_FILTER=".*/stats/base/dists/triangular/cdf/.*"` is clean.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The resulting assertion matches the idiom used by the already-migrated sibling packages `stats/base/dists/triangular/logcdf` and `stats/base/dists/triangular/mgf`, which apply the migration across `test.<name>.js`, `test.factory.js`, and `test.native.js` over the same style of Julia fixtures.

One environment note: `make install-node-modules` fails out of the box here because npm cannot resolve `es-object-atoms@^1.1.2` (a transitive dependency; the registry publishes only up to `1.1.1`). The install was completed by temporarily pinning that transitive dependency via an npm `overrides` entry, which was reverted before committing and is not part of this diff. The pre-commit `editorconfig` hook could not run either, since it downloads its checker binary from GitHub and network access to that repository is not available in this environment; the three changed files were instead verified manually against `.editorconfig` (LF endings, UTF-8, tab indentation, no trailing whitespace, final newline present).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously converted packages in the same family to match the established idiom, performed the conversion, and determined the minimum passing ULP bound empirically over the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMdFi7UjR2HWqwVCypejPd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMdFi7UjR2HWqwVCypejPd)_