### PR TITLE
test: migrate `stats/base/dists/exponential/cdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/cdf/test/test.cdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( './../lib' );
 
 
@@ -98,8 +97,6 @@ tape( 'if provided a negative `lambda`, the function always returns `NaN`', func
 tape( 'the function evaluates the cdf for `x` given parameter `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -109,9 +106,7 @@ tape( 'the function evaluates the cdf for `x` given parameter `lambda`', functio
 	lambda = data.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], lambda[i] );
-		delta = abs( y - expected[ i ] );
-		tol = 4.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/cdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -124,9 +123,7 @@ tape( 'if provided a negative `lambda`, the created function always returns `NaN
 tape( 'the created function evaluates the cdf for `x` given parameter `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var cdf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -137,13 +134,7 @@ tape( 'the created function evaluates the cdf for `x` given parameter `lambda`',
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( lambda[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 4.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/cdf/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -107,8 +106,6 @@ tape( 'if provided a negative `lambda`, the function always returns `NaN`', opts
 tape( 'the function evaluates the cdf for `x` given parameter `lambda`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -118,9 +115,7 @@ tape( 'the function evaluates the cdf for `x` given parameter `lambda`', opts, f
 	lambda = data.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], lambda[i] );
-		delta = abs( y - expected[ i ] );
-		tol = 4.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the test suite for `stats/base/dists/exponential/cdf` from relative tolerance testing (`delta`/`tol`/`EPS`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   Applies to the fixture-driven tests in `test/test.cdf.js`, `test/test.factory.js`, and `test/test.native.js`.
-   The final fixture-set comparison in all three files uses `ULP = 0`, the minimum required value: computed output matches the R-generated expected values bit-for-bit across all 1000 fixtures.
-   Measured the minimum required ULP bound agentically (starting from a high value and lowering until the smallest passing bound), and confirmed determinism by running the suite twice at the final bound.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, run as an unattended scheduled task on behalf of the repository maintainer, following the exact idiom established by prior merged PRs addressing #11352 (`isAlmostSameValue` assertions, tightest-passing bound found by lowering from a high starting value and confirmed deterministic across two runs).

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZCk2TWSuBNs9r9uiT5tGS


---
_Generated by [Claude Code](https://claude.ai/code/session_01FZCk2TWSuBNs9r9uiT5tGS)_