### PR TITLE
feat: add float16 dtype support to `ndarray/data-buffer`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/data-buffer/README.md
+++ b/lib/node_modules/@stdlib/ndarray/data-buffer/README.md
@@ -100,6 +100,16 @@ x = zeros( [ 2, 2 ], opts );
 buf = data( x );
 // returns <Float32Array>
 
+// Create a 'float16' array...
+opts = {
+    'dtype': 'float16'
+};
+x = zeros( [ 2, 2 ], opts );
+// returns <ndarray>
+
+buf = data( x );
+// returns <Float16Array>
+
 // Create a 'complex128' array...
 opts = {
     'dtype': 'complex128'

--- a/lib/node_modules/@stdlib/ndarray/data-buffer/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/data-buffer/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { typedndarray, genericndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, complex128ndarray, complex64ndarray } from '@stdlib/types/ndarray';
+import { typedndarray, genericndarray, float64ndarray, float32ndarray, float16ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, complex128ndarray, complex64ndarray } from '@stdlib/types/ndarray';
 
 /**
 * Returns the underlying data buffer of a provided ndarray.
@@ -57,6 +57,24 @@ declare function data( x: float64ndarray ): float64ndarray[ 'data' ];
 * // returns <Float32Array>
 */
 declare function data( x: float32ndarray ): float32ndarray[ 'data' ];
+
+/**
+* Returns the underlying data buffer of a provided ndarray.
+*
+* @param x - input ndarray
+* @returns underlying data buffer
+*
+* @example
+* var zeros = require( '@stdlib/ndarray/zeros' );
+*
+* var x = zeros( [ 3, 3, 3 ], {
+*     'dtype': 'float16'
+* });
+*
+* var out = data( x );
+* // returns <Float16Array>
+*/
+declare function data( x: float16ndarray ): float16ndarray[ 'data' ];
 
 /**
 * Returns the underlying data buffer of a provided ndarray.

--- a/lib/node_modules/@stdlib/ndarray/data-buffer/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/data-buffer/docs/types/test.ts
@@ -26,6 +26,7 @@ import data = require( './index' );
 {
 	data( zeros( [ 3, 2, 1 ], { 'dtype': 'float64' } ) ); // $ExpectType Float64Array
 	data( zeros( [ 3, 2, 1 ], { 'dtype': 'float32' } ) ); // $ExpectType Float32Array
+	data( zeros( [ 3, 2, 1 ], { 'dtype': 'float16' } ) ); // $ExpectType Float16Array
 	data( zeros( [ 3, 2, 1 ], { 'dtype': 'int32' } ) ); // $ExpectType Int32Array
 	data( zeros( [ 3, 2, 1 ], { 'dtype': 'int16' } ) ); // $ExpectType Int16Array
 	data( zeros( [ 3, 2, 1 ], { 'dtype': 'int8' } ) ); // $ExpectType Int8Array

--- a/lib/node_modules/@stdlib/ndarray/data-buffer/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/data-buffer/docs/types/test.ts
@@ -26,7 +26,7 @@ import data = require( './index' );
 {
 	data( zeros( [ 3, 2, 1 ], { 'dtype': 'float64' } ) ); // $ExpectType Float64Array
 	data( zeros( [ 3, 2, 1 ], { 'dtype': 'float32' } ) ); // $ExpectType Float32Array
-	data( zeros( [ 3, 2, 1 ], { 'dtype': 'float16' } ) ); // $ExpectType Float16Array
+	data( zeros( [ 3, 2, 1 ], { 'dtype': 'float16' } ) ); // $ExpectType Float16ArrayFallback
 	data( zeros( [ 3, 2, 1 ], { 'dtype': 'int32' } ) ); // $ExpectType Int32Array
 	data( zeros( [ 3, 2, 1 ], { 'dtype': 'int16' } ) ); // $ExpectType Int16Array
 	data( zeros( [ 3, 2, 1 ], { 'dtype': 'int8' } ) ); // $ExpectType Int8Array

--- a/lib/node_modules/@stdlib/ndarray/data-buffer/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/data-buffer/examples/index.js
@@ -45,6 +45,18 @@ buf = data( x );
 
 console.log( buf );
 
+// Create a 'float16' array...
+opts = {
+	'dtype': 'float16'
+};
+x = zeros( [ 2, 2 ], opts );
+// returns <ndarray>
+
+buf = data( x );
+// returns <Float16Array>
+
+console.log( buf );
+
 // Create a 'complex128' array...
 opts = {
 	'dtype': 'complex128'

--- a/lib/node_modules/@stdlib/ndarray/data-buffer/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/data-buffer/test/test.js
@@ -81,6 +81,9 @@ tape( 'the function returns the underlying data buffer of a provided ndarray', f
 		zeros( [ 3, 3, 3 ], {
 			'dtype': 'float32'
 		}),
+		zeros( [ 2, 2 ], {
+			'dtype': 'float16'
+		}),
 		zeros( [ 1, 1 ], {
 			'dtype': 'int32'
 		}),
@@ -101,7 +104,8 @@ tape( 'the function returns the underlying data buffer of a provided ndarray', f
 		values[ 2 ].data,
 		values[ 3 ].data,
 		values[ 4 ].data,
-		values[ 5 ].data
+		values[ 5 ].data,
+		values[ 6 ].data
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
@@ -125,6 +129,9 @@ tape( 'the function accepts minimal ndarray-like objects (data)', function test(
 			'data': buffer( 'float32', 10 )
 		},
 		{
+			'data': buffer( 'float16', 10 )
+		},
+		{
 			'data': buffer( 'int32', 10 )
 		},
 		{
@@ -144,7 +151,8 @@ tape( 'the function accepts minimal ndarray-like objects (data)', function test(
 		values[ 2 ].data,
 		values[ 3 ].data,
 		values[ 4 ].data,
-		values[ 5 ].data
+		values[ 5 ].data,
+		values[ 6 ].data
 	];
 
 	for ( i = 0; i < values.length; i++ ) {


### PR DESCRIPTION
Progresses #14240

## Description

> What is the purpose of this pull request?

This pull request:

-   add float16 dtype support to `ndarray/data-buffer`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-  #14240

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
