### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/rank-users/lib/pluck.ratio.js
+++ b/lib/node_modules/@stdlib/_tools/github/rank-users/lib/pluck.ratio.js
@@ -30,10 +30,10 @@ function ratio( data, key1, key2 ) {
 	var out;
 	var i;
 	var r;
-	out = new Array( data.length );
-	for ( i = 0; i < out.length; i++ ) {
+	out = [];
+	for ( i = 0; i < data.length; i++ ) {
 		r = data[i][key1] / data[i][key2];
-		out[ i ] = [ i, r ];
+		out.push( [ i, r ] );
 	}
 	return out;
 }


### PR DESCRIPTION
## Related Issues

resolves #15154

## Description

The JavaScript lint workflow failed on `stdlib/no-new-array` in:

`lib/node_modules/@stdlib/_tools/github/rank-users/lib/pluck.ratio.js`

This replaces `new Array( data.length )` with an array literal and `push`, matching the pattern already used in `pluck.raw.js`.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
-   [x] Followed the issue PR title format
-   [x] Referenced the issue as `resolves #15154`