### PR TITLE
refactor: use `format` to construct error message

### DIFF
--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-namespace-toc/lib/transformer.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-namespace-toc/lib/transformer.js
@@ -25,6 +25,7 @@ var visit = require( 'unist-util-visit' );
 var createTOC = require( '@stdlib/_tools/markdown/namespace-toc' );
 var startsWith = require( '@stdlib/string/starts-with' );
 var endsWith = require( '@stdlib/string/ends-with' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -171,7 +172,7 @@ function transformer( tree, file ) {
 					}
 				}
 				if ( i === parent.children.length - 1 ) {
-					throw new Error( 'invalid node. Invalid table of contents (toc) comment. Ensure that the Markdown file includes both starting and ending `toc` comments. Node: `' + node.value + '`.' );
+					throw new Error( format( 'invalid node. Invalid table of contents (toc) comment. Ensure that the Markdown file includes both starting and ending `toc` comments. Node: `%s`.', node.value ) );
 				}
 				if ( found ) {
 					debug( 'Append links to links section...' );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   normalizes error-message construction in `_tools/remark/plugins/remark-namespace-toc` to use `@stdlib/string/format` in place of string concatenation

### `remark-namespace-toc`

The TOC transformer assembled its one thrown-error message via string concatenation, the lone deviation from the namespace convention. `format` is the error-construction idiom in 11 of the 12 error-constructing packages in `_tools/remark/plugins` (~92%). The message is now built with `format`, leaving the rendered text byte-for-byte identical. No observable behavior, signature, or test expectation changes.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by an automated cross-package drift scan of the `_tools/remark/plugins` namespace. `package.json` shape, README sections, and the file tree are already uniform across the namespace, so no structural change is warranted; in particular, no `package.json` dependency edit is needed, since the namespace declares runtime dependencies as `{}` and requires `@stdlib/string/format` in code, per sibling convention.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was produced by Claude Code (Opus 4.8) running an automated cross-package drift-detection routine. It extracted structural and semantic features across the namespace, identified the majority error-construction pattern, validated the single outlier through multiple independent review passes, and applied the mechanical, behavior-preserving fix.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUP1buS4hqMNkdDbim1cNn

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUP1buS4hqMNkdDbim1cNn)_