### PR TITLE
test: migrate `stats/base/dists/chisquare/logpdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/logpdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/logpdf/test/test.factory.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var randu = require( '@stdlib/random/base/randu' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
@@ -146,8 +146,6 @@ tape( 'the returned function returns `-Infinity` for all `x < 0`', function test
 tape( 'the created function evaluates the logpdf for `x` given degrees of freedom `k`', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
-	var tol;
 	var k;
 	var x;
 	var y;
@@ -159,13 +157,7 @@ tape( 'the created function evaluates the logpdf for `x` given degrees of freedo
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( k[i] );
 		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 15 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/logpdf/test/test.logpdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/logpdf/test/test.logpdf.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var randu = require( '@stdlib/random/base/randu' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
@@ -117,8 +117,6 @@ tape( 'the function returns `-Infinity` for all `x < 0`', function test( t ) {
 
 tape( 'the function evaluates the logpdf for `x` given degrees of freedom `k`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var k;
 	var y;
@@ -129,13 +127,7 @@ tape( 'the function evaluates the logpdf for `x` given degrees of freedom `k`', 
 	k = decimalDecimal.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 15 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/logpdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/logpdf/test/test.native.js
@@ -22,9 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var randu = require( '@stdlib/random/base/randu' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
@@ -126,8 +126,6 @@ tape( 'the function returns `-Infinity` for all `x < 0`', opts, function test( t
 
 tape( 'the function evaluates the logpdf for `x` given degrees of freedom `k`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var k;
 	var y;
@@ -138,13 +136,7 @@ tape( 'the function evaluates the logpdf for `x` given degrees of freedom `k`', 
 	k = decimalDecimal.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[ i ], k[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', k: '+k[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 15 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/chisquare/logpdf` from computed relative-tolerance comparisons (`delta = abs( y - expected[ i ] )` / `tol = 10.0 * EPS * abs( expected[ i ] )`, asserted via `t.ok( delta <= tol, ... )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to `test/test.logpdf.js`, `test/test.factory.js`, and `test/test.native.js` (one fixture block in each).
-   removes the now-unused `@stdlib/math/base/special/abs` require from all three test files, along with the `delta` and `tol` variable declarations and the redundant `y === expected[ i ]` exact-match branch.

The `@stdlib/constants/float64/eps` require is retained in all three files, as `EPS` remains in use by the "returns `-Infinity` for all `x < 0`" test (`x = -( randu()*100.0 ) - EPS;`).

Only test files are changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| Fixture block | Fixture | Previous tolerance | ULP bound |
| --- | --- | --- | :-: |
| logpdf for `x` given degrees of freedom `k` (`test.logpdf.js`, `test.factory.js`, `test.native.js`) | `julia/decimal_decimal.json` | `10.0 * EPS * abs( expected[ i ] )` | `15` |

`15` is the minimum integer `N` such that `isAlmostSameValue( y, expected[ i ], N )` holds for every entry in the fixture. Starting from a high bound and tightening, the measured maximum ULP difference over the 5000 fixture values is exactly `15`, attained at `x = 8.727837272289122`, `k = 17.266858371208855` (`y = -3.6381142627612433`, expected `-3.6381142627612366`). This was confirmed independently of the test harness by searching, for each fixture entry, for the smallest `N` satisfying `isAlmostSameValue( y, expected[ i ], N )`, and confirmed within the harness by observing that `N = 14` fails exactly one assertion while `N = 15` passes all of them. Both the main function and the function returned by `factory` produce identical results, so both share the same bound.

The C implementation was measured the same way over the same fixture and also requires exactly `15` ULP, attaining its maximum at the same fixture entry, so `test.native.js` uses the same bound as the JavaScript tests.

The native add-on was built locally, so `test/test.native.js` executes rather than being skipped. The full suite was run twice at the final bound with identical results both times: `15348` assertions passing across `test.js` (3), `test.logpdf.js` (5115), `test.factory.js` (5115), and `test.native.js` (5115); no failures and no skipped tests. `make eslint-tests TESTS_FILTER=".*/stats/base/dists/chisquare/logpdf/.*"` is clean.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The resulting assertion matches the idiom used by already-migrated sibling packages such as `stats/base/dists/triangular/cdf` and `stats/base/dists/planck/logcdf`, which apply the migration across `test.<name>.js`, `test.factory.js`, and `test.native.js` over the same style of Julia fixtures.

Two environment notes:

-   `make install-node-modules` initially failed because npm could not resolve `es-object-atoms@^1.1.2` from a stale local cache; clearing the npm cache and re-running the install resolved it, with no change to any manifest in this repository.
-   The pre-commit `editorconfig` hook could not run, since it downloads its checker binary from GitHub and network access to that repository is not available in this environment; the three changed files were instead verified manually against `.editorconfig` (LF endings, UTF-8, tab indentation, no trailing whitespace, final newline present).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously converted packages in the same family to match the established idiom, performed the conversion, and determined the minimum passing ULP bound empirically over the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LHxfiAd8FbaZFbDEqvzFG

---
_Generated by [Claude Code](https://claude.ai/code/session_016LHxfiAd8FbaZFbDEqvzFG)_