### PR TITLE
test: migrate `stats/incr/nanmhmean` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nanmhmean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmhmean/test/test.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPSILON = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var incrnanmhmean = require( './../lib' );
 
 
@@ -72,9 +71,7 @@ tape( 'the function returns an accumulator function', function test( t ) {
 tape( 'the accumulator function computes a moving harmonic mean incrementally', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
-	var tol;
 	var acc;
 	var N;
 	var i;
@@ -101,13 +98,7 @@ tape( 'the accumulator function computes a moving harmonic mean incrementally', 
 	];
 
 	for ( i = 0; i < N; i++ ) {
-		if ( actual[ i ] === expected[ i ] ) {
-			t.strictEqual( actual[ i ], expected[ i ], 'returns expected value' );
-		} else {
-			delta = abs( expected[ i ] - actual[ i ] );
-			tol = EPSILON * abs( expected[ i ] );
-			t.equal( delta <= tol, true, 'within tolerance. Expected: '+expected[ i ]+'. Actual: '+actual[ i ]+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual[ i ], expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -115,10 +106,8 @@ tape( 'the accumulator function computes a moving harmonic mean incrementally', 
 tape( 'if not provided an input value, the accumulator function returns the current harmonic mean', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
 	var acc;
-	var tol;
 	var i;
 
 	data = [ 2.0, NaN, 3.0, NaN, 5.0 ];
@@ -128,9 +117,7 @@ tape( 'if not provided an input value, the accumulator function returns the curr
 	}
 	actual = acc();
 	expected = 3.75; // Note: computed by hand using textbook formula
-	delta = abs( expected - actual );
-	tol = 1.1 * EPSILON * abs( expected );
-	t.equal( delta <= tol, true, 'within tolerance. Expected: '+expected+'. Actual: '+actual+'. Delta: '+delta+'. Tol: '+tol+'.' );
+	t.strictEqual( isAlmostSameValue( actual, expected, 2 ), true, 'returns expected value' );
 	t.end();
 });
 


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/incr/nanmhmean` from computed relative-tolerance comparisons (`delta = abs( expected - actual )` / `tol = EPSILON * abs( expected )`, asserted via `t.equal( delta <= tol, ... )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to the two tolerance-based assertion sites in `test/test.js`. The package has no `test/test.native.js`, and the remaining assertions in the file are exact comparisons against `null`, `NaN`, and exactly representable values, which are correct as-is and are left unchanged.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires, along with the `delta` and `tol` variable declarations.
-   collapses the `if ( actual[ i ] === expected[ i ] ) { ... } else { ... }` branch in the moving-harmonic-mean test into a single ULP assertion, matching the migrated idiom.

Only a test file is changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| Assertion | Previous tolerance | ULP bound |
| --- | --- | :-: |
| moving harmonic mean computed incrementally (8 values) | `EPSILON * abs( expected )` | `1` |
| current harmonic mean when not provided an input value | `1.1 * EPSILON * abs( expected )` | `2` |

These are the minimum integer bounds `N` such that `isAlmostSameValue( actual, expected, N )` holds at each site. They were measured independently of the test harness by computing `ulpDifference( actual, expected )` directly at every assertion site, starting from a high bound (`64`, which passes) and tightening:

-   Moving harmonic mean: the per-element ULP differences are `0, 1, 1, 0, 1, 1, 1, 1`, so `1` is the tightest bound covering the loop. `N = 0` fails on six of the eight elements (e.g., `2.4000000000000004` vs. `2.4`, and `2.769230769230769` vs. `2.7692307692307696`).
-   Current harmonic mean: the accumulator returns `3.750000000000001` against a hand-computed expected value of `3.75`, a difference of exactly `2` ULP, so `N = 2` is required and `N = 1` fails.

Tightening either site by one ULP was verified to fail (7 of 31 assertions fail at `N - 1`), confirming both bounds are minimal rather than merely sufficient.

`make test TESTS_FILTER=".*/stats/incr/nanmhmean/.*"` was run twice at the final bounds with identical results: 31/31 passing on both runs, no failures, ruling out FMA/architecture-dependent flakiness on this platform. `make eslint-tests TESTS_FILTER=".*/stats/incr/nanmhmean/.*"` is clean.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

The second site requires `2` ULP rather than `1`. This reflects the pre-existing test, which already used a loosened `1.1 * EPSILON` tolerance at that site (as opposed to the plain `EPSILON` used in the loop), so the looser bound is carried over rather than introduced here. The expected value is hand-computed from the textbook formula, so the extra ULP is accumulation error in the incremental algorithm relative to the closed-form value, not a regression. Flagging it in case a reviewer would prefer the expected value be adjusted instead; no change was made, since that would go beyond migrating the assertions.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The resulting diff mirrors the already-merged migration for the sibling package `stats/incr/nanmstdev` (#15072), which has the same accumulator test structure.

One environment note, which did not affect verification: `make install-node-modules` initially failed with `ETARGET` for `es-object-atoms@^1.1.2`. As previously observed in #15116, this is a stale local npm packument cache rather than a repository or registry problem; `npm cache clean --force` followed by `make install-node-modules` and `make init` succeeded, and the full toolchain was available for this PR. Separately, the `lint-editorconfig-files` pre-commit step could not download the `editorconfig-checker` binary in this sandbox and was skipped via `SKIP_LINT_EDITORCONFIG`; the changed lines were checked manually for LF line endings, tab indentation, no trailing whitespace, and a final newline. All other pre-commit lint steps ran normally.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously migrated packages in the same family to match the established idiom, performed the migration, and determined the minimum passing ULP bound empirically at each assertion site.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QwrWGg9D1Fp13W6tJv1gF

---
_Generated by [Claude Code](https://claude.ai/code/session_012QwrWGg9D1Fp13W6tJv1gF)_