### PR TITLE
test: migrate `stats/incr/nanmmda` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nanmmda/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmmda/test/test.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var incrnanmmda = require( './../lib' );
 
 
@@ -72,10 +71,8 @@ tape( 'the function returns an accumulator function', function test( t ) {
 tape( 'the accumulator function computes a moving mean directional accuracy incrementally', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
 	var acc;
-	var tol;
 	var N;
 	var i;
 
@@ -112,13 +109,7 @@ tape( 'the accumulator function computes a moving mean directional accuracy incr
 	];
 	for ( i = 0; i < N; i++ ) {
 		actual = acc( data[i][0], data[i][1] );
-		if ( actual === expected[i] ) {
-			t.equal( actual, expected[i], 'returns expected value' );
-		} else {
-			delta = abs( expected[i] - actual );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.equal( delta <= tol, true, 'within tolerance. Actual: '+actual+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/incr/nanmmda` from a computed relative-tolerance comparison (`delta = abs( expected - actual )` / `tol = 1.0 * EPSILON * abs( expected )`, asserted via `t.equal( delta <= tol, ... )`) to a ULP-difference assertion using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to the single tolerance-based assertion site in `test/test.js`. The package has no `test/test.native.js`, and the remaining assertions in the file are exact comparisons against `null` and exactly representable values, which are correct as-is and are left unchanged.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires, along with the `delta` and `tol` variable declarations.
-   collapses the `if ( actual === expected[i] ) { ... } else { ... }` branch in the moving mean directional accuracy test into a single ULP assertion, matching the migrated idiom.

Only a test file is changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| Assertion | Previous tolerance | ULP bound |
| --- | --- | :-: |
| moving mean directional accuracy computed incrementally (11 values) | `1.0 * EPSILON * abs( expected )` | `0` |

`0` is the minimum integer bound `N` such that `isAlmostSameValue( actual, expected[ i ], N )` holds at the assertion site, and it is minimal by construction, since `N` cannot be lowered further.

The bound was measured independently of the test harness by computing `ulpDifference( actual, expected[ i ] )` directly at every element of the fixture, starting from a high bound (`64`, which passes) and tightening. The per-element ULP differences are `0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0`: the accumulator reproduces each hand-computed expected value (`1`, `1/2`, `2/3`, `1/3`, `0`) exactly. This is expected for this accumulator, since each returned value is a ratio of small integer counts over a fixed window, so no rounding error accumulates. Note that at `N = 0`, `isAlmostSameValue` reduces to the SameValue algorithm, which still distinguishes `+0` from `-0`; the two zero-valued expectations are `+0` on both sides, so the assertion holds.

`make test TESTS_FILTER=".*/stats/incr/nanmmda/.*"` was run three times at the final bound with identical results: 28/28 passing on every run, no failures, ruling out FMA/architecture-dependent flakiness on this platform. `make lint-javascript-tests TESTS_FILTER=".*/stats/incr/nanmmda/.*"` is clean.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

The pre-existing test already had an exact-equality fast path (`if ( actual === expected[i] )`) with the relative-tolerance comparison only as a fallback, and the fallback turns out never to be taken. The migration therefore collapses to `N = 0`, matching the idiom used elsewhere in the migration (a bound of `0` is used at 829 assertion sites already on `develop`). Flagging in case a reviewer would prefer a plain `t.strictEqual( actual, expected[ i ], ... )` at this site instead; no such change was made, since it would go beyond migrating the assertion.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The resulting diff mirrors the already-merged migration for the sibling package `stats/incr/mskewness` (#15101), which has the same accumulator test structure.

Two environment notes, neither of which affected verification:

-   `make install-node-modules` failed with `ETARGET` for `es-object-atoms@^1.1.2`. In this sandbox the failure was not a stale cache: `npm view es-object-atoms versions` reports `1.1.1` as the highest published version, so the constraint is unsatisfiable against the live registry. It was worked around by temporarily adding an `overrides` entry pinning `es-object-atoms` to `1.1.1` in the root `package.json`, running `npm install`, and then restoring `package.json`. The override is local only and is not part of this diff; `make init` and the full toolchain then worked normally.
-   The `lint-editorconfig-files` pre-commit step could not download the `editorconfig-checker` binary in this sandbox and was skipped via `SKIP_LINT_EDITORCONFIG`; the changed lines were checked manually for LF line endings, tab indentation, no trailing whitespace, and a final newline. All other pre-commit lint steps ran normally.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously migrated packages in the same family to match the established idiom, performed the migration, and determined the minimum passing ULP bound empirically at the assertion site.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9twLhajFJVu4yHjgYdCzM


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9twLhajFJVu4yHjgYdCzM)_