### PR TITLE
test: migrate `stats/base/dists/bernoulli/cdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/bernoulli/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bernoulli/cdf/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -122,9 +121,7 @@ tape( 'if provided a success probability `p` outside of `[0,1]`, the created fun
 
 tape( 'the created function evaluates the cdf for `x` given small parameter `p`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var x;
 	var p;
 	var y;
@@ -136,22 +133,14 @@ tape( 'the created function evaluates the cdf for `x` given small parameter `p`'
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( p[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given large parameter `p`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var x;
 	var p;
 	var y;
@@ -163,13 +152,7 @@ tape( 'the created function evaluates the cdf for `x` given large parameter `p`'
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( p[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of  #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for stats/base/dists/bernoulli/cdf from relative tolerance (abs/EPS-based) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
-   updates test/test.factory.js only. test/test.cdf.js and test/test.native.js already used exact equality (t.strictEqual) with no tolerance logic and required no changes.
-   removes the now-unused abs and EPS imports and the corresponding delta/tol variable declarations, collapsing each if/else exact-match-or-tolerance branch into a single isAlmostSameValue assertion.

Measured minimum ULP bound:

| Fixture | ULP |
|---|---|
| small_p | 0 |
| large_p | 0 |

Both bounds reflect exact bitwise agreement across all fixture rows the previous 20.0 * EPS and 1.0 * EPS tolerances were never actually exercised by any fixture value.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
