### PR TITLE
test: migrate `stats/base/dists/logistic/mgf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/test/test.factory.js
@@ -21,12 +21,11 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -130,9 +129,7 @@ tape( 'if provided `s = 0`, the created function evaluates the MGF of the degene
 
 tape( 'the created function evaluates the MGF for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var mgf;
-	var tol;
 	var mu;
 	var s;
 	var x;
@@ -147,13 +144,7 @@ tape( 'the created function evaluates the MGF for `x` given positive `mu`', func
 		mgf = factory( mu[i], s[i] );
 		y = mgf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -161,9 +152,7 @@ tape( 'the created function evaluates the MGF for `x` given positive `mu`', func
 
 tape( 'the created function evaluates the MGF for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var mgf;
-	var tol;
 	var mu;
 	var s;
 	var x;
@@ -178,13 +167,7 @@ tape( 'the created function evaluates the MGF for `x` given negative `mu`', func
 		mgf = factory( mu[i], s[i] );
 		y = mgf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -192,9 +175,7 @@ tape( 'the created function evaluates the MGF for `x` given negative `mu`', func
 
 tape( 'the created function evaluates the MGF for `x` given large variance ( = large `s`)', function test( t ) {
 	var expected;
-	var delta;
 	var mgf;
-	var tol;
 	var mu;
 	var s;
 	var x;
@@ -209,13 +190,7 @@ tape( 'the created function evaluates the MGF for `x` given large variance ( = l
 		mgf = factory( mu[i], s[i] );
 		y = mgf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/test/test.mgf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/test/test.mgf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mgf = require( './../lib' );
 
 
@@ -80,8 +79,6 @@ tape( 'if provided a negative `s`, the function returns `NaN`', function test( t
 
 tape( 'the function evaluates the MGF for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -95,13 +92,7 @@ tape( 'the function evaluates the MGF for `x` given positive `mu`', function tes
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -109,8 +100,6 @@ tape( 'the function evaluates the MGF for `x` given positive `mu`', function tes
 
 tape( 'the function evaluates the MGF for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -124,13 +113,7 @@ tape( 'the function evaluates the MGF for `x` given negative `mu`', function tes
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -138,8 +121,6 @@ tape( 'the function evaluates the MGF for `x` given negative `mu`', function tes
 
 tape( 'the function evaluates the MGF for `x` given large variance ( = large `s` )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -153,13 +134,7 @@ tape( 'the function evaluates the MGF for `x` given large variance ( = large `s`
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -89,8 +88,6 @@ tape( 'if provided a negative `s`, the function returns `NaN`', opts, function t
 
 tape( 'the function evaluates the MGF for `x` given positive `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -104,13 +101,7 @@ tape( 'the function evaluates the MGF for `x` given positive `mu`', opts, functi
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -118,8 +109,6 @@ tape( 'the function evaluates the MGF for `x` given positive `mu`', opts, functi
 
 tape( 'the function evaluates the MGF for `x` given negative `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -133,13 +122,7 @@ tape( 'the function evaluates the MGF for `x` given negative `mu`', opts, functi
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -147,8 +130,6 @@ tape( 'the function evaluates the MGF for `x` given negative `mu`', opts, functi
 
 tape( 'the function evaluates the MGF for `x` given large variance ( = large `s` )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var s;
@@ -162,13 +143,7 @@ tape( 'the function evaluates the MGF for `x` given large variance ( = large `s`
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/logistic/mgf` from relative tolerance testing to ULP difference testing.

Changes are limited to the package's test files:

-   `test/test.mgf.js`
-   `test/test.factory.js`
-   `test/test.native.js`

In each fixture loop, the `delta`/`tol` computation and the `y === expected[i]` special case are replaced with a single assertion:

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
```

The `@stdlib/assert/is-almost-same-value` require is added, and the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires are removed. No fixtures, implementations, or test cases were otherwise modified.

**ULP bound: `3`**, applied uniformly across all three test files.

This is the measured minimum. Maximum observed ULP difference over the full fixture set (3 fixtures x 1000 values, evaluated against both `lib/main.js` and `lib/factory.js`):

| Fixture | max ULP (JS) | max ULP (C) |
| --- | --- | --- |
| `positive_mean.json` | 2 | 2 |
| `negative_mean.json` | 2 | 2 |
| `large_variance.json` | 3 | 3 |

Tightness was confirmed by re-running the suite at lower bounds: `2` fails (1 assertion), `1` fails (156), and `0` fails (621). The suite was run twice at `3` with identical results (3011 passing assertions in `test.mgf.js`, 3017 in `test.factory.js`, 0 failures), so the bound is not sensitive to run-to-run variation.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The C implementation (`src/main.c`) mirrors the JS implementation exactly (`exp( mu*t ) / sinc( s*t )`). Because the Node addon was not built in the environment used to prepare this PR, `test/test.native.js` skipped locally. To avoid guessing at the native bound, the C routine was compiled into a standalone harness and evaluated against the same fixtures; it agrees with the JS implementation and also peaks at 3 ULP, which is why `test.native.js` uses the same constant.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an unattended scheduled task. The test migration, the ULP bound measurement, and this description were produced by Claude Code; the ULP bound was determined empirically by measuring the fixture set and verifying that lower bounds fail.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_014tDJcwG5Ru7a73zmYG7pba)_