### PR TITLE
bench: add length benchmark to `buffer/reviver`

### DIFF
--- a/lib/node_modules/@stdlib/buffer/reviver/benchmark/benchmark.length.js
+++ b/lib/node_modules/@stdlib/buffer/reviver/benchmark/benchmark.length.js
@@ -23,6 +23,8 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isBuffer = require( '@stdlib/assert/is-buffer' );
+var zeros = require( '@stdlib/array/zeros' );
+var join = require( '@stdlib/array/base/join' );
 var parseJSON = require( '@stdlib/utils/parse-json' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -41,13 +43,10 @@ var reviver = require( './../lib' );
 function createBenchmark( len ) {
 	var data;
 	var str;
-	var i;
 
-	data = [];
-	for ( i = 0; i < len; i++ ) {
-		data.push( 0 );
-	}
-	str = '{"type":"Buffer","data":[' + data.join( ',' ) + ']}';
+	data = zeros( len, 'generic' );
+	str = '{"type":"Buffer","data":[' + join( data, ',' ) + ']}';
+
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/buffer/reviver/benchmark/benchmark.length.js
+++ b/lib/node_modules/@stdlib/buffer/reviver/benchmark/benchmark.length.js
@@ -1,0 +1,104 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isBuffer = require( '@stdlib/assert/is-buffer' );
+var parseJSON = require( '@stdlib/utils/parse-json' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var reviver = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - buffer length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var data;
+	var str;
+	var i;
+
+	data = [];
+	for ( i = 0; i < len; i++ ) {
+		data.push( 0 );
+	}
+	str = '{"type":"Buffer","data":[' + data.join( ',' ) + ']}';
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var out;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			out = parseJSON( str, reviver );
+			if ( out.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isBuffer( out ) ) {
+			b.fail( 'should return a Buffer' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:len=%d', pkg, len ), f );
+	}
+}
+
+main();


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request adds a missing length-scaling benchmark to `@stdlib/buffer/reviver`, restoring parity with the rest of the `buffer` namespace.

**Namespace summary.** The `buffer` namespace has 8 non-generated members: `alloc-unsafe`, `ctor`, `from-array`, `from-arraybuffer`, `from-buffer`, `from-string`, `reviver`, and `to-json`. Structural features (file tree, `package.json`/`manifest` shape, README section list, and test/benchmark/example file naming) and semantic features (public signature, validation prologue, error construction, return kind, JSDoc shape, and source dependencies) were extracted per package and compared against a 75% majority threshold (≥6/8). Features with a clear majority: the standard file tree, the `package.json` key set (8/8), `benchmark/benchmark.js` (8/8), `benchmark/benchmark.length.js` (7/8), `format`-based error construction among the packages that throw (6/6), `value` return kind (8/8), and `@example` presence (8/8). Features without a clear majority (excluded from correction): README section ordering (package-specific `Notes`/`Properties`/`Methods` blocks), public signature and validation prologue (genuinely per-function), and `lib/polyfill.js`/`test/test.polyfill.js` presence (6/8 — only packages wrapping native `Buffer` APIs carry a polyfill).

The sole surviving, high-signal drift correction targets one outlier package.

### `@stdlib/buffer/reviver`

Adds `benchmark/benchmark.length.js` to `@stdlib/buffer/reviver`, the only member of the `buffer` namespace lacking one (present in 7/8, 87.5%). The reviver's cost scales with the `data` array it hands to `@stdlib/buffer/from-array`, so the benchmark parses `{"type":"Buffer","data":[...]}` JSON via the reviver across lengths 10^1 through 10^6, using the same `createBenchmark(len)` factory as the sibling `to-json` benchmark. No changes to source, public API, tests, or examples.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Structural features were extracted directly from the filesystem; semantic features were extracted with one agent per package. The candidate correction passed a three-agent drift validation — semantic review of applicability, cross-reference of tests/examples and documented contracts, and structural review of the majority pattern — with all three confirming the missing `benchmark.length.js` as unintentional drift rather than a justified deviation. The revive path was verified locally: reviving a length-`n` `data` array yields a `Buffer` of length `n`.

Deliberately excluded from this PR:

-   Absence of `lib/polyfill.js` / `test/test.polyfill.js` in `reviver` and `to-json` — intentional, as these pure-JS packages wrap no native `Buffer` API to polyfill.
-   The `errorConstruction` deviation in `ctor` and `reviver` — both throw no errors, so there is nothing to normalize to `format`.
-   All features without a clear 75% majority (README section order, per-function signatures, and validation prologues).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This PR was authored by Claude Code (Claude Opus 4.8) running an automated cross-package drift-detection routine over the `buffer` namespace. The routine extracted structural and semantic features per package, computed per-feature majority patterns, validated the single surviving outlier through multiple review agents, and generated the new benchmark file from the established sibling scaffold. The benchmark's correctness was verified locally before committing.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dMN9GA3gkkmq4yzQdBKh4

---
_Generated by [Claude Code](https://claude.ai/code/session_018dMN9GA3gkkmq4yzQdBKh4)_