### PR TITLE
test: migrate `stats/base/dists/rayleigh/entropy` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/entropy/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/entropy/test/test.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var entropy = require( './../lib' );
 
 
@@ -65,8 +64,6 @@ tape( 'if provided a scale `sigma` that is not a positive number, the function r
 tape( 'the function returns the differential entropy of a Rayleigh distribution', function test( t ) {
 	var expected;
 	var sigma;
-	var delta;
-	var tol;
 	var i;
 	var y;
 
@@ -74,13 +71,7 @@ tape( 'the function returns the differential entropy of a Rayleigh distribution'
 	sigma = data.sigma;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'sigma:'+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/entropy/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/entropy/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -74,8 +73,6 @@ tape( 'if provided a scale `sigma` that is not a positive number, the function r
 tape( 'the function returns the differential entropy of a Rayleigh distribution', opts, function test( t ) {
 	var expected;
 	var sigma;
-	var delta;
-	var tol;
 	var i;
 	var y;
 
@@ -83,13 +80,7 @@ tape( 'the function returns the differential entropy of a Rayleigh distribution'
 	sigma = data.sigma;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'sigma:'+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the test suite for `@stdlib/stats/base/dists/rayleigh/entropy` from relative-tolerance testing to ULP (units in the last place) based assertions, per the migration described in #11352.
-   Replaces the `delta`/`tol` relative-tolerance comparison (and the now-dead exact-match branch) in the fixture-driven test with a single `t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );` assertion, mirroring the idiom used in already-converted sibling packages (e.g. `stats/base/dists/rayleigh/pdf`, `rayleigh/cdf`, `rayleigh/logcdf`, `rayleigh/quantile`, `rayleigh/variance`).
-   Applies the change to both `test/test.js` and `test/test.native.js`. No other files are changed.
-   The measured minimum ULP bound required for the full 50-value fixture set to pass is **`1`**, for both the JavaScript implementation and the native C implementation (built locally via `node-gyp rebuild` so `test/test.native.js` was actually exercised rather than skipped). A bound of `0` fails 6 assertions in each file.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed locally on `linux/x64`, Node.js v22:

-   `test/test.js` — 56 passing, 0 failing
-   `test/test.native.js` — 56 passing, 0 failing (native add-on built locally)
-   The full suite was run three times at the final bound (`1`) with identical results, confirming no FMA/architecture-dependent flakiness locally.
-   `npx eslint` and `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/rayleigh/entropy/.*"` are both clean for the changed files.
-   The only files changed are the two test files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, running as an unattended scheduled task. It searched the repository for packages still using the relative-tolerance test idiom, studied the git history of several already-converted packages in the same distribution family (e.g. `stats/base/dists/rayleigh/pdf`, `rayleigh/variance`) to mirror the established idiom, applied the conversion, and determined the minimum ULP bound by computing the exact ULP distance between actual and expected values across the fixture set for both the JS and native implementations.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPZpFvV75WUR79qSe8Katc

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPZpFvV75WUR79qSe8Katc)_