### PR TITLE
test: migrate `stats/strided/dsemch` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/dsemch/test/test.dsemch.js
+++ b/lib/node_modules/@stdlib/stats/strided/dsemch/test/test.dsemch.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var dsemch = require( './../lib/dsemch.js' );
 
 
@@ -44,8 +43,6 @@ tape( 'the function has an arity of 4', function test( t ) {
 
 tape( 'the function calculates the standard error of the mean for a strided array (population)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -53,9 +50,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsemch( x.length, 0, x, 1 );
 	expected = sqrt( 53.5/x.length ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsemch( x.length, 0, x, 1 );
@@ -70,8 +65,6 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 
 tape( 'the function calculates the standard error of the mean for a strided array (sample)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -79,9 +72,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsemch( x.length, 1, x, 1 );
 	expected = sqrt( 53.5/(x.length-1) ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsemch( x.length, 1, x, 1 );

--- a/lib/node_modules/@stdlib/stats/strided/dsemch/test/test.dsemch.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dsemch/test/test.dsemch.native.js
@@ -23,10 +23,9 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -53,8 +52,6 @@ tape( 'the function has an arity of 4', opts, function test( t ) {
 
 tape( 'the function calculates the standard error of the mean for a strided array (population)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -62,9 +59,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsemch( x.length, 0, x, 1 );
 	expected = sqrt( 53.5/x.length ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsemch( x.length, 0, x, 1 );
@@ -79,8 +74,6 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 
 tape( 'the function calculates the standard error of the mean for a strided array (sample)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -88,9 +81,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsemch( x.length, 1, x, 1 );
 	expected = sqrt( 53.5/(x.length-1) ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsemch( x.length, 1, x, 1 );

--- a/lib/node_modules/@stdlib/stats/strided/dsemch/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/dsemch/test/test.ndarray.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var dsemch = require( './../lib/ndarray.js' );
 
 
@@ -44,8 +43,6 @@ tape( 'the function has an arity of 5', function test( t ) {
 
 tape( 'the function calculates the standard error of the mean for a strided array (population)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -53,9 +50,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsemch( x.length, 0, x, 1, 0 );
 	expected = sqrt( 53.5/x.length ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsemch( x.length, 0, x, 1, 0 );
@@ -70,8 +65,6 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 
 tape( 'the function calculates the standard error of the mean for a strided array (sample)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -79,9 +72,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsemch( x.length, 1, x, 1, 0 );
 	expected = sqrt( 53.5/(x.length-1) ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsemch( x.length, 1, x, 1, 0 );

--- a/lib/node_modules/@stdlib/stats/strided/dsemch/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dsemch/test/test.ndarray.native.js
@@ -23,10 +23,9 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -53,8 +52,6 @@ tape( 'the function has an arity of 5', opts, function test( t ) {
 
 tape( 'the function calculates the standard error of the mean for a strided array (population)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -62,9 +59,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsemch( x.length, 0, x, 1, 0 );
 	expected = sqrt( 53.5/x.length ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsemch( x.length, 0, x, 1, 0 );
@@ -79,8 +74,6 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 
 tape( 'the function calculates the standard error of the mean for a strided array (sample)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -88,9 +81,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsemch( x.length, 1, x, 1, 0 );
 	expected = sqrt( 53.5/(x.length-1) ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsemch( x.length, 1, x, 1, 0 );


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/strided/dsemch` from computed relative-tolerance comparisons (`delta = abs( v - expected )` / `tol = 1.0 * EPS * abs( expected )`, asserted via `t.strictEqual( delta <= tol, ... )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to `test/test.dsemch.js`, `test/test.ndarray.js`, `test/test.dsemch.native.js`, and `test/test.ndarray.native.js` (two assertion sites in each). `test/test.js` contains no tolerance-based assertions and is unchanged.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from the four test files, along with the `delta` and `tol` variable declarations.

Only test files are changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| Test file | Assertion | Previous tolerance | ULP bound |
| --- | --- | --- | :-: |
| `test.dsemch.js` | standard error of the mean (population) | `1.0 * EPS * abs( expected )` | `1` |
| `test.dsemch.js` | standard error of the mean (sample) | `1.0 * EPS * abs( expected )` | `1` |
| `test.ndarray.js` | standard error of the mean (population) | `1.0 * EPS * abs( expected )` | `1` |
| `test.ndarray.js` | standard error of the mean (sample) | `1.0 * EPS * abs( expected )` | `1` |
| `test.dsemch.native.js` | standard error of the mean (population) | `1.0 * EPS * abs( expected )` | `1` |
| `test.dsemch.native.js` | standard error of the mean (sample) | `1.0 * EPS * abs( expected )` | `1` |
| `test.ndarray.native.js` | standard error of the mean (population) | `1.0 * EPS * abs( expected )` | `1` |
| `test.ndarray.native.js` | standard error of the mean (sample) | `1.0 * EPS * abs( expected )` | `1` |

`1` is the minimum integer `N` such that `isAlmostSameValue( v, expected, N )` holds at every migrated assertion site. This was measured by running the package's full test suite at successively tighter bounds, starting high and tightening: `N = 64, 32, 16, 8, 4, 3, 2, 1` each pass 77/77, and `N = 0` (bit-for-bit equality) fails at all eight sites, 69/77. The returned value differs from the expected value by exactly one ULP at every site (e.g., `1.2190615698606493` vs. `1.2190615698606495` for the population case, `1.3354150416006751` vs. `1.3354150416006754` for the sample case), as independently confirmed with `@stdlib/number/float64/base/ulp-difference`. `1` is therefore the measured minimum rather than a conservative choice.

The native add-on was built locally (`node-gyp rebuild`) so that `test/test.dsemch.native.js` and `test/test.ndarray.native.js` actually execute rather than being skipped; that the four native assertion sites are among the eight that fail at `N = 0` confirms they ran. The C implementation produces the same values as the JavaScript implementation at all four native assertion sites, so the native tests use the same `1` ULP bound, verified by execution rather than by inference.

`make test TESTS_FILTER=".*/stats/strided/dsemch/.*"` was run twice at the final bound with identical results: 77/77 passing across all five test files on both runs (18 + 18 + 18 + 5 + 18), no failures, ruling out FMA/architecture-dependent flakiness on this platform. `make eslint-tests TESTS_FILTER=".*/stats/strided/dsemch/.*"` is clean.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The resulting assertions match the idiom used by the already-migrated sibling package `stats/strided/dsemwd` (#15116), which computes the same quantity via a Welford algorithm rather than the one-pass trial mean algorithm used here. The two packages' test files were byte-identical modulo the package name prior to this change, and the resulting diff is line-for-line equivalent to the one already merged for that package, at the same `1` ULP bound at the same eight assertion sites.

Two environment notes, neither of which affected verification:

-   `make install-node-modules` initially failed with `ETARGET` for `es-object-atoms@^1.1.2`. This was a stale local npm packument cache rather than a repository or registry problem; `npm cache clean --force` followed by `make install-node-modules` and `make init` succeeded, and the full toolchain (tests, ESLint, native add-on build) was available for this PR.
-   The `pre-commit` hook's EditorConfig check could not run, as downloading the `editorconfig-checker` binary from GitHub releases is blocked in this environment. It was skipped via `SKIP_LINT_EDITORCONFIG`; every other `pre-commit` check (ESLint, filenames, license headers) ran and passed. EditorConfig conformance of the four changed files was instead verified directly: LF line endings, UTF-8 with no BOM, tab indentation, final newline present, and no added line carrying trailing whitespace. The two pre-existing trailing-whitespace lines per file are untouched by this diff and their counts are unchanged.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package at random from those still using computed relative tolerances, studied previously migrated packages in the same family to match the established idiom, performed the migration, and determined the minimum passing ULP bound empirically at every assertion site.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Br5stFXKsyQoBbUZ2yAaWK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Br5stFXKsyQoBbUZ2yAaWK)_