### PR TITLE
style: add spaces

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/bernoulli/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bernoulli/cdf/test/test.factory.js
@@ -133,7 +133,7 @@ tape( 'the created function evaluates the cdf for `x` given small parameter `p`'
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( p[i] );
 		y = cdf( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -152,7 +152,7 @@ tape( 'the created function evaluates the cdf for `x` given large parameter `p`'
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( p[i] );
 		y = cdf( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/bernoulli/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bernoulli/cdf/test/test.factory.js
@@ -131,8 +131,8 @@ tape( 'the created function evaluates the cdf for `x` given small parameter `p`'
 	x = smallP.x;
 	p = smallP.p;
 	for ( i = 0; i < x.length; i++ ) {
-		cdf = factory( p[i] );
-		y = cdf( x[i] );
+		cdf = factory( p[ i ] );
+		y = cdf( x[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -150,8 +150,8 @@ tape( 'the created function evaluates the cdf for `x` given large parameter `p`'
 	x = largeP.x;
 	p = largeP.p;
 	for ( i = 0; i < x.length; i++ ) {
-		cdf = factory( p[i] );
-		y = cdf( x[i] );
+		cdf = factory( p[ i ] );
+		y = cdf( x[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-09-08 23:09 (-0700) (dec095d) and 2026-09-09 01:25 (-0500) (6298f5e).

This pull request:

**`stats/base/dists/bernoulli/cdf`**

-   Fix `expected[i]` → `expected[ i ]` in `test.factory.js` (lines 136, 155), missed by 6f3dfa0's ULP migration and inconsistent with every other file in the batch; violates the "spaces around array indices" rule in the style guide.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation**

All 10 commits merged to `develop` in the review window were audited for:

-   stdlib style guide compliance (two independent passes against `docs/style-guides`, cross-checked against unmodified reference packages already using `@stdlib/assert/is-almost-same-value`)
-   bugs and incorrect logic in the introduced code (two independent passes; migrated test files were additionally executed to confirm all assertions pass at the new ULP tolerances)

Deliberately excluded: anything requiring interpretation or judgment (e.g., chosen ULP tolerances, `require` ordering, which varies among existing reference files, and "See Also" README ordering, which follows the established bot accumulation pattern rather than strict alphabetical order).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of a scheduled automated review of commits merged to `develop` in the preceding 24 hours; the fix was applied and verified by Claude Code.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1HVy6g25PpNnoamrmovE4

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1HVy6g25PpNnoamrmovE4)_