### PR TITLE
test: migrate `stats/incr/nanmda` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nanmda/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmda/test/test.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var incrnanmda = require( './../lib' );
 
 
@@ -48,10 +47,8 @@ tape( 'the initial accumulated value is `null`', function test( t ) {
 tape( 'the accumulator function incrementally computes the mean directional accuracy', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
 	var acc;
-	var tol;
 	var N;
 	var i;
 
@@ -79,13 +76,7 @@ tape( 'the accumulator function incrementally computes the mean directional accu
 	acc = incrnanmda();
 	for ( i = 0; i < N; i++ ) {
 		actual = acc( data[ i ][ 0 ], data[ i ][ 1 ] );
-		if ( actual === expected[ i ] ) {
-			t.equal( actual, expected[ i ], 'returns expected value' );
-		} else {
-			delta = abs( expected[ i ] - actual );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.equal( delta <= tol, true, 'within tolerance. Actual: '+actual+'. Expected: '+expected[ i ]+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/incr/nanmda` from relative tolerance testing to ULP difference testing.

Specifically, this replaces the `delta`/`tol` comparison

```javascript
delta = abs( expected[ i ] - actual );
tol = 1.0 * EPS * abs( expected[ i ] );
t.equal( delta <= tol, true, 'within tolerance. ...' );
```

with

```javascript
t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
```

and adds the `@stdlib/assert/is-almost-same-value` require, removing the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

The package has a single relative tolerance assertion site (`test/test.js`); there is no `test/test.native.js`.

**ULP bound:** `1`

This is the measured minimum. Over the full fixture set, exactly one value differs from its expected value (`0.6666666666666667` vs. `0.6666666666666666`), a distance of 1 ULP. The bound was tightened downward and verified empirically: the suite passes at `1` and fails at `0`. The suite was run twice at the final value to confirm determinism.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Only the test file is modified; no source or fixture changes. The exact-equality branch (`actual === expected[ i ]`) was collapsed into the single ULP assertion, since `isAlmostSameValue` already accepts exactly equal values, mirroring the idiom used in previously migrated packages.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code, which selected the package, mirrored the migration idiom from previously merged conversions, determined the minimum ULP bound empirically by running the test suite, and verified the result.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXJxc7UPuqC5NGaw733ZQw)_