### PR TITLE
test: migrate `stats/base/dists/exponential/pdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -127,9 +126,7 @@ tape( 'if provided a negative `lambda`, the created function always returns `NaN
 tape( 'the created function evaluates the pdf for `x` given parameter `lambda` (when `x` and `lambda` are small)', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var pdf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -140,13 +137,7 @@ tape( 'the created function evaluates the pdf for `x` given parameter `lambda` (
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( lambda[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -154,9 +145,7 @@ tape( 'the created function evaluates the pdf for `x` given parameter `lambda` (
 tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x` is large and `lambda` small)', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var pdf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -167,13 +156,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( lambda[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 22.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 12 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -181,9 +164,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x` is small and `lambda` large)', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var pdf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -194,13 +175,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( lambda[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 22.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -208,9 +183,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x` and `lambda` are large)', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var pdf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -221,13 +194,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( lambda[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 10.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.native.js
@@ -24,10 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -102,8 +101,6 @@ tape( 'if provided a negative `lambda`, the function always returns `NaN`', opts
 tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x` and `lambda` are small)', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -113,13 +110,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	lambda = smallSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 20.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'.  lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -127,8 +118,6 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x` is large and `lambda` small)', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -138,13 +127,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	lambda = largeSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 22.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'.  lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 12 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -152,8 +135,6 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x` is small and `lambda` large)', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -163,13 +144,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	lambda = smallLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 22.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'.  lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -177,8 +152,6 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x` and `lambda` are large)', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -188,13 +161,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	lambda = largeLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 10.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'.  lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.pdf.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( './../lib' );
 
 
@@ -101,8 +100,6 @@ tape( 'if provided a negative `lambda`, the function always returns `NaN`', func
 tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x` and `lambda` are small)', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -112,13 +109,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	lambda = smallSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 20.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'.  lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -126,8 +117,6 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x` is large and `lambda` small)', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -137,13 +126,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	lambda = largeSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 22.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'.  lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 12 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -151,8 +134,6 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x` is small and `lambda` large)', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -162,13 +143,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	lambda = smallLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 22.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'.  lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -176,8 +151,6 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x` and `lambda` are large)', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -187,13 +160,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	lambda = largeLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 10.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'.  lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of  #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-    migrates the test suite for stats/base/dists/exponential/pdf from relative tolerance (EPS/delta/tol) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
-   updates test/test.pdf.js, test/test.factory.js, and test/test.native.js. No other files are changed.
-   removes the now-unused EPS and abs imports and the corresponding delta/tol variable declarations from each file.
-   the ULP bound was verified directly against the fixture data using a script that computes the actual ULP distance between computed and expected values for every input across all four fixtures. Verified minimums (identical across JS and native): small_small=2, large_small=12, small_large=2, large_large=1.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
