### PR TITLE
style: add missing spaces

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.factory.js
@@ -135,8 +135,8 @@ tape( 'the created function evaluates the pdf for `x` given parameter `lambda` (
 	x = smallSmall.x;
 	lambda = smallSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
-		pdf = factory( lambda[i] );
-		y = pdf( x[i] );
+		pdf = factory( lambda[ i ] );
+		y = pdf( x[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -154,8 +154,8 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	x = largeSmall.x;
 	lambda = largeSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
-		pdf = factory( lambda[i] );
-		y = pdf( x[i] );
+		pdf = factory( lambda[ i ] );
+		y = pdf( x[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 12 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -173,8 +173,8 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	x = smallLarge.x;
 	lambda = smallLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
-		pdf = factory( lambda[i] );
-		y = pdf( x[i] );
+		pdf = factory( lambda[ i ] );
+		y = pdf( x[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -192,8 +192,8 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	x = largeLarge.x;
 	lambda = largeLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
-		pdf = factory( lambda[i] );
-		y = pdf( x[i] );
+		pdf = factory( lambda[ i ] );
+		y = pdf( x[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.factory.js
@@ -137,7 +137,7 @@ tape( 'the created function evaluates the pdf for `x` given parameter `lambda` (
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( lambda[i] );
 		y = pdf( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 2 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -156,7 +156,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( lambda[i] );
 		y = pdf( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 12 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 12 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -175,7 +175,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( lambda[i] );
 		y = pdf( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 2 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -194,7 +194,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( lambda[i] );
 		y = pdf( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.native.js
@@ -110,7 +110,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	lambda = smallSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], lambda[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 2 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -127,7 +127,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	lambda = largeSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], lambda[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 12 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 12 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -144,7 +144,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	lambda = smallLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], lambda[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 2 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -161,7 +161,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	lambda = largeLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], lambda[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.native.js
@@ -109,7 +109,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	x = smallSmall.x;
 	lambda = smallSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], lambda[i] );
+		y = pdf( x[ i ], lambda[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -126,7 +126,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	x = largeSmall.x;
 	lambda = largeSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], lambda[i] );
+		y = pdf( x[ i ], lambda[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 12 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -143,7 +143,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	x = smallLarge.x;
 	lambda = smallLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], lambda[i] );
+		y = pdf( x[ i ], lambda[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -160,7 +160,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	x = largeLarge.x;
 	lambda = largeLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], lambda[i] );
+		y = pdf( x[ i ], lambda[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.pdf.js
@@ -109,7 +109,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	lambda = smallSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], lambda[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 2 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -126,7 +126,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	lambda = largeSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], lambda[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 12 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 12 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -143,7 +143,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	lambda = smallLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], lambda[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 2 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -160,7 +160,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	lambda = largeLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], lambda[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/test/test.pdf.js
@@ -108,7 +108,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	x = smallSmall.x;
 	lambda = smallSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], lambda[i] );
+		y = pdf( x[ i ], lambda[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -125,7 +125,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	x = largeSmall.x;
 	lambda = largeSmall.lambda;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], lambda[i] );
+		y = pdf( x[ i ], lambda[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 12 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -142,7 +142,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	x = smallLarge.x;
 	lambda = smallLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], lambda[i] );
+		y = pdf( x[ i ], lambda[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -159,7 +159,7 @@ tape( 'the function evaluates the pdf for `x` given parameter `lambda` (when `x`
 	x = largeLarge.x;
 	lambda = largeLarge.lambda;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], lambda[i] );
+		y = pdf( x[ i ], lambda[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/t/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/cdf/test/test.cdf.js
@@ -94,7 +94,7 @@ tape( 'the function evaluates the cdf for `x` given parameter `v` (when `x` and 
 	v = smallSmall.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], v[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 13 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 13 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -111,7 +111,7 @@ tape( 'the function evaluates the cdf for `x` given parameter `v` (when `x` is l
 	v = largeSmall.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], v[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 11 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 11 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -128,7 +128,7 @@ tape( 'the function evaluates the cdf for `x` given parameter `v` (when `x` is s
 	v = smallLarge.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], v[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 15 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 15 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -145,7 +145,7 @@ tape( 'the function evaluates the cdf for `x` given parameter `v` (when `x` and 
 	v = largeLarge.v;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], v[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 32 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 32 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/t/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/cdf/test/test.cdf.js
@@ -93,7 +93,7 @@ tape( 'the function evaluates the cdf for `x` given parameter `v` (when `x` and 
 	x = smallSmall.x;
 	v = smallSmall.v;
 	for ( i = 0; i < x.length; i++ ) {
-		y = cdf( x[i], v[i] );
+		y = cdf( x[ i ], v[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 13 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -110,7 +110,7 @@ tape( 'the function evaluates the cdf for `x` given parameter `v` (when `x` is l
 	x = largeSmall.x;
 	v = largeSmall.v;
 	for ( i = 0; i < x.length; i++ ) {
-		y = cdf( x[i], v[i] );
+		y = cdf( x[ i ], v[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 11 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -127,7 +127,7 @@ tape( 'the function evaluates the cdf for `x` given parameter `v` (when `x` is s
 	x = smallLarge.x;
 	v = smallLarge.v;
 	for ( i = 0; i < x.length; i++ ) {
-		y = cdf( x[i], v[i] );
+		y = cdf( x[ i ], v[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 15 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -144,7 +144,7 @@ tape( 'the function evaluates the cdf for `x` given parameter `v` (when `x` and 
 	x = largeLarge.x;
 	v = largeLarge.v;
 	for ( i = 0; i < x.length; i++ ) {
-		y = cdf( x[i], v[i] );
+		y = cdf( x[ i ], v[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 32 ), true, 'returns expected value' );
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/t/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/cdf/test/test.factory.js
@@ -138,8 +138,8 @@ tape( 'the created function evaluates the cdf for `x` given parameter `v` (when 
 	x = smallSmall.x;
 	v = smallSmall.v;
 	for ( i = 0; i < x.length; i++ ) {
-		cdf = factory( v[i] );
-		y = cdf( x[i] );
+		cdf = factory( v[ i ] );
+		y = cdf( x[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 13 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -157,8 +157,8 @@ tape( 'the function evaluates the cdf for `x` given parameter `v` (when `x` is l
 	x = largeSmall.x;
 	v = largeSmall.v;
 	for ( i = 0; i < x.length; i++ ) {
-		cdf = factory( v[i] );
-		y = cdf( x[i] );
+		cdf = factory( v[ i ] );
+		y = cdf( x[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 11 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -176,8 +176,8 @@ tape( 'the function evaluates the cdf for `x` given parameter `v` (when `x` is s
 	x = smallLarge.x;
 	v = smallLarge.v;
 	for ( i = 0; i < x.length; i++ ) {
-		cdf = factory( v[i] );
-		y = cdf( x[i] );
+		cdf = factory( v[ i ] );
+		y = cdf( x[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 15 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -195,8 +195,8 @@ tape( 'the function evaluates the cdf for `x` given parameter `v` (when `x` and 
 	x = largeLarge.x;
 	v = largeLarge.v;
 	for ( i = 0; i < x.length; i++ ) {
-		cdf = factory( v[i] );
-		y = cdf( x[i] );
+		cdf = factory( v[ i ] );
+		y = cdf( x[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 32 ), true, 'returns expected value' );
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/t/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/cdf/test/test.factory.js
@@ -140,7 +140,7 @@ tape( 'the created function evaluates the cdf for `x` given parameter `v` (when 
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( v[i] );
 		y = cdf( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 13 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 13 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -159,7 +159,7 @@ tape( 'the function evaluates the cdf for `x` given parameter `v` (when `x` is l
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( v[i] );
 		y = cdf( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 11 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 11 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -178,7 +178,7 @@ tape( 'the function evaluates the cdf for `x` given parameter `v` (when `x` is s
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( v[i] );
 		y = cdf( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 15 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 15 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -197,7 +197,7 @@ tape( 'the function evaluates the cdf for `x` given parameter `v` (when `x` and 
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( v[i] );
 		y = cdf( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 32 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 32 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 6d0ed9ae (2026-09-09 21:35 PT) and d083c3ff (2026-09-09 21:56 PT).

This pull request:

-   Fixes spacing in the 12 `isAlmostSameValue` calls added in cd8ce6ea (`stats/base/dists/exponential/pdf` ULP migration): `expected[i]` → `expected[ i ]` per style guide, across `test.factory.js`, `test.native.js`, and `test.pdf.js`.
-   Fixes spacing in the 8 `isAlmostSameValue` calls added in f9a255c1 (`stats/base/dists/t/cdf` ULP migration): `expected[i]` → `expected[ i ]` per style guide, across `test.cdf.js` and `test.factory.js`; brings the new lines in line with the stdlib style guide.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** All 13 commits merged to `develop` in the window were reviewed by two independent style-compliance passes (checked against `docs/style-guides` and against untouched reference packages already using `isAlmostSameValue`) and two independent bug-scan passes (argument order of `isAlmostSameValue`, dangling references after removed `abs`/`EPS`/`delta`/`tol` declarations, ULP tolerance equivalence vs the removed `N * EPS` tolerances, seed validity of `opts.seed = i + 1` in the `random/base/*` benchmarks, `format()` placeholder pairing). No runtime bugs were found; the only surviving high-signal findings are the 20 bracket-spacing violations fixed here.

**Deliberately excluded** (interpretation-dependent, not unambiguous violations): `require` ordering of `isAlmostSameValue` relative to `isnan` (existing files are split on this), and pre-existing unspaced indices on neighboring lines outside the reviewed diff.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated review of commits recently merged to `develop`; findings were cross-validated by multiple independent review passes before fixes were applied.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQnmnkmZwDWFCTdWtMaJri

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQnmnkmZwDWFCTdWtMaJri)_