### PR TITLE
test: migrate `stats/incr/mda` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/mda/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/mda/test/test.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var incrmda = require( './../lib' );
 
 
@@ -48,10 +47,8 @@ tape( 'the initial accumulated value is `null`', function test( t ) {
 tape( 'the accumulator function incrementally computes the mean directional accuracy', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
 	var acc;
-	var tol;
 	var N;
 	var i;
 
@@ -77,13 +74,7 @@ tape( 'the accumulator function incrementally computes the mean directional accu
 	acc = incrmda();
 	for ( i = 0; i < N; i++ ) {
 		actual = acc( data[ i ][ 0 ], data[ i ][ 1 ] );
-		if ( actual === expected[ i ] ) {
-			t.strictEqual( actual, expected[ i ], 'returns expected value' );
-		} else {
-			delta = abs( expected[ i ] - actual );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+actual+'. Expected: '+expected[ i ]+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/incr/mda` from relative tolerance testing to ULP difference testing.

Specifically, in `test/test.js`, the `abs`/`EPS` relative tolerance branch

```javascript
if ( actual === expected[ i ] ) {
    t.strictEqual( actual, expected[ i ], 'returns expected value' );
} else {
    delta = abs( expected[ i ] - actual );
    tol = 1.0 * EPS * abs( expected[ i ] );
    t.strictEqual( delta <= tol, true, 'within tolerance. ...' );
}
```

is replaced by

```javascript
t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
```

along with the corresponding `require` and unused local variable (`delta`, `tol`) removals.

**ULP bound: `1`.** This is the measured minimum. The maximum observed ULP difference across the test's data set is `1` (a single `2/3` accumulation step differs by 1 ULP; every other step is bit-exact), so the suite passes at `1` and fails at `0`. The suite was run twice at the final bound to confirm determinism.

Notes:

-   The package has no `test/test.native.js`, so `test/test.js` is the only file changed.
-   Exact assertions elsewhere in the file (e.g. `t.strictEqual( acc(), 2.0/3.0, ... )`) were left untouched.

Verification:

-   `make test TESTS_FILTER=".*/stats/incr/mda/.*"` — 11/11 passing (run twice).
-   `make eslint-tests TESTS_FILTER=".*/stats/incr/mda/.*"` — clean.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The change mirrors the idiom used in the sibling package `stats/incr/nanmda` (#15138).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running unattended as a scheduled task. It reviewed prior converted packages to match the established idiom, applied the conversion, and empirically determined the minimum passing ULP bound by measuring the ULP difference across the test data and confirming the suite fails at `0` and passes deterministically at `1`.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7gA3mBMiAE2XWGgsUwvab

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7gA3mBMiAE2XWGgsUwvab)_