### PR TITLE
test: migrate `stats/base/dists/bradford/pdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/pdf/test/test.factory.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -106,9 +105,7 @@ tape( 'if provided a valid `c`, the function returns a function which returns `0
 
 tape( 'the created function evaluates the pdf for `x` given small `c`', function test( t ) {
 	var expected;
-	var delta;
 	var pdf;
-	var tol;
 	var c;
 	var i;
 	var x;
@@ -120,22 +117,14 @@ tape( 'the created function evaluates the pdf for `x` given small `c`', function
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( c[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the pdf for `x` given a medium `c`', function test( t ) {
 	var expected;
-	var delta;
 	var pdf;
-	var tol;
 	var c;
 	var i;
 	var x;
@@ -147,22 +136,14 @@ tape( 'the created function evaluates the pdf for `x` given a medium `c`', funct
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( c[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.9 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the pdf for `x` given a large `c`', function test( t ) {
 	var expected;
-	var delta;
 	var pdf;
-	var tol;
 	var c;
 	var i;
 	var x;
@@ -174,13 +155,7 @@ tape( 'the created function evaluates the pdf for `x` given a large `c`', functi
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( c[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/pdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -100,8 +99,6 @@ tape( 'if provided a number outside [0,1] for `x` and a valid `c`, the function 
 
 tape( 'the function evaluates the pdf for `x` given small parameter `c`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var c;
 	var y;
@@ -113,13 +110,7 @@ tape( 'the function evaluates the pdf for `x` given small parameter `c`', opts, 
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[i] );
-				tol = 2.2 * EPS * abs( expected[i] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -127,8 +118,6 @@ tape( 'the function evaluates the pdf for `x` given small parameter `c`', opts, 
 
 tape( 'the function evaluates the pdf for `x` given medium parameter `c`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var c;
 	var y;
@@ -140,13 +129,7 @@ tape( 'the function evaluates the pdf for `x` given medium parameter `c`', opts,
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[i] );
-				tol = 2.2 * EPS * abs( expected[i] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -154,8 +137,6 @@ tape( 'the function evaluates the pdf for `x` given medium parameter `c`', opts,
 
 tape( 'the function evaluates the pdf for `x` given large parameter `c`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var c;
 	var y;
@@ -167,13 +148,7 @@ tape( 'the function evaluates the pdf for `x` given large parameter `c`', opts, 
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[i] );
-				tol = 2.2 * EPS * abs( expected[i] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/pdf/test/test.pdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( './../lib' );
 
 
@@ -91,8 +90,6 @@ tape( 'if provided a number outside [0,1] for `x` and a valid `c`, the function 
 
 tape( 'the function evaluates the pdf for `x` given small parameter `c`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var c;
 	var y;
@@ -103,21 +100,13 @@ tape( 'the function evaluates the pdf for `x` given small parameter `c`', functi
 	c = smallC.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. c:'+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given medium parameter `c`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var c;
 	var y;
@@ -128,21 +117,13 @@ tape( 'the function evaluates the pdf for `x` given medium parameter `c`', funct
 	c = mediumC.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. c:'+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.9 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pdf for `x` given large parameter `c`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var c;
 	var y;
@@ -153,13 +134,7 @@ tape( 'the function evaluates the pdf for `x` given large parameter `c`', functi
 	c = largeC.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], c[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/bradford/pdf` from EPS-scaled relative tolerance comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from `test/test.pdf.js`, `test/test.factory.js`, and `test/test.native.js`.

Details:

-   **Package converted:** `stats/base/dists/bradford/pdf` (`test/test.pdf.js`, `test/test.factory.js`, and `test/test.native.js`; `test/test.js` contains no tolerance math and is unchanged).
-   **Final ULP constants,** one per fixture set, identical across all three test files:

    | fixture set | previous tolerance (JS / native) | final ULP bound |
    | ----------- | -------------------------------- | --------------- |
    | `small_c`   | `2.0 * EPS` / `2.2 * EPS`        | `3`             |
    | `medium_c`  | `1.9 * EPS` / `2.2 * EPS`        | `3`             |
    | `large_c`   | `2.0 * EPS` / `2.2 * EPS`        | `2`             |

-   **Measured minimum:** starting from a loose bound and tightening, the values above are the smallest integers under which the full 1000-value fixture set passes for each set. Lowering any of them by one produces 13 / 1 / 11 failures in `small_c` / `medium_c` / `large_c` respectively, in each test file, so none can be tightened further. Of the 1000 values per set, 534 / 590 / 624 respectively are already bit-for-bit exact.
-   **Determinism:** the suite was run twice at the final bounds, with the native add-on compiled locally so `test/test.native.js` actually executed rather than being skipped. Both runs: 3011 / 3013 / 3 / 3011 assertions across `test.pdf.js`, `test.factory.js`, `test.js`, and `test.native.js`, all passing.
-   Linting is clean for all three files under `etc/eslint/.eslintrc.tests.js`, and the only changed files are the three test files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves a part of #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The conversion mirrors the idiom already merged for the sibling package `stats/base/dists/bradford/cdf` (#14401): the fixture loop drops the exact-vs-tolerance branch entirely in favor of a single `t.strictEqual( isAlmostSameValue( y, expected[ i ], N ), true, 'returns expected value' );` assertion. The `expected[i] !== null` guard in `test/test.native.js` is left in place.

The same bounds apply to `test/test.native.js` because the JavaScript and C implementations return bit-identical results at every one of the 3000 fixture points, which was verified directly before choosing the bounds.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running unattended as a scheduled task, which selected the package, mirrored the conversion idiom from previously merged conversions, and empirically determined and verified the minimum ULP bounds.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2VCdns8cQeMxx8Q5uWRmm

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2VCdns8cQeMxx8Q5uWRmm)_