### PR TITLE
test: migrate `stats/base/dists/frechet/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/stdev/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -97,8 +96,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', function test
 tape( 'the function returns the standard deviation of a Fréchet distribution', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var y;
 	var i;
@@ -109,13 +106,7 @@ tape( 'the function returns the standard deviation of a Fréchet distribution', 
 	for ( i = 0; i < alpha.length; i++ ) {
 		y = stdev( alpha[i], s[i], 0.0 );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'alpha:'+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 10.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. s: '+s[i]+'. m: 0. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 12 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/stdev/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -112,8 +111,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', opts, functio
 tape( 'the function returns the standard deviation of a Fréchet distribution', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var y;
 	var i;
@@ -124,13 +121,7 @@ tape( 'the function returns the standard deviation of a Fréchet distribution', 
 	for ( i = 0; i < alpha.length; i++ ) {
 		y = stdev( alpha[i], s[i], 0.0 );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'alpha:'+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 10.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. s: '+s[i]+'. m: 0. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 12 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/frechet/stdev` from relative tolerance testing to ULP difference testing.
-   replaces the `delta`/`tol` computations in `test/test.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 12 ), true, 'returns expected value' );`.
-   adds the `@stdlib/assert/is-almost-same-value` import and removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` imports.

The ULP bound was tightened to the measured minimum:

| File | ULP constant | Notes |
| ---- | ------------ | ----- |
| `test/test.js` | `12` | measured maximum ULP difference over all 68 non-`null` fixture cases is exactly 12; the suite fails at `11` (1 failing assertion) and passes at `12`. |
| `test/test.native.js` | `12` | the C implementation is bit-for-bit identical to the JavaScript implementation over the full fixture set, so the same bound applies. |

The previous assertions used a relative tolerance of `10.0 * EPS`, which is consistent with the measured 12 ULP bound.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification notes:

-   `test/test.js` passes (83/83 assertions), and the suite was run twice at the final ULP value to confirm determinism.
-   The measured minimum was established by computing `number/float64/base/ulp-difference` between the returned values and the Julia fixture values for every fixture case, and confirmed empirically by running the suite at `11` (fails) and `12` (passes).
-   Because the native add-on is not built in this environment, `test/test.native.js` skips. To bound the native ULP value, `src/main.c` and its transitive C dependencies were compiled into a standalone harness and evaluated over the same fixture set at `-O0`, `-O2`, and `-O3`. In all three cases the C results were bit-for-bit identical to the JavaScript results and the maximum ULP difference versus the fixtures was 12, so no FMA/optimization-level sensitivity was observed.
-   Linting is clean for both changed files under `etc/eslint/.eslintrc.tests.js` (0 errors). The only warnings are pre-existing `@cspell` "Unknown word: échet" warnings on the unchanged test description strings.
-   Only the two test files are changed.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code. The test migration mirrors the idiom established in the already-merged conversion for the sibling package `stats/base/dists/frechet/median` (#15123), and the ULP bound was measured rather than guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVM4G3stpWkuj632fLHnYP

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVM4G3stpWkuj632fLHnYP)_