### PR TITLE
test: migrate `stats/strided/dsemwd` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/dsemwd/test/test.dsemwd.js
+++ b/lib/node_modules/@stdlib/stats/strided/dsemwd/test/test.dsemwd.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var dsemwd = require( './../lib/dsemwd.js' );
 
 
@@ -44,8 +43,6 @@ tape( 'the function has an arity of 4', function test( t ) {
 
 tape( 'the function calculates the standard error of the mean for a strided array (population)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -53,9 +50,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsemwd( x.length, 0, x, 1 );
 	expected = sqrt( 53.5/x.length ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsemwd( x.length, 0, x, 1 );
@@ -70,8 +65,6 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 
 tape( 'the function calculates the standard error of the mean for a strided array (sample)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -79,9 +72,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsemwd( x.length, 1, x, 1 );
 	expected = sqrt( 53.5/(x.length-1) ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsemwd( x.length, 1, x, 1 );

--- a/lib/node_modules/@stdlib/stats/strided/dsemwd/test/test.dsemwd.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dsemwd/test/test.dsemwd.native.js
@@ -23,10 +23,9 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -53,8 +52,6 @@ tape( 'the function has an arity of 4', opts, function test( t ) {
 
 tape( 'the function calculates the standard error of the mean for a strided array (population)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -62,9 +59,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsemwd( x.length, 0, x, 1 );
 	expected = sqrt( 53.5/x.length ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsemwd( x.length, 0, x, 1 );
@@ -79,8 +74,6 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 
 tape( 'the function calculates the standard error of the mean for a strided array (sample)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -88,9 +81,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsemwd( x.length, 1, x, 1 );
 	expected = sqrt( 53.5/(x.length-1) ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsemwd( x.length, 1, x, 1 );

--- a/lib/node_modules/@stdlib/stats/strided/dsemwd/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/dsemwd/test/test.ndarray.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var dsemwd = require( './../lib/ndarray.js' );
 
 
@@ -44,8 +43,6 @@ tape( 'the function has an arity of 5', function test( t ) {
 
 tape( 'the function calculates the standard error of the mean for a strided array (population)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -53,9 +50,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsemwd( x.length, 0, x, 1, 0 );
 	expected = sqrt( 53.5/x.length ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsemwd( x.length, 0, x, 1, 0 );
@@ -70,8 +65,6 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 
 tape( 'the function calculates the standard error of the mean for a strided array (sample)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -79,9 +72,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsemwd( x.length, 1, x, 1, 0 );
 	expected = sqrt( 53.5/(x.length-1) ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsemwd( x.length, 1, x, 1, 0 );

--- a/lib/node_modules/@stdlib/stats/strided/dsemwd/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dsemwd/test/test.ndarray.native.js
@@ -23,10 +23,9 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -53,8 +52,6 @@ tape( 'the function has an arity of 5', opts, function test( t ) {
 
 tape( 'the function calculates the standard error of the mean for a strided array (population)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -62,9 +59,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsemwd( x.length, 0, x, 1, 0 );
 	expected = sqrt( 53.5/x.length ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsemwd( x.length, 0, x, 1, 0 );
@@ -79,8 +74,6 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 
 tape( 'the function calculates the standard error of the mean for a strided array (sample)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -88,9 +81,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsemwd( x.length, 1, x, 1, 0 );
 	expected = sqrt( 53.5/(x.length-1) ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsemwd( x.length, 1, x, 1, 0 );


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/strided/dsemwd` from computed relative-tolerance comparisons (`delta = abs( v - expected )` / `tol = 1.0 * EPS * abs( expected )`, asserted via `t.strictEqual( delta <= tol, ... )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to `test/test.dsemwd.js`, `test/test.ndarray.js`, `test/test.dsemwd.native.js`, and `test/test.ndarray.native.js` (two assertion sites in each). `test/test.js` contains no tolerance-based assertions and is unchanged.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from the four test files, along with the `delta` and `tol` variable declarations.

Only test files are changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| Test file | Assertion | Previous tolerance | ULP bound |
| --- | --- | --- | :-: |
| `test.dsemwd.js` | standard error of the mean (population) | `1.0 * EPS * abs( expected )` | `1` |
| `test.dsemwd.js` | standard error of the mean (sample) | `1.0 * EPS * abs( expected )` | `1` |
| `test.ndarray.js` | standard error of the mean (population) | `1.0 * EPS * abs( expected )` | `1` |
| `test.ndarray.js` | standard error of the mean (sample) | `1.0 * EPS * abs( expected )` | `1` |
| `test.dsemwd.native.js` | standard error of the mean (population) | `1.0 * EPS * abs( expected )` | `1` |
| `test.dsemwd.native.js` | standard error of the mean (sample) | `1.0 * EPS * abs( expected )` | `1` |
| `test.ndarray.native.js` | standard error of the mean (population) | `1.0 * EPS * abs( expected )` | `1` |
| `test.ndarray.native.js` | standard error of the mean (sample) | `1.0 * EPS * abs( expected )` | `1` |

`1` is the minimum integer `N` such that `isAlmostSameValue( v, expected, N )` holds at every migrated assertion site. This was measured independently of the test harness by searching, for each site, for the smallest `N` satisfying `isAlmostSameValue( v, expected, N )`, starting from a high bound and tightening. The measured minimum is exactly `1` at all eight sites: `N = 0` (bit-for-bit equality) fails, as the returned value differs from the expected value by a single ULP (e.g., `1.2190615698606493` vs. `1.2190615698606495`), and `N = 1` succeeds.

The native add-on was built locally (`node-gyp rebuild`) so that `test/test.dsemwd.native.js` and `test/test.ndarray.native.js` actually execute rather than being skipped. The C implementation produces the same values as the JavaScript implementation at all four native assertion sites, so the native tests use the same `1` ULP bound, verified by execution rather than by inference.

`make test TESTS_FILTER=".*/stats/strided/dsemwd/.*"` was run twice at the final bound with identical results: 77/77 passing across all five test files on both runs, no failures, ruling out FMA/architecture-dependent flakiness on this platform. `make eslint-tests TESTS_FILTER=".*/stats/strided/dsemwd/.*"` is clean.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The resulting assertions match the idiom used by the already-migrated sibling package `stats/strided/dsem`, which computes the same quantity via a textbook (non-Welford) algorithm and uses the same `1` ULP bound at the corresponding eight assertion sites in its `test.dsem.js`, `test.ndarray.js`, `test.dsem.native.js`, and `test.ndarray.native.js`. The resulting diff is line-for-line equivalent to the one already merged for that package.

One environment note, which did not affect verification: `make install-node-modules` initially failed with `ETARGET` for `es-object-atoms@^1.1.2`. This turned out to be a stale local npm packument cache rather than a repository or registry problem; `npm cache clean --force` followed by `make install-node-modules` and `make init` succeeded, and the full toolchain (tests, ESLint, native add-on build) was available for this PR.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously converted packages in the same family to match the established idiom, performed the conversion, and determined the minimum passing ULP bound empirically at every assertion site.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KpivvFHFQiGAeH3L1N8ET


---
_Generated by [Claude Code](https://claude.ai/code/session_016KpivvFHFQiGAeH3L1N8ET)_