### PR TITLE
test: migrate `stats/base/dists/planck/pmf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/planck/pmf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/pmf/test/test.factory.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -129,9 +128,7 @@ tape( 'if provided a `lambda` which is nonpositive, the created function always 
 tape( 'the created function evaluates the pmf for `x` given small `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var pmf;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -142,13 +139,7 @@ tape( 'the created function evaluates the pmf for `x` given small `lambda`', fun
 	for ( i = 0; i < x.length; i++ ) {
 		pmf = factory( lambda[ i ] );
 		y = pmf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. lambda: '+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -156,9 +147,7 @@ tape( 'the created function evaluates the pmf for `x` given small `lambda`', fun
 tape( 'the created function evaluates the pmf for `x` given large `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var pmf;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -169,13 +158,7 @@ tape( 'the created function evaluates the pmf for `x` given large `lambda`', fun
 	for ( i = 0; i < x.length; i++ ) {
 		pmf = factory( lambda[ i ] );
 		y = pmf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. lambda: '+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/pmf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/pmf/test/test.native.js
@@ -22,10 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -106,8 +105,6 @@ tape( 'if provided a shape parameter `lambda` which is nonpositive, the function
 tape( 'the function evaluates the pmf for `x` given small parameter `lambda`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -117,13 +114,7 @@ tape( 'the function evaluates the pmf for `x` given small parameter `lambda`', o
 	lambda = smallLambda.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. lambda:'+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -131,8 +122,6 @@ tape( 'the function evaluates the pmf for `x` given small parameter `lambda`', o
 tape( 'the function evaluates the pmf for `x` given large parameter `lambda`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -142,13 +131,7 @@ tape( 'the function evaluates the pmf for `x` given large parameter `lambda`', o
 	lambda = largeLambda.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. lambda:'+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/pmf/test/test.pmf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/pmf/test/test.pmf.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pmf = require( './../lib/main.js' );
 
 
@@ -97,8 +96,6 @@ tape( 'if provided a shape parameter `lambda` which is nonpositive, the function
 tape( 'the function evaluates the pmf for `x` given small parameter `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -108,13 +105,7 @@ tape( 'the function evaluates the pmf for `x` given small parameter `lambda`', f
 	lambda = smallLambda.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. lambda:'+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -122,8 +113,6 @@ tape( 'the function evaluates the pmf for `x` given small parameter `lambda`', f
 tape( 'the function evaluates the pmf for `x` given large parameter `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -133,13 +122,7 @@ tape( 'the function evaluates the pmf for `x` given large parameter `lambda`', f
 	lambda = largeLambda.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[ i ], lambda[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. lambda:'+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/planck/pmf` from EPS-scaled relative tolerance comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from `test/test.pmf.js`, `test/test.factory.js`, and `test/test.native.js`.

Details:

-   **Package converted:** `stats/base/dists/planck/pmf` (`test/test.pmf.js`, `test/test.factory.js`, and `test/test.native.js`; `test/test.js` contains no tolerance math and is unchanged).
-   **Final ULP constants,** one per fixture set, identical across all three test files:

    | fixture set     | previous tolerance | final ULP bound |
    | --------------- | ------------------ | --------------- |
    | `small_lambda`  | `2.0 * EPS`        | `2`             |
    | `large_lambda`  | `2.0 * EPS`        | `1`             |

-   **Measured minimum:** starting from a loose bound and tightening, the values above are the smallest integers under which the full 1000-value fixture set passes for each set. Lowering either by one produces 10 failures in `small_lambda` (at `1`) and 91 failures in `large_lambda` (at `0`), so neither can be tightened further. Of the 1000 values per set, 909 are already bit-for-bit exact in each.
-   **Determinism:** the suite was run twice at the final bounds via `make test TESTS_FILTER=".*/stats/base/dists/planck/pmf/.*"`. Both runs: 2013 / 2015 / 3 assertions across `test.pmf.js`, `test.factory.js`, and `test.js`, all passing.
-   Linting is clean for all three files under `etc/eslint/.eslintrc.tests.js`, and the only changed files are the three test files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves a part of #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The conversion mirrors the idiom already merged for the sibling package `stats/base/dists/planck/logcdf` (#15114): the fixture loop drops the exact-vs-tolerance branch entirely in favor of a single `t.strictEqual( isAlmostSameValue( y, expected[ i ], N ), true, 'returns expected value' );` assertion.

The same bounds apply to `test/test.native.js`. The native add-on could not be built in the environment used to author this change, so `test/test.native.js` was skipped by the test runner. To avoid asserting unverified bounds, the C implementation was instead compiled standalone against its `manifest.json` dependency closure and evaluated over both fixture sets: it yields the same minima as the JavaScript implementation (2 and 1), unchanged when rebuilt with `-O3 -march=native -ffp-contract=fast` to enable FMA contraction.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running unattended as a scheduled task, which selected the package, mirrored the conversion idiom from previously merged conversions, and empirically determined and verified the minimum ULP bounds.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSAA8G5ozKyq256YdvVVDN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSAA8G5ozKyq256YdvVVDN)_