### PR TITLE
test: migrate `stats/incr/nanmprod` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nanmprod/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmprod/test/test.js
@@ -21,9 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPSILON = require( '@stdlib/constants/float64/eps' );
 var isEven = require( '@stdlib/math/base/assert/is-even' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
@@ -31,7 +31,6 @@ var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var normal = require( '@stdlib/random/base/normal' );
 var randu = require( '@stdlib/random/base/randu' );
 var ldexp = require( '@stdlib/math/base/special/ldexp' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var incrnanmprod = require( './../lib' );
 
 
@@ -190,8 +189,7 @@ tape( 'the accumulator function can return a result which overflows', function t
 
 tape( 'overflow may be transient', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
+	var actual;
 	var acc;
 	var x;
 	var y;
@@ -209,10 +207,9 @@ tape( 'overflow may be transient', function test( t ) {
 	acc( y );
 	acc( z );
 
-	delta = abs( expected - acc() );
-	tol = EPSILON * abs( expected );
+	actual = acc();
 
-	t.strictEqual( delta <= tol, true, 'within tolerance. Expected: '+expected+'. Actual: '+acc()+'. Delta: '+delta+'. Tol: '+tol+'.' );
+	t.strictEqual( isAlmostSameValue( actual, expected, 1 ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -228,8 +225,7 @@ tape( 'the accumulator function can return a result which underflows', function 
 
 tape( 'underflow may be transient', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
+	var actual;
 	var acc;
 	var x;
 	var y;
@@ -250,10 +246,9 @@ tape( 'underflow may be transient', function test( t ) {
 
 	acc( z );
 
-	delta = abs( acc() - expected );
-	tol = EPSILON * abs( expected );
+	actual = acc();
 
-	t.strictEqual( delta <= tol, true, 'within tolerance. Expected: '+expected+'. Actual: '+acc()+'. Delta: '+delta+'. Tol: '+tol+'.' );
+	t.strictEqual( isAlmostSameValue( actual, expected, 1 ), true, 'returns expected value' );
 	t.end();
 });
 


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/incr/nanmprod` from computed relative-tolerance comparisons (`delta = abs( expected - acc() )` / `tol = EPSILON * abs( expected )`, asserted via `t.strictEqual( delta <= tol, ... )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to the two tolerance-based assertion sites in `test/test.js` (the `overflow may be transient` and `underflow may be transient` tests). The package has no `test/test.native.js`, and the remaining assertions in the file are exact comparisons against `null`, `NaN`, `+-infinity`, signed zeros, and exactly representable values, which are correct as-is and are left unchanged.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires, along with the `delta` and `tol` variable declarations, introducing an `actual` variable at each site to match the migrated idiom used elsewhere in `stats/incr`.

Only a test file is changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| Assertion | Previous tolerance | ULP bound |
| --- | --- | :-: |
| overflow may be transient | `EPSILON * abs( expected )` | `1` |
| underflow may be transient | `EPSILON * abs( expected )` | `1` |

These are the minimum integer bounds `N` such that `isAlmostSameValue( actual, expected, N )` holds at each site. They were measured independently of the test harness by driving the accumulator directly and searching upward from `0` for the smallest bound satisfied at each site, starting from a high bound (`64`, which passes) and tightening:

-   Overflow site: the accumulator returns `1.0715086071862675e+299` against an expected value of `ldexp( 0.01, 1000 )` = `1.0715086071862673e+299`, a difference of exactly `1` ULP.
-   Underflow site: the accumulator returns `9.33263618503219e-304` against an expected value of `ldexp( 0.01, -1000 )` = `9.332636185032189e-304`, a difference of exactly `1` ULP.

Tightening either site by one ULP was verified to fail: at `N = 0`, 2 of 483 assertions fail (one per site), confirming both bounds are minimal rather than merely sufficient. Both sites are fully deterministic — they use fixed `ldexp` inputs with no random data.

`make test TESTS_FILTER=".*/stats/incr/nanmprod/.*"` was run twice at the final bounds with identical results: 483/483 passing on both runs, no failures, ruling out FMA/architecture-dependent flakiness on this platform. `make eslint-tests TESTS_FILTER=".*/stats/incr/nanmprod/.*"` is clean.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The resulting diff mirrors the already-merged migrations for the sibling packages `stats/incr/nanmhmean` (#15125) and `stats/incr/nanmstdev` (#15072), which have the same accumulator test structure.

One environment note, which did not affect verification: `make install-node-modules` initially failed with `ETARGET` for `es-object-atoms@^1.1.2`. As previously observed in #15116 and #15125, this is a stale local npm packument cache rather than a repository or registry problem (the registry does serve `1.1.2`); `npm cache clean --force` followed by `make install-node-modules` and `make init` succeeded, and the full toolchain was available for this PR. Separately, the `lint-editorconfig-files` pre-commit step could not download the `editorconfig-checker` binary in this sandbox and was skipped via `SKIP_LINT_EDITORCONFIG`; the changed lines were checked manually for LF line endings, tab indentation, no trailing whitespace, and a final newline. All other pre-commit lint steps ran normally.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously migrated packages in the same family to match the established idiom, performed the migration, and determined the minimum passing ULP bound empirically at each assertion site.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Fdzvd3XioK2mzPYas59Hf

---
_Generated by [Claude Code](https://claude.ai/code/session_019Fdzvd3XioK2mzPYas59Hf)_