### PR TITLE
test: migrate `stats/incr/mmape` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/mmape/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/mmape/test/test.js
@@ -21,9 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var incrmmape = require( './../lib' );
 
 
@@ -73,10 +73,8 @@ tape( 'the function returns an accumulator function', function test( t ) {
 tape( 'the accumulator function computes a moving mean absolute percentage error incrementally', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
 	var acc;
-	var tol;
 	var N;
 	var i;
 
@@ -103,13 +101,7 @@ tape( 'the accumulator function computes a moving mean absolute percentage error
 	];
 	for ( i = 0; i < N; i++ ) {
 		actual = acc( data[i][0], data[i][1] );
-		if ( actual === expected[i] ) {
-			t.strictEqual( actual, expected[i], 'returns expected value' );
-		} else {
-			delta = abs( expected[i] - actual );
-			tol = 1.5 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+actual+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/incr/mmape` from relative tolerance testing to ULP difference testing.

Specifically, in `test/test.js`, the `abs`/`EPS` relative tolerance branch

```javascript
if ( actual === expected[i] ) {
    t.strictEqual( actual, expected[i], 'returns expected value' );
} else {
    delta = abs( expected[i] - actual );
    tol = 1.5 * EPS * abs( expected[i] );
    t.strictEqual( delta <= tol, true, 'within tolerance. ...' );
}
```

is replaced by

```javascript
t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );
```

along with the corresponding `require` and unused local variable (`delta`, `tol`) removals. The `abs` require is retained, as `abs` is still used when computing the expected values.

**ULP bound: `2`.** This is the measured minimum. Starting from `64` and tightening, the suite passes at `64`, `4`, and `2`, and fails at `1`. The maximum observed ULP difference across the test's data set is `2` (the final windowed accumulation step, `30.000000000000007` vs. `30`, differs by 2 ULP; every other step is bit-exact). The suite was run twice at the final bound to confirm determinism.

Notes:

-   The package has no `test/test.native.js`, so `test/test.js` is the only file changed.
-   Exact assertions elsewhere in the file (e.g. `t.strictEqual( acc(), 65.0, ... )` and the `NaN` window checks) were left untouched.

Verification:

-   `make test TESTS_FILTER=".*/stats/incr/mmape/.*"` — 98/98 passing (run twice).
-   `make lint-javascript-tests TESTS_FILTER=".*/stats/incr/mmape/.*"` — clean.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The change mirrors the idiom used in the sibling packages `stats/incr/nanmhmean`, `stats/incr/nanmda`, and `stats/incr/mskewness`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running unattended as a scheduled task. It reviewed prior converted packages to match the established idiom, applied the conversion, and empirically determined the minimum passing ULP bound by measuring the ULP difference across the test data and confirming the suite fails at `1` and passes deterministically at `2`.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7NocVPa8jUrjnEbk8HCEZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7NocVPa8jUrjnEbk8HCEZ)_