### PR TITLE
test: migrate `stats/ttest` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/ttest/test/test.js
+++ b/lib/node_modules/@stdlib/stats/ttest/test/test.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var contains = require( '@stdlib/assert/contains' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var ttest = require( './../lib' );
 
 
@@ -201,8 +200,6 @@ tape( 'the function throws an error if the `alpha` option is a numeric value out
 
 tape( 'the function correctly computes a one-sample two-sided t-test', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var out;
 	var x;
 
@@ -211,33 +208,23 @@ tape( 'the function correctly computes a one-sample two-sided t-test', function 
 
 	// Tested against R:
 	expected = twosided.pValue;
-	delta = abs( out.pValue - expected );
-	tol = 16.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. p-value: '+out.pValue+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.pValue, expected, 10 ), true, 'returns expected value' );
 
 	expected = twosided.statistic;
-	delta = abs( out.statistic - expected );
-	tol = 30.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. test statistic: '+out.statistic+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.statistic, expected, 1 ), true, 'returns expected value' );
 
 	expected = twosided.lower;
-	delta = abs( out.ci[0] - expected );
-	tol = 16.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. CI lower bound: '+out.ci[0]+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.ci[0], expected, 24 ), true, 'returns expected value' );
 
 	expected = twosided.upper;
-	delta = abs( out.ci[1] - expected );
-	tol = 16.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. CI upper bound: '+out.ci[1]+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.ci[1], expected, 0 ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function correctly computes a one-sample one-sided t-test', function test( t ) {
 	var expected;
-	var delta;
 	var out;
-	var tol;
 	var x;
 
 	// Alternative: mu > 0.0
@@ -248,19 +235,13 @@ tape( 'the function correctly computes a one-sample one-sided t-test', function 
 
 	// Tested against R:
 	expected = greater.pValue;
-	delta = abs( out.pValue - expected );
-	tol = 40.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. alternative: greater. p-value: '+out.pValue+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.pValue, expected, 2 ), true, 'returns expected value' );
 
 	expected = greater.statistic;
-	delta = abs( out.statistic - expected );
-	tol = 20.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. alternative: greater. statistic: '+out.statistic+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.statistic, expected, 1 ), true, 'returns expected value' );
 
 	expected = greater.lower;
-	delta = abs( out.ci[0] - expected );
-	tol = 20.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. alternative: greater. CI lower bound: '+out.ci[0]+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.ci[0], expected, 2 ), true, 'returns expected value' );
 
 	t.strictEqual( out.ci[1], PINF, 'CI upper bound is +infinity' );
 
@@ -272,30 +253,22 @@ tape( 'the function correctly computes a one-sample one-sided t-test', function 
 
 	// Tested against R:
 	expected = less.pValue;
-	delta = abs( out.pValue - expected );
-	tol = 10.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. alternative: less. p-value: '+out.pValue+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.pValue, expected, 8 ), true, 'returns expected value' );
 
 	expected = less.statistic;
-	delta = abs( out.statistic - expected );
-	tol = 30.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. alternative: less. statistic: '+out.statistic+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.statistic, expected, 1 ), true, 'returns expected value' );
 
 	t.strictEqual( out.ci[0], NINF, 'CI lower bound is -infinity' );
 
 	expected = less.upper;
-	delta = abs( out.ci[1] - expected );
-	tol = 16.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. alternative: less. CI upper bound: '+out.ci[1]+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.ci[1], expected, 4 ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function correctly computes a one-sample two-sided t-test with a custom significance level', function test( t ) {
 	var expected;
-	var delta;
 	var out;
-	var tol;
 	var x;
 
 	x = twosidedCustomAlpha.x;
@@ -305,33 +278,23 @@ tape( 'the function correctly computes a one-sample two-sided t-test with a cust
 
 	// Tested against R:
 	expected = twosidedCustomAlpha.pValue;
-	delta = abs( out.pValue - expected );
-	tol = 50.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. p-value: '+out.pValue+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.pValue, expected, 36 ), true, 'returns expected value' );
 
 	expected = twosidedCustomAlpha.statistic;
-	delta = abs( out.statistic - expected );
-	tol = 50.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. test statistic: '+out.statistic+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.statistic, expected, 1 ), true, 'returns expected value' );
 
 	expected = twosidedCustomAlpha.lower;
-	delta = abs( out.ci[0] - expected );
-	tol = 12.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. CI lower bound: '+out.ci[0]+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.ci[0], expected, 3 ), true, 'returns expected value' );
 
 	expected = twosidedCustomAlpha.upper;
-	delta = abs( out.ci[1] - expected );
-	tol = 8.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. CI upper bound: '+out.ci[1]+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.ci[1], expected, 1 ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function correctly computes a one-sample one-sided t-test with a custom significance level', function test( t ) {
 	var expected;
-	var delta;
 	var out;
-	var tol;
 	var x;
 
 	x = greaterCustomAlpha.x;
@@ -344,19 +307,13 @@ tape( 'the function correctly computes a one-sample one-sided t-test with a cust
 
 	// Tested against R:
 	expected = greaterCustomAlpha.pValue;
-	delta = abs( out.pValue - expected );
-	tol = 20.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. p-value: '+out.pValue+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.pValue, expected, 3 ), true, 'returns expected value' );
 
 	expected = greaterCustomAlpha.statistic;
-	delta = abs( out.statistic - expected );
-	tol = 35.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. statistic: '+out.statistic+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.statistic, expected, 11 ), true, 'returns expected value' );
 
 	expected = greaterCustomAlpha.lower;
-	delta = abs( out.ci[0] - expected );
-	tol = 20.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. CI lower bound: '+out.ci[0]+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.ci[0], expected, 24 ), true, 'returns expected value' );
 
 	t.strictEqual( out.ci[1], PINF, 'CI upper bound is +infinity' );
 
@@ -369,30 +326,22 @@ tape( 'the function correctly computes a one-sample one-sided t-test with a cust
 
 	// Tested against R:
 	expected = lessCustomAlpha.pValue;
-	delta = abs( out.pValue - expected );
-	tol = 20.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. p-value: '+out.pValue+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.pValue, expected, 2 ), true, 'returns expected value' );
 
 	expected = lessCustomAlpha.statistic;
-	delta = abs( out.statistic - expected );
-	tol = 32.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. statistic: '+out.statistic+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.statistic, expected, 4 ), true, 'returns expected value' );
 
 	t.strictEqual( out.ci[0], NINF, 'CI lower bound is -infinity' );
 
 	expected = lessCustomAlpha.upper;
-	delta = abs( out.ci[1] - expected );
-	tol = 6.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. CI upper bound: '+out.ci[1]+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.ci[1], expected, 1 ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function correctly computes a paired t-test', function test( t ) {
 	var expected;
-	var delta;
 	var out;
-	var tol;
 	var x;
 	var y;
 
@@ -402,33 +351,23 @@ tape( 'the function correctly computes a paired t-test', function test( t ) {
 
 	// Tested against R:
 	expected = paired.pValue;
-	delta = abs( out.pValue - expected );
-	tol = 24.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. p-value: '+out.pValue+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.pValue, expected, 4 ), true, 'returns expected value' );
 
 	expected = paired.statistic;
-	delta = abs( out.statistic - expected );
-	tol = 32.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. test statistic: '+out.statistic+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.statistic, expected, 4 ), true, 'returns expected value' );
 
 	expected = paired.lower;
-	delta = abs( out.ci[0] - expected );
-	tol = 8.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. CI lower bound: '+out.ci[0]+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.ci[0], expected, 3 ), true, 'returns expected value' );
 
 	expected = paired.upper;
-	delta = abs( out.ci[1] - expected );
-	tol = 11.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. CI upper bound: '+out.ci[1]+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.ci[1], expected, 2 ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function correctly computes a paired one-sided t-test', function test( t ) {
 	var expected;
-	var delta;
 	var out;
-	var tol;
 	var x;
 	var y;
 
@@ -440,21 +379,15 @@ tape( 'the function correctly computes a paired one-sided t-test', function test
 
 	// Tested against R:
 	expected = pairedLess.pValue;
-	delta = abs( out.pValue - expected );
-	tol = 35.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. p-value: '+out.pValue+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.pValue, expected, 12 ), true, 'returns expected value' );
 
 	expected = pairedLess.statistic;
-	delta = abs( out.statistic - expected );
-	tol = 16.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. statistic: '+out.statistic+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.statistic, expected, 0 ), true, 'returns expected value' );
 
 	t.strictEqual( out.ci[0], NINF, 'CI lower bound is -infinity' );
 
 	expected = pairedLess.upper;
-	delta = abs( out.ci[1] - expected );
-	tol = 20.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. CI upper bound: '+out.ci[1]+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.ci[1], expected, 0 ), true, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/ttest` from relative tolerance testing to ULP difference testing.

Specifically, in `test/test.js`, each of the 27 relative tolerance assertions of the form

```javascript
expected = twosided.pValue;
delta = abs( out.pValue - expected );
tol = 16.0 * EPS * abs( expected );
t.ok( delta <= tol, 'within tolerance. p-value: '+out.pValue+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
```

is replaced by

```javascript
expected = twosided.pValue;
t.strictEqual( isAlmostSameValue( out.pValue, expected, 10 ), true, 'returns expected value' );
```

along with the corresponding `require` changes (`@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` dropped in favor of `@stdlib/assert/is-almost-same-value`) and the removal of the now-unused `delta`/`tol` locals.

**ULP bounds (all measured minimums).** Because each assertion compares a distinct output quantity against its own R-derived fixture value, the bounds are per-assertion rather than a single package-wide constant:

| Test case | Quantity | ULP |
| --- | --- | --- |
| one-sample, two-sided | `pValue` | 10 |
| | `statistic` | 1 |
| | `ci[0]` | 24 |
| | `ci[1]` | 0 |
| one-sample, `alternative: 'greater'` | `pValue` | 2 |
| | `statistic` | 1 |
| | `ci[0]` | 2 |
| one-sample, `alternative: 'less'` | `pValue` | 8 |
| | `statistic` | 1 |
| | `ci[1]` | 4 |
| one-sample, two-sided, `alpha: 0.1` | `pValue` | 36 |
| | `statistic` | 1 |
| | `ci[0]` | 3 |
| | `ci[1]` | 1 |
| one-sample, `alternative: 'greater'`, `alpha: 0.1` | `pValue` | 3 |
| | `statistic` | 11 |
| | `ci[0]` | 24 |
| one-sample, `alternative: 'less'`, `alpha: 0.01` | `pValue` | 2 |
| | `statistic` | 4 |
| | `ci[1]` | 1 |
| paired, two-sided | `pValue` | 4 |
| | `statistic` | 4 |
| | `ci[0]` | 3 |
| | `ci[1]` | 2 |
| paired, `alternative: 'less'` | `pValue` | 12 |
| | `statistic` | 0 |
| | `ci[1]` | 0 |

Each bound was determined empirically by computing, for every `(actual, expected)` pair, the smallest integer `N` for which `isAlmostSameValue( actual, expected, N )` returns `true`. Every bound in the table was additionally confirmed to **fail** at `N-1`, so none can be tightened further. Three comparisons are bit-exact and therefore use `0`. The suite was run twice at the final bounds to confirm determinism.

The largest bounds (`36` for the `alpha: 0.1` two-sided p-value, `24` for two of the confidence interval endpoints) correspond to the pre-existing loosest relative tolerances in the file (`50.0 * EPS` and `16.0`/`20.0 * EPS` respectively); these are quantities computed via `t/cdf` and `t/quantile` near the tails, where the accumulated error is largest.

Notes:

-   The package has no `test/test.native.js`, so `test/test.js` is the only file changed.
-   Exact assertions elsewhere in the file (e.g. `t.strictEqual( out.ci[1], PINF, ... )`, the `.print()` and argument-validation tests) were left untouched.
-   `test/test.validate.js` contains no relative tolerance assertions and is unchanged.

Verification:

-   `make test TESTS_FILTER=".*/stats/ttest/.*"` — 103/103 and 45/45 passing (run twice, identical results).
-   `make eslint-tests TESTS_FILTER=".*/stats/ttest/.*"` — clean.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The change mirrors the idiom established in previously converted packages, e.g. `stats/incr/mskewness` (`6298f5ea5`) and `stats/base/dists/exponential/pdf` (`cd8ce6eaf`).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running unattended as a scheduled task. It reviewed prior converted packages to match the established idiom, applied the conversion, and empirically determined the minimum passing ULP bound for each assertion by measuring the ULP difference against the R fixtures, confirming each bound fails at `N-1`, and re-running the suite to confirm determinism.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhSYciweAtKct6rtG9DpZ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhSYciweAtKct6rtG9DpZ2)_