### PR TITLE
test: migrate `blas/base/drotg` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/drotg/test/test.assign.js
+++ b/lib/node_modules/@stdlib/blas/base/drotg/test/test.assign.js
@@ -43,13 +43,11 @@ tape( 'the function has an arity of 5', function test( t ) {
 tape( 'the function computes a Givens plane rotation', function test( t ) {
 	var expected;
 	var values;
-	var ULP;
 	var out;
 	var e;
 	var i;
 	var j;
 
-	ULP = 2;
 	expected = [
 		[ 0.5, 1.0/0.6, 0.6, 0.8 ],
 		[ 0.5, 0.6, 0.8, 0.6 ],
@@ -76,7 +74,7 @@ tape( 'the function computes a Givens plane rotation', function test( t ) {
 		out = new Float64Array( 4 );
 		drotg( values[i][0], values[i][1], out, 1, 0 );
 		for ( j = 0; j < out.length; j++ ) {
-			t.strictEqual( isAlmostSameValue( out[j], e[j], ULP ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValue( out[j], e[j], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/blas/base/drotg/test/test.assign.js
+++ b/lib/node_modules/@stdlib/blas/base/drotg/test/test.assign.js
@@ -104,18 +104,16 @@ tape( 'the function returns an array of NaNs if provided a rotation elimination 
 tape( 'the function supports providing a positive stride', function test( t ) {
 	var expected;
 	var actual;
-	var ULP;
 	var out;
 	var i;
 
-	ULP = 2;
 	expected = new Float64Array( [ 0.5, 0.0, 1.0/0.6, 0.0, 0.6, 0.0, 0.8 ] );
 	out = new Float64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 
 	actual = drotg( 0.3, 0.4, out, 2, 0 );
 	t.strictEqual( actual, out, 'returns expected value' );
 	for ( i = 0; i < out.length; i++ ) {
-		t.strictEqual( isAlmostSameValue( out[i], expected[i], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( out[i], expected[i], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -123,18 +121,16 @@ tape( 'the function supports providing a positive stride', function test( t ) {
 tape( 'the function supports providing a negative stride', function test( t ) {
 	var expected;
 	var actual;
-	var ULP;
 	var out;
 	var i;
 
-	ULP = 2;
 	expected = new Float64Array( [ 0.8, 0.0, 0.6, 0.0, 1.0/0.6, 0.0, 0.5 ] );
 	out = new Float64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 
 	actual = drotg( 0.3, 0.4, out, -2, 6 );
 	t.strictEqual( actual, out, 'returns expected value' );
 	for ( i = 0; i < out.length; i++ ) {
-		t.strictEqual( isAlmostSameValue( out[i], expected[i], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( out[i], expected[i], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -142,18 +138,16 @@ tape( 'the function supports providing a negative stride', function test( t ) {
 tape( 'the function supports providing a positive offset', function test( t ) {
 	var expected;
 	var actual;
-	var ULP;
 	var out;
 	var i;
 
-	ULP = 2;
 	expected = new Float64Array( [ 0.0, 0.5, 1.0/0.6, 0.6, 0.8 ] );
 	out = new Float64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 
 	actual = drotg( 0.3, 0.4, out, 1, 1 );
 	t.strictEqual( actual, out, 'returns expected value' );
 	for ( i = 0; i < out.length; i++ ) {
-		t.strictEqual( isAlmostSameValue( out[i], expected[i], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( out[i], expected[i], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -161,18 +155,16 @@ tape( 'the function supports providing a positive offset', function test( t ) {
 tape( 'the function supports providing both a stride and offset', function test( t ) {
 	var expected;
 	var actual;
-	var ULP;
 	var out;
 	var i;
 
-	ULP = 2;
 	expected = new Float64Array( [ 0.0, 0.0, 0.5, 0.0, 1.0/0.6, 0.0, 0.6, 0.0, 0.8 ] ); // eslint-disable-line max-len
 	out = new Float64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 
 	actual = drotg( 0.3, 0.4, out, 2, 2 );
 	t.strictEqual( actual, out, 'returns expected value' );
 	for ( i = 0; i < out.length; i++ ) {
-		t.strictEqual( isAlmostSameValue( out[i], expected[i], ULP ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( out[i], expected[i], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/base/drotg/test/test.assign.js
+++ b/lib/node_modules/@stdlib/blas/base/drotg/test/test.assign.js
@@ -23,8 +23,7 @@
 var tape = require( 'tape' );
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var drotg = require( './../lib/assign.js' );
 
 
@@ -44,13 +43,13 @@ tape( 'the function has an arity of 5', function test( t ) {
 tape( 'the function computes a Givens plane rotation', function test( t ) {
 	var expected;
 	var values;
-	var delta;
-	var tol;
+	var ULP;
 	var out;
 	var e;
 	var i;
 	var j;
 
+	ULP = 2;
 	expected = [
 		[ 0.5, 1.0/0.6, 0.6, 0.8 ],
 		[ 0.5, 0.6, 0.8, 0.6 ],
@@ -77,13 +76,7 @@ tape( 'the function computes a Givens plane rotation', function test( t ) {
 		out = new Float64Array( 4 );
 		drotg( values[i][0], values[i][1], out, 1, 0 );
 		for ( j = 0; j < out.length; j++ ) {
-			if ( out[j] === e[j] ) {
-				t.strictEqual( out[j], e[j], 'returns expected value' );
-			} else {
-				delta = abs( out[j] - e[j] );
-				tol = 1.5 * EPS * abs( e[j] );
-				t.ok( delta <= tol, 'within tolerance. out: '+out[j]+'. expected: '+e[j]+'. delta: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( out[j], e[j], ULP ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -113,24 +106,18 @@ tape( 'the function returns an array of NaNs if provided a rotation elimination 
 tape( 'the function supports providing a positive stride', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
+	var ULP;
 	var out;
 	var i;
 
+	ULP = 2;
 	expected = new Float64Array( [ 0.5, 0.0, 1.0/0.6, 0.0, 0.6, 0.0, 0.8 ] );
 	out = new Float64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 
 	actual = drotg( 0.3, 0.4, out, 2, 0 );
 	t.strictEqual( actual, out, 'returns expected value' );
 	for ( i = 0; i < out.length; i++ ) {
-		if ( out[i] === expected[i] ) {
-			t.strictEqual( out[i], expected[i], 'returns expected value' );
-		} else {
-			delta = abs( out[i] - expected[i] );
-			tol = 1.5 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. out: '+out[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( out[i], expected[i], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -138,24 +125,18 @@ tape( 'the function supports providing a positive stride', function test( t ) {
 tape( 'the function supports providing a negative stride', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
+	var ULP;
 	var out;
 	var i;
 
+	ULP = 2;
 	expected = new Float64Array( [ 0.8, 0.0, 0.6, 0.0, 1.0/0.6, 0.0, 0.5 ] );
 	out = new Float64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 
 	actual = drotg( 0.3, 0.4, out, -2, 6 );
 	t.strictEqual( actual, out, 'returns expected value' );
 	for ( i = 0; i < out.length; i++ ) {
-		if ( out[i] === expected[i] ) {
-			t.strictEqual( out[i], expected[i], 'returns expected value' );
-		} else {
-			delta = abs( out[i] - expected[i] );
-			tol = 1.5 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. out: '+out[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( out[i], expected[i], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -163,24 +144,18 @@ tape( 'the function supports providing a negative stride', function test( t ) {
 tape( 'the function supports providing a positive offset', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
+	var ULP;
 	var out;
 	var i;
 
+	ULP = 2;
 	expected = new Float64Array( [ 0.0, 0.5, 1.0/0.6, 0.6, 0.8 ] );
 	out = new Float64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 
 	actual = drotg( 0.3, 0.4, out, 1, 1 );
 	t.strictEqual( actual, out, 'returns expected value' );
 	for ( i = 0; i < out.length; i++ ) {
-		if ( out[i] === expected[i] ) {
-			t.strictEqual( out[i], expected[i], 'returns expected value' );
-		} else {
-			delta = abs( out[i] - expected[i] );
-			tol = 1.5 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. out: '+out[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( out[i], expected[i], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -188,24 +163,18 @@ tape( 'the function supports providing a positive offset', function test( t ) {
 tape( 'the function supports providing both a stride and offset', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
+	var ULP;
 	var out;
 	var i;
 
+	ULP = 2;
 	expected = new Float64Array( [ 0.0, 0.0, 0.5, 0.0, 1.0/0.6, 0.0, 0.6, 0.0, 0.8 ] ); // eslint-disable-line max-len
 	out = new Float64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 
 	actual = drotg( 0.3, 0.4, out, 2, 2 );
 	t.strictEqual( actual, out, 'returns expected value' );
 	for ( i = 0; i < out.length; i++ ) {
-		if ( out[i] === expected[i] ) {
-			t.strictEqual( out[i], expected[i], 'returns expected value' );
-		} else {
-			delta = abs( out[i] - expected[i] );
-			tol = 1.5 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. out: '+out[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( out[i], expected[i], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/base/drotg/test/test.main.js
+++ b/lib/node_modules/@stdlib/blas/base/drotg/test/test.main.js
@@ -43,13 +43,11 @@ tape( 'the function has an arity of 2', function test( t ) {
 tape( 'the function computes a Givens plane rotation', function test( t ) {
 	var expected;
 	var values;
-	var ULP;
 	var out;
 	var i;
 	var j;
 	var e;
 
-	ULP = 2;
 	expected = [
 		[ 0.5, 1.0/0.6, 0.6, 0.8 ],
 		[ 0.5, 0.6, 0.8, 0.6 ],
@@ -75,7 +73,7 @@ tape( 'the function computes a Givens plane rotation', function test( t ) {
 		e = new Float64Array( expected[i] );
 		out = drotg( values[i][0], values[i][1] );
 		for ( j = 0; j < out.length; j++ ) {
-			t.strictEqual( isAlmostSameValue( out[j], e[j], ULP ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValue( out[j], e[j], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/blas/base/drotg/test/test.main.js
+++ b/lib/node_modules/@stdlib/blas/base/drotg/test/test.main.js
@@ -23,8 +23,7 @@
 var tape = require( 'tape' );
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var drotg = require( './../lib/main.js' );
 
 
@@ -44,13 +43,13 @@ tape( 'the function has an arity of 2', function test( t ) {
 tape( 'the function computes a Givens plane rotation', function test( t ) {
 	var expected;
 	var values;
-	var delta;
-	var tol;
+	var ULP;
 	var out;
 	var i;
 	var j;
 	var e;
 
+	ULP = 2;
 	expected = [
 		[ 0.5, 1.0/0.6, 0.6, 0.8 ],
 		[ 0.5, 0.6, 0.8, 0.6 ],
@@ -76,13 +75,7 @@ tape( 'the function computes a Givens plane rotation', function test( t ) {
 		e = new Float64Array( expected[i] );
 		out = drotg( values[i][0], values[i][1] );
 		for ( j = 0; j < out.length; j++ ) {
-			if ( out[j] === expected[j] ) {
-				t.strictEqual( out[j], e[j], 'returns expected value' );
-			} else {
-				delta = abs( out[j] - e[j] );
-				tol = 1.5 * EPS * abs( e[j] );
-				t.ok( delta <= tol, 'within tolerance. out: '+out[j]+'. expected: '+e[j]+'. delta: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( out[j], e[j], ULP ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the tests for `blas/base/drotg` from relative-tolerance (`EPS`-based) assertions to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per the RFC in #11352.
-   Replaces the `delta <= tol` (`tol = 1.5 * EPS * abs( expected )`) checks in `test/test.main.js` and `test/test.assign.js` with `t.strictEqual( isAlmostSameValue( actual, expected, ULP ), true, 'returns expected value' )`.
-   The minimum ULP bound was determined empirically by starting from a high value and lowering it until the full fixture set stopped passing, then re-running the suite twice at the final value to confirm determinism. The tightest bound for all affected assertions in both files is `ULP = 2`.
-   No other files were touched; `test/test.js` (which only requires the other two test files) already contained no tolerance-based assertions and needed no changes.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running as an automated, unattended agent on behalf of the repository owner. It searched the repository for a qualifying package, studied prior merged conversions (including the same author's own prior PRs, e.g. #15086) to mirror the established idiom, applied the mechanical tolerance-to-ULP conversion to `blas/base/drotg`, and empirically tightened the ULP bound by iterating `make test` locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJNEnc52kw6tpQnESbhW9k

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJNEnc52kw6tpQnESbhW9k)_