### PR TITLE
build: cap xargs batch size in `run_affected_tests`

### DIFF
--- a/.github/workflows/scripts/run_affected_tests/run
+++ b/.github/workflows/scripts/run_affected_tests/run
@@ -168,8 +168,8 @@ main() {
 	files=$(echo "${files}" | grep -v '/fixtures/') || true
 
 	if [[ -n "${files}" ]]; then
-		# Invoke make in batches to avoid "Argument list too long" errors:
-		printf '%s\n' ${files} | xargs sh -c 'make test-javascript-files-min FILES="$*"' _
+		# Invoke make in batches, capped well under the 128KiB Linux single-argument limit, as `make` re-expands each batch into one `FILES="$*"` recipe string:
+		printf '%s\n' ${files} | xargs -s 40000 sh -c 'make test-javascript-files-min FILES="$*"' _
 	fi
 
 	cleanup

--- a/.github/workflows/scripts/run_affected_tests/run
+++ b/.github/workflows/scripts/run_affected_tests/run
@@ -168,7 +168,7 @@ main() {
 	files=$(echo "${files}" | grep -v '/fixtures/') || true
 
 	if [[ -n "${files}" ]]; then
-		# Invoke make in batches, capped well under the 128KiB Linux single-argument limit, as `make` re-expands each batch into one `FILES="$*"` recipe string:
+		# Invoke make in batches, capped well under the 128KiB Linux single-argument limit, in order to avoid "Argument list too long" errors:
 		printf '%s\n' ${files} | xargs -s 40000 sh -c 'make test-javascript-files-min FILES="$*"' _
 	fi
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   caps the `xargs` batch size in `.github/workflows/scripts/run_affected_tests/run` to prevent `make: bash: Argument list too long` failures on commits with a large affected-file fan-out.

Failing run: https://github.com/stdlib-js/stdlib/actions/runs/34439117284

Symptom: `run_affected_tests` failed on `develop` after a commit touched 38 `random/base/*` packages at once (#15130), producing `make: bash: Argument list too long` / `Error 127` in `test-javascript-files-min`, then exiting 123.

Root cause: `xargs`'s default batching only bounds its own `sh -c` invocation against the ~2MB aggregate `ARG_MAX`. It does not know that `make` re-expands the whole batch into a single `FILES="$*"` string inside a `for test in $(FILES)` recipe, exec'd as one argv element subject to Linux's tighter 128KiB `MAX_ARG_STRLEN`. On the actual affected-file corpus for that commit, the default batch produced a 131,016-byte `FILES` string against a 131,072-byte ceiling — no room left for the recipe's own boilerplate.

Fix: add `-s 40000` to force smaller `xargs` batches, keeping every reconstructed `FILES` string well under the single-argument limit. Typical PRs are unaffected (one small batch, byte-identical before and after); only the small set of commits with a very wide reverse-dependency fan-out change behavior, and now succeed instead of crashing.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Two related items intentionally left out of scope:

-   `.github/workflows/scripts/run_affected_benchmarks/run` (lines 145, 177) has the identical unpatched pattern for `benchmark-javascript-files` / `benchmark-c-files`. Same latent bug, separate script, separate fix.
-   A commit with a wide enough fan-out (thousands of affected test files) could still hit the job's 30-minute timeout once the crash is fixed and the tests actually run. Batching fixes the crash; wall-clock is a separate, unrelated failure mode.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, triaging a CI failure on `develop` and validated by three independent automated reviewers (correctness, regression scope, style/conventions) before being opened.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018anXwSR9QPNycoSC2HzpuX

---
_Generated by [Claude Code](https://claude.ai/code/session_018anXwSR9QPNycoSC2HzpuX)_