### PR TITLE
chore: clean-up

### DIFF
--- a/.github/workflows/scripts/run_affected_benchmarks/run
+++ b/.github/workflows/scripts/run_affected_benchmarks/run
@@ -141,8 +141,8 @@ main() {
 
 	# Run JS benchmarks:
 	if [ -n "${js_bench_files}" ]; then
-		# Invoke make in batches to avoid "Argument list too long" errors:
-		printf '%s\n' ${js_bench_files} | xargs sh -c 'make benchmark-javascript-files FILES="$*"' _
+		# Invoke make in batches, capped well under the 128KiB Linux single-argument limit, in order to avoid "Argument list too long" errors:
+		printf '%s\n' ${js_bench_files} | xargs -s 40000 sh -c 'make benchmark-javascript-files FILES="$*"' _
 	else
 		echo 'No JavaScript benchmarks to run.' >&2
 	fi
@@ -173,8 +173,8 @@ main() {
 	fi
 
 	if [ -n "${c_bench_files}" ]; then
-		# Invoke make in batches to avoid "Argument list too long" errors:
-		printf '%s\n' ${c_bench_files} | xargs sh -c 'make benchmark-c-files FILES="$*"' _
+		# Invoke make in batches, capped well under the 128KiB Linux single-argument limit, in order to avoid "Argument list too long" errors:
+		printf '%s\n' ${c_bench_files} | xargs -s 40000 sh -c 'make benchmark-c-files FILES="$*"' _
 	else
 		echo 'No C benchmarks to run.' >&2
 	fi

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-immediate-require/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-immediate-require/examples/index.js
@@ -36,17 +36,17 @@ result = linter.verify( code, {
 });
 console.log( result );
 /* =>
-    [
-        {
-            'ruleId': 'no-immediate-require',
-            'severity': 2,
-            'message': 'require() expressions should not be immediately invoked',
-            'line': 2,
-            'column': 15,
-            'nodeType': 'CallExpression',
-            'source': 'var pdf = require( \'@stdlib/stats/base/dists/normal/pdf\' ).factory( 0.0, 1.0 );',
-            'endLine': 2,
-            'endColumn': 29
-        }
-    ]
+	[
+		{
+			'ruleId': 'no-immediate-require',
+			'severity': 2,
+			'message': 'require() expressions should not be immediately invoked',
+			'line': 2,
+			'column': 15,
+			'nodeType': 'CallExpression',
+			'source': 'var pdf = require( \'@stdlib/stats/base/dists/normal/pdf\' ).factory( 0.0, 1.0 );',
+			'endLine': 2,
+			'endColumn': 29
+		}
+	]
 */

--- a/lib/node_modules/@stdlib/_tools/github/rank-users/lib/shuffle.js
+++ b/lib/node_modules/@stdlib/_tools/github/rank-users/lib/shuffle.js
@@ -28,9 +28,9 @@
 function shuffle( data, sorted ) {
 	var out;
 	var i;
-	out = new Array( data.length );
+	out = [];
 	for ( i = 0; i < data.length; i++ ) {
-		out[ i ] = data[ sorted[i][0] ];
+		out.push( data[ sorted[i][0] ] );
 	}
 	return out;
 }

--- a/lib/node_modules/@stdlib/blas/base/drotg/test/test.assign.js
+++ b/lib/node_modules/@stdlib/blas/base/drotg/test/test.assign.js
@@ -70,11 +70,11 @@ tape( 'the function computes a Givens plane rotation', function test( t ) {
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		e = new Float64Array( expected[i] );
+		e = new Float64Array( expected[ i ] );
 		out = new Float64Array( 4 );
 		drotg( values[i][0], values[i][1], out, 1, 0 );
 		for ( j = 0; j < out.length; j++ ) {
-			t.strictEqual( isAlmostSameValue( out[j], e[j], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValue( out[ j ], e[ j ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -86,17 +86,17 @@ tape( 'the function returns an array of NaNs if provided a rotation elimination 
 
 	actual = drotg( NaN, 1.0, new Float64Array( 4 ), 1, 0 );
 	for ( i = 0; i < actual.length; i++ ) {
-		t.strictEqual( isnan( actual[i] ), true, 'returns expected value' );
+		t.strictEqual( isnan( actual[ i ] ), true, 'returns expected value' );
 	}
 
 	actual = drotg( 1.0, NaN, new Float64Array( 4 ), 1, 0 );
 	for ( i = 0; i < actual.length; i++ ) {
-		t.strictEqual( isnan( actual[i] ), true, 'returns expected value' );
+		t.strictEqual( isnan( actual[ i ] ), true, 'returns expected value' );
 	}
 
 	actual = drotg( NaN, NaN, new Float64Array( 4 ), 1, 0 );
 	for ( i = 0; i < actual.length; i++ ) {
-		t.strictEqual( isnan( actual[i] ), true, 'returns expected value' );
+		t.strictEqual( isnan( actual[ i ] ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -113,7 +113,7 @@ tape( 'the function supports providing a positive stride', function test( t ) {
 	actual = drotg( 0.3, 0.4, out, 2, 0 );
 	t.strictEqual( actual, out, 'returns expected value' );
 	for ( i = 0; i < out.length; i++ ) {
-		t.strictEqual( isAlmostSameValue( out[i], expected[i], 2 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( out[ i ], expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -130,7 +130,7 @@ tape( 'the function supports providing a negative stride', function test( t ) {
 	actual = drotg( 0.3, 0.4, out, -2, 6 );
 	t.strictEqual( actual, out, 'returns expected value' );
 	for ( i = 0; i < out.length; i++ ) {
-		t.strictEqual( isAlmostSameValue( out[i], expected[i], 2 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( out[ i ], expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -147,7 +147,7 @@ tape( 'the function supports providing a positive offset', function test( t ) {
 	actual = drotg( 0.3, 0.4, out, 1, 1 );
 	t.strictEqual( actual, out, 'returns expected value' );
 	for ( i = 0; i < out.length; i++ ) {
-		t.strictEqual( isAlmostSameValue( out[i], expected[i], 2 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( out[ i ], expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -164,7 +164,7 @@ tape( 'the function supports providing both a stride and offset', function test(
 	actual = drotg( 0.3, 0.4, out, 2, 2 );
 	t.strictEqual( actual, out, 'returns expected value' );
 	for ( i = 0; i < out.length; i++ ) {
-		t.strictEqual( isAlmostSameValue( out[i], expected[i], 2 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( out[ i ], expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/base/drotg/test/test.main.js
+++ b/lib/node_modules/@stdlib/blas/base/drotg/test/test.main.js
@@ -70,10 +70,10 @@ tape( 'the function computes a Givens plane rotation', function test( t ) {
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		e = new Float64Array( expected[i] );
+		e = new Float64Array( expected[ i ] );
 		out = drotg( values[i][0], values[i][1] );
 		for ( j = 0; j < out.length; j++ ) {
-			t.strictEqual( isAlmostSameValue( out[j], e[j], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValue( out[ j ], e[ j ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -85,17 +85,17 @@ tape( 'the function returns an array of NaNs if provided a rotational eliminatio
 
 	actual = drotg( NaN, 1.0 );
 	for ( i = 0; i < actual.length; i++ ) {
-		t.strictEqual( isnan( actual[i] ), true, 'returns expected value' );
+		t.strictEqual( isnan( actual[ i ] ), true, 'returns expected value' );
 	}
 
 	actual = drotg( 1.0, NaN );
 	for ( i = 0; i < actual.length; i++ ) {
-		t.strictEqual( isnan( actual[i] ), true, 'returns expected value' );
+		t.strictEqual( isnan( actual[ i ] ), true, 'returns expected value' );
 	}
 
 	actual = drotg( NaN, NaN );
 	for ( i = 0; i < actual.length; i++ ) {
-		t.strictEqual( isnan( actual[i] ), true, 'returns expected value' );
+		t.strictEqual( isnan( actual[ i ] ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/pdf/test/test.factory.js
@@ -115,8 +115,8 @@ tape( 'the created function evaluates the pdf for `x` given small `c`', function
 	x = smallC.x;
 	c = smallC.c;
 	for ( i = 0; i < x.length; i++ ) {
-		pdf = factory( c[i] );
-		y = pdf( x[i] );
+		pdf = factory( c[ i ] );
+		y = pdf( x[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -134,8 +134,8 @@ tape( 'the created function evaluates the pdf for `x` given a medium `c`', funct
 	x = mediumC.x;
 	c = mediumC.c;
 	for ( i = 0; i < x.length; i++ ) {
-		pdf = factory( c[i] );
-		y = pdf( x[i] );
+		pdf = factory( c[ i ] );
+		y = pdf( x[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -153,8 +153,8 @@ tape( 'the created function evaluates the pdf for `x` given a large `c`', functi
 	x = largeC.x;
 	c = largeC.c;
 	for ( i = 0; i < x.length; i++ ) {
-		pdf = factory( c[i] );
-		y = pdf( x[i] );
+		pdf = factory( c[ i ] );
+		y = pdf( x[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/pdf/test/test.native.js
@@ -108,8 +108,8 @@ tape( 'the function evaluates the pdf for `x` given small parameter `c`', opts, 
 	x = smallC.x;
 	c = smallC.c;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], c[i] );
-		if ( expected[i] !== null ) {
+		y = pdf( x[ i ], c[ i ] );
+		if ( expected[ i ] !== null ) {
 			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
@@ -127,8 +127,8 @@ tape( 'the function evaluates the pdf for `x` given medium parameter `c`', opts,
 	x = mediumC.x;
 	c = mediumC.c;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], c[i] );
-		if ( expected[i] !== null ) {
+		y = pdf( x[ i ], c[ i ] );
+		if ( expected[ i ] !== null ) {
 			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
@@ -146,8 +146,8 @@ tape( 'the function evaluates the pdf for `x` given large parameter `c`', opts, 
 	x = largeC.x;
 	c = largeC.c;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], c[i] );
-		if ( expected[i] !== null ) {
+		y = pdf( x[ i ], c[ i ] );
+		if ( expected[ i ] !== null ) {
 			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/pdf/test/test.pdf.js
@@ -99,7 +99,7 @@ tape( 'the function evaluates the pdf for `x` given small parameter `c`', functi
 	x = smallC.x;
 	c = smallC.c;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], c[i] );
+		y = pdf( x[ i ], c[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -116,7 +116,7 @@ tape( 'the function evaluates the pdf for `x` given medium parameter `c`', funct
 	x = mediumC.x;
 	c = mediumC.c;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], c[i] );
+		y = pdf( x[ i ], c[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
@@ -133,7 +133,7 @@ tape( 'the function evaluates the pdf for `x` given large parameter `c`', functi
 	x = largeC.x;
 	c = largeC.c;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], c[i] );
+		y = pdf( x[ i ], c[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/cdf/test/test.cdf.js
@@ -105,7 +105,7 @@ tape( 'the function evaluates the cdf for `x` given parameter `lambda`', functio
 	x = data.x;
 	lambda = data.lambda;
 	for ( i = 0; i < x.length; i++ ) {
-		y = cdf( x[i], lambda[i] );
+		y = cdf( x[ i ], lambda[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/cdf/test/test.factory.js
@@ -132,8 +132,8 @@ tape( 'the created function evaluates the cdf for `x` given parameter `lambda`',
 	x = data.x;
 	lambda = data.lambda;
 	for ( i = 0; i < x.length; i++ ) {
-		cdf = factory( lambda[i] );
-		y = cdf( x[i] );
+		cdf = factory( lambda[ i ] );
+		y = cdf( x[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/cdf/test/test.native.js
@@ -114,7 +114,7 @@ tape( 'the function evaluates the cdf for `x` given parameter `lambda`', opts, f
 	x = data.x;
 	lambda = data.lambda;
 	for ( i = 0; i < x.length; i++ ) {
-		y = cdf( x[i], lambda[i] );
+		y = cdf( x[ i ], lambda[ i ] );
 		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/ttest/test/test.js
+++ b/lib/node_modules/@stdlib/stats/ttest/test/test.js
@@ -65,7 +65,7 @@ tape( 'the function throws an error if the `x` argument is not a numeric array',
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided '+values[ i ] );
 	}
 	t.end();
 
@@ -86,7 +86,7 @@ tape( 'the function throws an error if the `x` array has less than two elements'
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), Error, 'throws an error when provided '+values[i] );
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided '+values[ i ] );
 	}
 	t.end();
 
@@ -113,7 +113,7 @@ tape( 'the function throws an error if the `y` argument is not a numeric array',
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided '+values[ i ] );
 	}
 	t.end();
 
@@ -134,7 +134,7 @@ tape( 'the function throws an error if the `x` and `y` arguments are arrays of d
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), Error, 'throws an error when provided '+values[i] );
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided '+values[ i ] );
 	}
 	t.end();
 
@@ -160,7 +160,7 @@ tape( 'the function throws an error if provided an invalid option', function tes
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided '+values[ i ] );
 	}
 
 	t.throws( badValue( 'not one of less, greater or two-sided' ), Error, 'throws an error when provided not less, greater or two-sided' );
@@ -185,7 +185,7 @@ tape( 'the function throws an error if the `alpha` option is a numeric value out
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), RangeError, 'throws an error when provided '+values[i] );
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided '+values[ i ] );
 	}
 	t.end();
 
@@ -565,7 +565,7 @@ tape( 'the function returns an object with a `.print()` method that throws an er
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided '+values[ i ] );
 	}
 	t.end();
 
@@ -600,7 +600,7 @@ tape( 'the function returns an object with a `.print()` method that throws an er
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided '+values[ i ] );
 	}
 	t.end();
 
@@ -637,7 +637,7 @@ tape( 'the function returns an object with a `.print()` method that throws an er
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided '+values[ i ] );
 	}
 	t.end();
 

--- a/lib/node_modules/@stdlib/stats/ttest/test/test.validate.js
+++ b/lib/node_modules/@stdlib/stats/ttest/test/test.validate.js
@@ -49,8 +49,8 @@ tape( 'the function returns an error if not provided an options object', functio
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		err = validate( {}, values[i] );
-		t.strictEqual( err instanceof TypeError, true, 'returns expected value when provided '+values[i] );
+		err = validate( {}, values[ i ] );
+		t.strictEqual( err instanceof TypeError, true, 'returns expected value when provided '+values[ i ] );
 	}
 	t.end();
 });
@@ -73,9 +73,9 @@ tape( 'the function returns an error if provided an `alpha` option which is not 
 
 	for ( i = 0; i < values.length; i++ ) {
 		err = validate( {}, {
-			'alpha': values[i]
+			'alpha': values[ i ]
 		});
-		t.strictEqual( err instanceof TypeError, true, 'returns expected value when provided '+values[i] );
+		t.strictEqual( err instanceof TypeError, true, 'returns expected value when provided '+values[ i ] );
 	}
 	t.end();
 });
@@ -93,9 +93,9 @@ tape( 'the function returns an error if provided an `alpha` option which is not 
 
 	for ( i = 0; i < values.length; i++ ) {
 		err = validate( {}, {
-			'alpha': values[i]
+			'alpha': values[ i ]
 		});
-		t.strictEqual( err instanceof RangeError, true, 'returns expected value when provided '+values[i] );
+		t.strictEqual( err instanceof RangeError, true, 'returns expected value when provided '+values[ i ] );
 	}
 	t.end();
 });
@@ -118,9 +118,9 @@ tape( 'the function returns an error if provided an `alternative` option which i
 
 	for ( i = 0; i < values.length; i++ ) {
 		err = validate( {}, {
-			'alternative': values[i]
+			'alternative': values[ i ]
 		});
-		t.strictEqual( err instanceof TypeError, true, 'returns expected value when provided '+values[i] );
+		t.strictEqual( err instanceof TypeError, true, 'returns expected value when provided '+values[ i ] );
 	}
 	t.end();
 });
@@ -139,9 +139,9 @@ tape( 'the function returns an error if provided an unrecognized/unsupported `al
 
 	for ( i = 0; i < values.length; i++ ) {
 		err = validate( {}, {
-			'alternative': values[i]
+			'alternative': values[ i ]
 		});
-		t.strictEqual( err instanceof Error, true, 'returns expected value when provided '+values[i] );
+		t.strictEqual( err instanceof Error, true, 'returns expected value when provided '+values[ i ] );
 	}
 	t.end();
 });
@@ -164,9 +164,9 @@ tape( 'the function returns an error if provided a `mu` option which is not a nu
 
 	for ( i = 0; i < values.length; i++ ) {
 		err = validate( {}, {
-			'mu': values[i]
+			'mu': values[ i ]
 		});
-		t.strictEqual( err instanceof TypeError, true, 'returns expected value when provided '+values[i] );
+		t.strictEqual( err instanceof TypeError, true, 'returns expected value when provided '+values[ i ] );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Propagating fixes merged to `develop` between 2026-09-10T13:46-07:00 and 2026-09-11T00:28-07:00 (`f47e2f7...2f17548`) to sibling packages.

This pull request:

-   applies the batch-size cap from `04cd72b` to `.github/workflows/scripts/run_affected_benchmarks/run`, which contains the same uncapped `xargs` idiom at two call sites. Both the JavaScript and C benchmark file lists now pass through `xargs -s 40000`, keeping each `make` invocation's argument list well under the 128KiB Linux limit; the C site is the more exposed of the two, as it is built from absolute paths.
-   applies the same spacing normalization from `42d3459` ("style: add missing spaces") to the remaining ULP-migrated test suites that retain unspaced bracket indexing: `blas/base/drotg`, `stats/base/dists/bradford/pdf`, `stats/base/dists/exponential/cdf`, and `stats/ttest` (54 lines across 10 files). Single-level indexing (`x[i]`) becomes `x[ i ]`; chained accesses (`values[i][0]`) are left as-is, matching the source commit's scope.
-   applies the identical EditorConfig fix from `d30d365` to `_tools/eslint/rules/no-immediate-require/examples/index.js`: the space-indented `/* => ... */` example-output comment block (lines 39-51) is converted to tab indentation, matching the project's `.editorconfig` rule for JavaScript. No content or behavioral change — whitespace only.
-   applies the identical `stdlib/no-new-array` fix from `b15594b` to `_tools/github/rank-users/lib/shuffle.js`, the sole remaining `new Array(` call in the package. The constructor call is replaced with an empty array literal (`out = []`) populated via `out.push( data[ sorted[i][0] ] )` inside the existing loop. The loop fills every index densely, so behavior is unchanged.

One commit per source fix pattern preserves the per-pattern audit trail.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed before inclusion:

-   Pattern search scoped to sibling packages/files of each source commit (`_tools/github/rank-users`, `_tools/eslint/rules/*/examples`, test files of packages migrated to ULP-based assertions in the window, `.github/workflows/scripts`).
-   Two independent validation passes confirmed the defect is present at every included site and that each fix is a direct analog of its source commit.
-   An adaptation pass produced exact per-site patches; a style-consistency pass confirmed each patch matches surrounding package style.
-   Deliberately excluded: chained/nested bracket accesses (`values[i][0]` in `blas/base/drotg` tests), mirroring the source commit leaving `data[i][key1]` untouched; a `fix: update require path` pattern (`20f2bbe`) for which no other sites exist repo-wide; and any site requiring cross-package changes.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code as part of an automated fix-propagation routine: recent fixes on `develop` were pattern-matched against sibling packages, and each candidate site was validated by multiple independent review passes before inclusion.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb1Gpvp3E3LKqB4iF49u1C

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kb1Gpvp3E3LKqB4iF49u1C)_