### PR TITLE
bench: bound seed growth in `random/base/*` factory benchmarks

### DIFF
--- a/lib/node_modules/@stdlib/random/base/arcsine/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/arcsine/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/bernoulli/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/bernoulli/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/beta/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/beta/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/betaprime/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/betaprime/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/binomial/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/binomial/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/box-muller/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/box-muller/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/cauchy/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/cauchy/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/chi/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/chi/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/chisquare/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/chisquare/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/cosine/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/cosine/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/discrete-uniform/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/discrete-uniform/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/erlang/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/erlang/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/exponential/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/exponential/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/f/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/f/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/frechet/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/frechet/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/gamma/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/gamma/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/geometric/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/geometric/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/gumbel/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/gumbel/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/hypergeometric/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/hypergeometric/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/improved-ziggurat/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/improved-ziggurat/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/invgamma/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/invgamma/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/kumaraswamy/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/kumaraswamy/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/laplace/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/laplace/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/levy/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/levy/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/logistic/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/logistic/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/lognormal/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/lognormal/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/negative-binomial/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/negative-binomial/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/normal/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/normal/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/pareto-type1/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/pareto-type1/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/poisson/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/poisson/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/randi/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/randi/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/randn/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/randn/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/randu/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/randu/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/rayleigh/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/rayleigh/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/t/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/t/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/triangular/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/triangular/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/uniform/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/uniform/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );

--- a/lib/node_modules/@stdlib/random/base/weibull/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/random/base/weibull/benchmark/benchmark.factory.js
@@ -61,7 +61,7 @@ bench( format( '%s:factory:seed=<integer>', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		opts.seed += i;
+		opts.seed = i + 1;
 		f = factory( opts );
 		if ( typeof f !== 'function' ) {
 			b.fail( 'should return a function' );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   propagates the fix merged to `develop` in 448b57332b5deb707665dd500f8592b01b3be31e to sibling packages.

This applies the same one-line fix already merged in `448b573` to the 38 `random/base/*` packages whose `factory` benchmark shares the identical `opts.seed += i;` accumulation. Left unbounded, the seed grows quadratically and overtakes mt19937's `UINT32_MAX` ceiling once the benchmark harness auto-scales past roughly 92k iterations, throwing a `RangeError` and failing the benchmark. Each fix mirrors the bounded form already used in that same file's array-seed benchmark (`opts.seed[ 0 ] = i + 1;`), matching what `minstd`, `minstd-shuffle`, and `mt19937` already do.

Source commit: 448b573 ("bench: bound seed growth in `factory` benchmark"). Targets: all 38 packages under `random/base/*` with a `factory` benchmark carrying the accumulating form (`arcsine`, `bernoulli`, `beta`, `betaprime`, `binomial`, `box-muller`, `cauchy`, `chi`, `chisquare`, `cosine`, `discrete-uniform`, `erlang`, `exponential`, `f`, `frechet`, `gamma`, `geometric`, `gumbel`, `hypergeometric`, `improved-ziggurat`, `invgamma`, `kumaraswamy`, `laplace`, `levy`, `logistic`, `lognormal`, `negative-binomial`, `normal`, `pareto-type1`, `poisson`, `randi`, `randn`, `randu`, `rayleigh`, `t`, `triangular`, `uniform`, `weibull`).

## Related Issues

> Does this pull request have any related issues?

No related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed before applying the change:

-   Pattern search scoped to `lib/node_modules/@stdlib/random/**` (the accumulating form occurs nowhere else in the repository); `minstd`, `minstd-shuffle`, and `mt19937` already use the bounded form.
-   Two independent validation passes confirmed, per site, that the line sits in the identical structural position as the source fix and that each package funnels its `seed` option to the mt19937 factory's positive-integer/`UINT32_MAX` validation (directly, or via `gamma`/`chisquare`/`poisson`/`improved-ziggurat`/`box-muller` chains).
-   An adaptation pass confirmed each file contains exactly one occurrence with byte-identical surrounding context, so the source patch applies verbatim with no cascading edits; a style pass confirmed the replacement matches the merged form byte-for-byte.
-   Deliberately excluded: a second candidate pattern from the same 24-hour window (2740b02, removal of an unnecessary `Boolean` wrapper in `lib/native.js`) — all other textual matches wrap addons which return int32/uint32 values, where the wrapper is load-bearing, so no sites were propagated.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated fix-propagation routine; each target site was independently validated twice before the change was applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cVRuut4rg5J1R4WoiJgyP

---
_Generated by [Claude Code](https://claude.ai/code/session_011cVRuut4rg5J1R4WoiJgyP)_