### PR TITLE
test: migrate `stats/incr/nanmrss` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nanmrss/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrss/test/test.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var incrnanmrss = require( './../lib' );
 
 
@@ -72,10 +71,8 @@ tape( 'the function returns an accumulator function', function test( t ) {
 tape( 'the accumulator function computes a moving residual sum of squares incrementally', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
 	var acc;
-	var tol;
 	var N;
 	var i;
 
@@ -97,13 +94,7 @@ tape( 'the accumulator function computes a moving residual sum of squares increm
 	expected = [ 1.0, 1.0, 1.0, 17.0, 26.0, 89.0, 89.0, 82.0, 154.0 ];
 	for ( i = 0; i < N; i++ ) {
 		actual = acc( data[i][0], data[i][1] );
-		if ( actual === expected[i] ) {
-			t.equal( actual, expected[i], 'returns expected value' );
-		} else {
-			delta = abs( expected[i] - actual );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.equal( delta <= tol, true, 'within tolerance. Actual: '+actual+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/incr/nanmrss` from a computed relative-tolerance comparison (`delta = abs( expected - actual )` / `tol = 1.0 * EPS * abs( expected )`, asserted via `t.equal( delta <= tol, ... )`) to a ULP-difference assertion using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to the single tolerance-based assertion site in `test/test.js`. The package has no `test/test.native.js`. The remaining assertions in the file are exact comparisons against `null`, thrown `TypeError`s, function types, and the exactly representable value `145.0`, which are correct as-is and are left unchanged.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires, along with the `delta` and `tol` variable declarations.
-   collapses the `if ( actual === expected[i] ) { ... } else { ... }` branch in the moving-residual-sum-of-squares test into a single ULP assertion, matching the migrated idiom.

Only a test file is changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| Assertion | Previous tolerance | ULP bound |
| --- | --- | :-: |
| moving residual sum of squares computed incrementally (9 values) | `1.0 * EPS * abs( expected )` | `0` |

This is the minimum integer bound `N` such that `isAlmostSameValue( actual, expected[ i ], N )` holds at the assertion site, and it is the floor of the scale — no tighter bound exists. It was measured independently of the test harness by computing `ulpDifference( actual, expected[ i ] )` directly at every element, starting from a high bound (`64`, which passes) and tightening.

The per-element ULP differences are `0, 0, 0, 0, 0, 0, 0, 0, 0`: the accumulator reproduces every expected value (`1`, `1`, `1`, `17`, `26`, `89`, `89`, `82`, `154`) bit-for-bit. These are small integers well within the exactly representable range, and the incremental algorithm accumulates only sums of products of small integer-valued inputs, so no rounding occurs at any step. The original test anticipated this by branching on `actual === expected[i]` and taking the exact-comparison path first; the pre-existing relative tolerance was never actually exercised on this platform. At `N = 0`, `isAlmostSameValue` delegates to `isSameValue`, so the migrated assertion preserves that exact-comparison behavior rather than loosening it.

`make test TESTS_FILTER=".*/stats/incr/nanmrss/.*"` was run twice at the final bound with identical results: 25/25 passing on both runs, no failures, ruling out FMA/architecture-dependent flakiness on this platform. `make eslint-tests TESTS_FILTER=".*/stats/incr/nanmrss/.*"` is clean.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

The migrated bound is `0` rather than `1`. Since every value in this fixture is exact, `0` is the minimum required bound as the tracking issue asks for, and it preserves the exact comparison the original test already performed via its `actual === expected[i]` branch. A bound of `1` would be strictly weaker than the assertion being replaced. Flagging in case a reviewer would prefer `1` for consistency with sibling packages whose fixtures are genuinely inexact; `0` is used elsewhere in the migrated set, so this follows existing precedent.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The resulting diff mirrors the already-merged migrations for the sibling accumulator packages `stats/incr/nanmhmean` (#15125), `stats/incr/mmape` (#15150), and `stats/incr/mda` (#15142), which share the same test structure.

One environment note, which did not affect verification: `make install-node-modules` initially failed with `ETARGET` for `es-object-atoms@^1.1.2`. As previously observed in #15116 and #15125, this is a stale local npm packument cache rather than a repository or registry problem; refetching with `npm_config_prefer_online=true` succeeded, after which `make init` and the full toolchain were available for this PR.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously migrated packages in the same family to match the established idiom, performed the migration, and determined the minimum passing ULP bound empirically at the assertion site.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014muLqDv12CgWqs2cpTH9vW

---
_Generated by [Claude Code](https://claude.ai/code/session_014muLqDv12CgWqs2cpTH9vW)_