### PR TITLE
test: migrate `stats/base/dists/frechet/median` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/median/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/median/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var median = require( './../lib' );
 
 
@@ -97,8 +96,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', function test
 tape( 'the function returns the median of a Fréchet distribution', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var y;
 	var i;
@@ -109,13 +106,7 @@ tape( 'the function returns the median of a Fréchet distribution', function tes
 	for ( i = 0; i < alpha.length; i++ ) {
 		y = median( alpha[i], s[i], 0.0 );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'alpha:'+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. s: '+s[i]+'. m: 0. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/median/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/median/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -112,8 +111,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', opts, functio
 tape( 'the function returns the median of a Fréchet distribution', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var y;
 	var i;
@@ -124,13 +121,7 @@ tape( 'the function returns the median of a Fréchet distribution', opts, functi
 	for ( i = 0; i < alpha.length; i++ ) {
 		y = median( alpha[i], s[i], 0.0 );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'alpha:'+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. s: '+s[i]+'. m: 0. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates `stats/base/dists/frechet/median` testing from EPS-based relative tolerance assertions to `@stdlib/assert/is-almost-same-value` ULP difference assertions.
-   Measured the exact ULP difference between the implementation's output and each fixture's expected value across the full fixture set (100 cases): the maximum observed difference was `0` ULP (exact match), so the fixture-loop assertion now uses `isAlmostSameValue( y, expected[ i ], 0 )`.
-   Applied the identical change to `test.native.js`, keeping the same ULP bound as `test.js`.
-   Confirmed determinism by running the full fixture set twice at the final bound (`0` ULP).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, run as a scheduled/autonomous task. It studied issue #11352 and already-merged sibling PRs in the `stats/base/dists/frechet` family (`entropy`, `mode`) to mirror the settled idiom, then measured the exact ULP difference per fixture directly against the implementation to determine the tightest passing bound.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrzhCVu95Ue4a7iDFzbw3d

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrzhCVu95Ue4a7iDFzbw3d)_