### PR TITLE
feat: add C implementation for `stats/base/ndarray/scuminabs`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/README.md
@@ -104,6 +104,163 @@ console.log( ndarray2array( v ) );
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/stats/base/ndarray/scuminabs.h"
+```
+
+#### stdlib_stats_scuminabs( arrays )
+
+Computes the cumulative minimum absolute value of a one-dimensional single-precision floating-point ndarray.
+
+```c
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/dtypes.h"
+#include "stdlib/ndarray/index_modes.h"
+#include "stdlib/ndarray/orders.h"
+#include "stdlib/ndarray/base/bytes_per_element.h"
+#include <stdint.h>
+
+// Create ndarrays:
+const float dataX[] = { 1.0, 3.0, 4.0, 2.0 };
+float dataY[] = { 0.0, 0.0, 0.0, 0.0 };
+int64_t shape[] = { 4 };
+int64_t strides[] = { STDLIB_NDARRAY_FLOAT32_BYTES_PER_ELEMENT };
+int8_t submodes[] = { STDLIB_NDARRAY_INDEX_ERROR };
+
+struct ndarray *x = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT32, (uint8_t *)dataX, 1, shape, strides, 0, STDLIB_NDARRAY_ROW_MAJOR, STDLIB_NDARRAY_INDEX_ERROR, 1, submodes );
+struct ndarray *y = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT32, (uint8_t *)dataY, 1, shape, strides, 0, STDLIB_NDARRAY_ROW_MAJOR, STDLIB_NDARRAY_INDEX_ERROR, 1, submodes );
+
+// Perform computation:
+const struct ndarray *arrays[] = { x, y };
+stdlib_stats_scuminabs( arrays );
+
+// Free allocated memory:
+stdlib_ndarray_free( x );
+stdlib_ndarray_free( y );
+```
+
+The function accepts the following arguments:
+
+-   **arrays**: `[in] struct ndarray**` list containing the following ndarrays:
+
+    -   `[in] struct ndarray*` a one-dimensional input ndarray.
+    -   `[inout] struct ndarray*` a one-dimensional output ndarray.
+
+```c
+void stdlib_stats_scuminabs( const struct ndarray *arrays[] );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/stats/base/ndarray/scuminabs.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/dtypes.h"
+#include "stdlib/ndarray/index_modes.h"
+#include "stdlib/ndarray/orders.h"
+#include "stdlib/ndarray/base/bytes_per_element.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+    // Create data buffers:
+    const float dataX[] = { 1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0 };
+    float dataY[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+
+    // Specify the number of array dimensions:
+    const int64_t ndims = 1;
+
+    // Specify the array shape:
+    int64_t shape[] = { 8 };
+
+    // Specify the array strides:
+    int64_t strides[] = { STDLIB_NDARRAY_FLOAT32_BYTES_PER_ELEMENT };
+
+    // Specify the byte offset:
+    const int64_t offset = 0;
+
+    // Specify the array order:
+    const enum STDLIB_NDARRAY_ORDER order = STDLIB_NDARRAY_ROW_MAJOR;
+
+    // Specify the index mode:
+    const enum STDLIB_NDARRAY_INDEX_MODE imode = STDLIB_NDARRAY_INDEX_ERROR;
+
+    // Specify the subscript index modes:
+    int8_t submodes[] = { STDLIB_NDARRAY_INDEX_ERROR };
+    const int64_t nsubmodes = 1;
+
+    // Create ndarrays:
+    struct ndarray *x = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT32, (uint8_t *)dataX, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+    struct ndarray *y = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT32, (uint8_t *)dataY, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+    if ( x == NULL || y == NULL ) {
+        fprintf( stderr, "Error allocating memory.\n" );
+        exit( 1 );
+    }
+
+    // Define a list of ndarrays:
+    const struct ndarray *arrays[] = { x, y };
+
+    // Perform computation:
+    stdlib_stats_scuminabs( arrays );
+
+    // Print the result:
+    for ( int i = 0; i < 8; i++ ) {
+        printf( "y[ %i ] = %lf\n", i, dataY[ i ] );
+    }
+
+    // Free allocated memory:
+    stdlib_ndarray_free( x );
+    stdlib_ndarray_free( y );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/benchmark/benchmark.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,18 +20,21 @@
 
 // MODULES //
 
+var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/uniform' );
-var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
-var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
+var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
-var scuminabs = require( './../lib/main.js' );
 
 
 // VARIABLES //
 
+var scuminabs = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( scuminabs instanceof Error )
+};
 var options = {
 	'dtype': 'float32'
 };
@@ -43,16 +46,12 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} len - ndarray length
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x;
-	var y;
-
-	x = uniform( [ len ], -10.0, 10.0, options );
-	y = new Float32Vector( len );
-
+	var x = uniform( [ len ], -100.0, 100.0, options );
+	var y = uniform( [ len ], 1.0, 100.0, options );
 	return benchmark;
 
 	/**
@@ -62,19 +61,19 @@ function createBenchmark( len ) {
 	* @param {Benchmark} b - benchmark instance
 	*/
 	function benchmark( b ) {
-		var v;
+		var out;
 		var i;
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			v = scuminabs( [ x, y ] );
-			if ( typeof v !== 'object' ) {
+			out = scuminabs( [ x, y ] );
+			if ( typeof out !== 'object' ) {
 				b.fail( 'should return an ndarray' );
 			}
 		}
 		b.toc();
-		if ( isnanf( v.get( i%len ) ) ) {
-			b.fail( 'should not return NaN' );
+		if ( typeof out !== 'object' ) {
+			b.fail( 'should return an ndarray' );
 		}
 		b.pass( 'benchmark finished' );
 		b.end();
@@ -102,7 +101,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		bench( format( '%s:len=%d', pkg, len ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/benchmark/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.length.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/benchmark/c/benchmark.length.c
@@ -1,0 +1,198 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/ndarray/scuminabs.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/dtypes.h"
+#include "stdlib/ndarray/index_modes.h"
+#include "stdlib/ndarray/orders.h"
+#include "stdlib/ndarray/base/bytes_per_element.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "scuminabs"
+#define ITERATIONS 1000000
+#define REPEATS 3
+#define MIN 1
+#define MAX 6
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param iterations  number of iterations
+* @param elapsed     elapsed time in seconds
+*/
+static void print_results( int iterations, double elapsed ) {
+	double rate = (double)iterations / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", iterations );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [min,max).
+*
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return random number
+*/
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*(max-min) );
+}
+
+/**
+* Runs a benchmark.
+*
+* @param iterations   number of iterations
+* @param len          array length
+* @return             elapsed time in seconds
+*/
+static double benchmark( int iterations, int len ) {
+	enum STDLIB_NDARRAY_INDEX_MODE imode;
+	const struct ndarray *arrays[ 2 ];
+	enum STDLIB_NDARRAY_ORDER order;
+	int8_t submodes[ 1 ];
+	int64_t strides[ 1 ];
+	int64_t shape[ 1 ];
+	int64_t nsubmodes;
+	struct ndarray *x;
+	struct ndarray *y;
+	int64_t offset;
+	double elapsed;
+	int64_t ndims;
+	float *dataX;
+	float *dataY;
+	double t;
+	int i;
+
+	ndims = 1;
+	shape[ 0 ] = len;
+	strides[ 0 ] = STDLIB_NDARRAY_FLOAT32_BYTES_PER_ELEMENT;
+	offset = 0;
+	order = STDLIB_NDARRAY_ROW_MAJOR;
+	imode = STDLIB_NDARRAY_INDEX_ERROR;
+	submodes[ 0 ] = imode;
+	nsubmodes = 1;
+
+	dataX = (float *) malloc( len * sizeof( float ) );
+	dataY = (float *) malloc( len * sizeof( float ) );
+	for ( i = 0; i < len; i++ ) {
+		dataX[ i ] = random_uniform( -100.0, 100.0 );
+		dataY[ i ] = random_uniform( 1.0, 100.0 );
+	}
+
+	// cppcheck-suppress invalidPointerCast
+	x = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT32, (uint8_t *)dataX, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+
+	// cppcheck-suppress invalidPointerCast
+	y = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT32, (uint8_t *)dataY, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+
+	arrays[ 0 ] = x;
+	arrays[ 1 ] = y;
+
+	t = tic();
+	for ( i = 0; i < iterations; i++ ) {
+		stdlib_stats_scuminabs( arrays );
+		if ( dataY[ 0 ] != dataY[ 0 ] ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( dataY[ 0 ] != dataY[ 0 ] ) {
+		printf( "should not return NaN\n" );
+	}
+	stdlib_ndarray_free( x );
+	stdlib_ndarray_free( y );
+	free( dataX );
+	free( dataY );
+	arrays[ 0 ] = NULL;
+	arrays[ 1 ] = NULL;
+
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int count;
+	int iter;
+	int len;
+	int i;
+	int j;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	count = 0;
+	for ( i = MIN; i <= MAX; i++ ) {
+		len = pow( 10, i );
+		iter = ITERATIONS / pow( 10, i-1 );
+		for ( j = 0; j < REPEATS; j++ ) {
+			count += 1;
+			printf( "# c::%s:len=%d\n", NAME, len );
+			elapsed = benchmark( iter, len );
+			print_results( iter, elapsed );
+			printf( "ok %d benchmark finished\n", count );
+		}
+	}
+	print_summary( count, count );
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/examples/c/example.c
@@ -1,0 +1,81 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/ndarray/scuminabs.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/dtypes.h"
+#include "stdlib/ndarray/index_modes.h"
+#include "stdlib/ndarray/orders.h"
+#include "stdlib/ndarray/base/bytes_per_element.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+	// Create data buffers:
+	const float dataX[] = { 1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0 };
+	float dataY[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+
+	// Specify the number of array dimensions:
+	const int64_t ndims = 1;
+
+	// Specify the array shape:
+	int64_t shape[] = { 8 };
+
+	// Specify the array strides:
+	int64_t strides[] = { STDLIB_NDARRAY_FLOAT32_BYTES_PER_ELEMENT };
+
+	// Specify the byte offset:
+	const int64_t offset = 0;
+
+	// Specify the array order:
+	const enum STDLIB_NDARRAY_ORDER order = STDLIB_NDARRAY_ROW_MAJOR;
+
+	// Specify the index mode:
+	const enum STDLIB_NDARRAY_INDEX_MODE imode = STDLIB_NDARRAY_INDEX_ERROR;
+
+	// Specify the subscript index modes:
+	int8_t submodes[] = { STDLIB_NDARRAY_INDEX_ERROR };
+	const int64_t nsubmodes = 1;
+
+	// Create ndarrays:
+	// cppcheck-suppress invalidPointerCast
+	struct ndarray *x = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT32, (uint8_t *)dataX, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+
+	// cppcheck-suppress invalidPointerCast
+	struct ndarray *y = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT32, (uint8_t *)dataY, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+	if ( x == NULL || y == NULL ) {
+		fprintf( stderr, "Error allocating memory.\n" );
+		exit( 1 );
+	}
+
+	// Define a list of ndarrays:
+	const struct ndarray *arrays[] = { x, y };
+
+	// Perform computation:
+	stdlib_stats_scuminabs( arrays );
+
+	// Print the result:
+	for ( int i = 0; i < 8; i++ ) {
+		printf( "y[ %i ] = %lf\n", i, dataY[ i ] );
+	}
+
+	// Free allocated memory:
+	stdlib_ndarray_free( x );
+	stdlib_ndarray_free( y );
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/include/stdlib/stats/base/ndarray/scuminabs.h
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/include/stdlib/stats/base/ndarray/scuminabs.h
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_STATS_BASE_NDARRAY_scuminabs_H
+#define STDLIB_STATS_BASE_NDARRAY_scuminabs_H
+
+#include "stdlib/ndarray/ctor.h"
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Computes the cumulative minimum absolute value of a one-dimensional single-precision floating-point ndarray.
+*/
+void stdlib_stats_scuminabs( const struct ndarray *arrays[] );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_STATS_BASE_NDARRAY_scuminabs_H

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/lib/native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,14 +18,31 @@
 
 'use strict';
 
+// MODULES //
+
+var serialize = require( '@stdlib/ndarray/base/serialize-meta-data' );
+var getData = require( '@stdlib/ndarray/base/data-buffer' );
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
 /**
-* Compute the cumulative minimum absolute value of a one-dimensional single-precision floating-point ndarray.
+* Computes the cumulative minimum absolute value of a one-dimensional single-precision floating-point ndarray.
 *
-* @module @stdlib/stats/base/ndarray/scuminabs
+* ## Notes
+*
+* -   The function expects the following ndarrays:
+*
+*     -   a one-dimensional input ndarray.
+*     -   a one-dimensional output ndarray.
+*
+* @private
+* @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
+* @returns {ndarray} output ndarray
 *
 * @example
 * var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
-* var scuminabs = require( '@stdlib/stats/base/ndarray/scuminabs' );
 *
 * var x = new Float32Vector( [ 1.0, 3.0, 4.0, 2.0 ] );
 * var y = new Float32Vector( [ 0.0, 0.0, 0.0, 0.0 ] );
@@ -36,23 +53,11 @@
 * var bool = ( v === y );
 * // returns true
 */
-
-// MODULES //
-
-var join = require( 'path' ).join;
-var tryRequire = require( '@stdlib/utils/try-require' );
-var isError = require( '@stdlib/assert/is-error' );
-var main = require( './main.js' );
-
-
-// MAIN //
-
-var scuminabs;
-var tmp = tryRequire( join( __dirname, './native.js' ) );
-if ( isError( tmp ) ) {
-	scuminabs = main;
-} else {
-	scuminabs = tmp;
+function scuminabs( arrays ) {
+	var x = arrays[ 0 ];
+	var y = arrays[ 1 ];
+	addon( getData( x ), serialize( x ), getData( y ), serialize( y ) );
+	return y;
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/manifest.json
@@ -1,0 +1,110 @@
+{
+  "options": {
+    "task": "build",
+    "wasm": false
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/stats/strided/scuminabs",
+        "@stdlib/ndarray/ctor",
+        "@stdlib/ndarray/base/napi/addon-arguments",
+        "@stdlib/napi/export",
+        "@stdlib/napi/argv",
+        "@stdlib/napi/create-double"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/stats/strided/scuminabs",
+        "@stdlib/ndarray/ctor",
+        "@stdlib/ndarray/dtypes",
+        "@stdlib/ndarray/index-modes",
+        "@stdlib/ndarray/orders",
+        "@stdlib/ndarray/base/bytes-per-element"
+      ]
+    },
+    {
+      "task": "examples",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/stats/strided/scuminabs",
+        "@stdlib/ndarray/ctor",
+        "@stdlib/ndarray/dtypes",
+        "@stdlib/ndarray/index-modes",
+        "@stdlib/ndarray/orders",
+        "@stdlib/ndarray/base/bytes-per-element"
+      ]
+    },
+    {
+      "task": "",
+      "wasm": true,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/stats/strided/scuminabs",
+        "@stdlib/ndarray/ctor"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/package.json
@@ -14,11 +14,15 @@
     }
   ],
   "main": "./lib",
+  "browser": "./lib/main.js",
+  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
+    "include": "./include",
     "lib": "./lib",
+    "src": "./src",
     "test": "./test"
   },
   "types": "./docs/types",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/src/addon.c
@@ -1,0 +1,64 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/ndarray/scuminabs.h"
+#include "stdlib/ndarray/ctor.h"
+#include "stdlib/ndarray/base/napi/addon_arguments.h"
+#include "stdlib/napi/export.h"
+#include "stdlib/napi/argv.h"
+#include <node_api.h>
+#include <assert.h>
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon( napi_env env, napi_callback_info info ) {
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 4 );
+
+	// Process provided arguments:
+	struct ndarray *arrays[ 2 ];
+	napi_value err;
+	napi_status status = stdlib_ndarray_napi_addon_arguments( env, argv, 4, 2, arrays, &err );
+	assert( status == napi_ok );
+	if ( err != NULL ) {
+		status = napi_throw( env, err );
+		assert( status == napi_ok );
+		return NULL;
+	}
+	// Create a const-qualified view of the argument pointer list:
+	const struct ndarray *arr[ 2 ] = {
+		arrays[ 0 ],
+		arrays[ 1 ]
+	};
+	// Perform computation:
+	stdlib_stats_scuminabs( arr );
+
+	// Free allocated memory:
+	stdlib_ndarray_free( arrays[ 0 ] );
+	stdlib_ndarray_free( arrays[ 1 ] );
+	arrays[ 0 ] = NULL;
+	arrays[ 1 ] = NULL;
+
+	return NULL;
+}
+
+STDLIB_NAPI_MODULE_EXPORT_FCN( addon )

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/src/main.c
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/ndarray/scuminabs.h"
+#include "stdlib/stats/strided/scuminabs.h"
+#include "stdlib/ndarray/ctor.h"
+
+/**
+* Computes the cumulative minimum absolute value of a one-dimensional single-precision floating-point ndarray.
+*
+* ## Notes
+*
+* -   The function expects the following ndarrays:
+*
+*     -   a one-dimensional input ndarray.
+*     -   a one-dimensional output ndarray.
+*
+* @param arrays    list containing ndarrays
+*/
+void stdlib_stats_scuminabs( const struct ndarray *arrays[] ) {
+	const struct ndarray *x = arrays[ 0 ];
+	const struct ndarray *y = arrays[ 1 ];
+
+	const int64_t N = stdlib_ndarray_dimension( x, 0 );
+
+	const int64_t strideX = stdlib_ndarray_stride_elements( x, 0 );
+	const int64_t offsetX = stdlib_ndarray_offset_elements( x );
+	const int64_t strideY = stdlib_ndarray_stride_elements( y, 0 );
+	const int64_t offsetY = stdlib_ndarray_offset_elements( y );
+
+	const float *dataX = (const float *)stdlib_ndarray_data( x );
+	float *dataY = (float *)stdlib_ndarray_data( y );
+	API_SUFFIX(stdlib_strided_scuminabs_ndarray)( N, dataX, strideX, offsetX, dataY, strideY, offsetY );
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/test/test.js
@@ -21,29 +21,16 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var isSameFloat32Array = require( '@stdlib/assert/is-same-float32array' );
-var Float32Array = require( '@stdlib/array/float32' );
-var ndarray = require( '@stdlib/ndarray/base/ctor' );
-var zerosLike = require( '@stdlib/ndarray/zeros-like' );
-var getData = require( '@stdlib/ndarray/data-buffer' );
+var proxyquire = require( 'proxyquire' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
 var scuminabs = require( './../lib' );
 
 
-// FUNCTIONS //
+// VARIABLES //
 
-/**
-* Returns a one-dimensional ndarray.
-*
-* @private
-* @param {Float32Array} buffer - underlying data buffer
-* @param {NonNegativeInteger} length - number of indexed elements
-* @param {integer} stride - stride length
-* @param {NonNegativeInteger} offset - index offset
-* @returns {ndarray} one-dimensional ndarray
-*/
-function vector( buffer, length, stride, offset ) {
-	return new ndarray( 'float32', buffer, [ length ], [ stride ], offset, 'row-major' );
-}
+var opts = {
+	'skip': IS_BROWSER
+};
 
 
 // TESTS //
@@ -54,220 +41,37 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'the function has an arity of 1', function test( t ) {
-	t.strictEqual( scuminabs.length, 1, 'has expected arity' );
+tape( 'if a native implementation is available, the main export is the native implementation', opts, function test( t ) {
+	var scuminabs = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
+
+	t.strictEqual( scuminabs, mock, 'returns expected value' );
 	t.end();
+
+	function tryRequire() {
+		return mock;
+	}
+
+	function mock() {
+		// Mock...
+	}
 });
 
-tape( 'the function calculates the cumulative minimum absolute value of a one-dimensional ndarray', function test( t ) {
-	var expected;
-	var xbuf;
-	var x;
-	var y;
-	var v;
+tape( 'if a native implementation is not available, the main export is a JavaScript implementation', opts, function test( t ) {
+	var scuminabs;
+	var main;
 
-	xbuf = new Float32Array( [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0 ] );
-	x = vector( xbuf, 6, 1, 0 );
-	y = zerosLike( x );
-	v = scuminabs( [ x, y ] );
+	main = require( './../lib/main.js' );
 
-	expected = new Float32Array( [ 1.0, 1.0, 1.0, 1.0, 0.0, 0.0 ] );
-	t.strictEqual( v, y, 'returns expected value' );
-	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+	scuminabs = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
 
-	xbuf = new Float32Array( [ -4.0, -5.0 ] );
-	x = vector( xbuf, 2, 1, 0 );
-	y = zerosLike( x );
-	v = scuminabs( [ x, y ] );
-
-	expected = new Float32Array( [ 4.0, 4.0 ] );
-	t.strictEqual( v, y, 'returns expected value' );
-	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
-
-	xbuf = new Float32Array( [ -0.0, 0.0, -0.0 ] );
-	x = vector( xbuf, 3, 1, 0 );
-	y = zerosLike( x );
-	v = scuminabs( [ x, y ] );
-
-	expected = new Float32Array( [ 0.0, 0.0, 0.0 ] );
-	t.strictEqual( v, y, 'returns expected value' );
-	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
-
-	xbuf = new Float32Array( [ NaN ] );
-	x = vector( xbuf, 1, 1, 0 );
-	y = zerosLike( x );
-	v = scuminabs( [ x, y ] );
-
-	expected = new Float32Array( [ NaN ] );
-	t.strictEqual( v, y, 'returns expected value' );
-	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
-
-	xbuf = new Float32Array( [ NaN, NaN ] );
-	x = vector( xbuf, 2, 1, 0 );
-	y = zerosLike( x );
-	v = scuminabs( [ x, y ] );
-
-	expected = new Float32Array( [ NaN, NaN ] );
-	t.strictEqual( v, y, 'returns expected value' );
-	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
-
+	t.strictEqual( scuminabs, main, 'returns expected value' );
 	t.end();
-});
 
-tape( 'if provided an empty ndarray, the function returns the output array unchanged', function test( t ) {
-	var expected;
-	var xbuf;
-	var x;
-	var y;
-	var v;
-
-	xbuf = new Float32Array( [] );
-	x = vector( xbuf, 0, 1, 0 );
-	y = zerosLike( x );
-
-	v = scuminabs( [ x, y ] );
-
-	expected = new Float32Array( [] );
-	t.strictEqual( v, y, 'returns expected value' );
-	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
-
-	t.end();
-});
-
-tape( 'the function supports one-dimensional ndarrays having non-unit strides', function test( t ) {
-	var expected;
-	var xbuf;
-	var ybuf;
-	var x;
-	var y;
-	var v;
-
-	xbuf = new Float32Array([
-		1.0,  // 0
-		2.0,
-		2.0,  // 1
-		-7.0,
-		-2.0, // 2
-		3.0,
-		4.0,  // 3
-		2.0
-	]);
-	x = vector( xbuf, 4, 2, 0 );
-
-	ybuf = new Float32Array([
-		0.0,  // 0
-		0.0,
-		0.0,  // 1
-		0.0,
-		0.0,  // 2
-		0.0,
-		0.0,  // 3
-		0.0
-	]);
-	y = vector( ybuf, 4, 2, 0 );
-
-	v = scuminabs( [ x, y ] );
-
-	expected = new Float32Array([
-		1.0,   // 0
-		0.0,
-		1.0,   // 1
-		0.0,
-		1.0,  // 2
-		0.0,
-		1.0,  // 3
-		0.0
-	]);
-	t.strictEqual( v, y, 'returns expected value' );
-	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
-	t.end();
-});
-
-tape( 'the function supports one-dimensional ndarrays having negative strides', function test( t ) {
-	var expected;
-	var xbuf;
-	var ybuf;
-	var x;
-	var y;
-	var v;
-
-	xbuf = new Float32Array([
-		1.0,  // 2
-		-2.0,
-		3.0,  // 1
-		4.0,
-		-5.0  // 0
-	]);
-	x = vector( xbuf, 3, -2, 4 );
-
-	ybuf = new Float32Array([
-		0.0, // 2
-		0.0, // 1
-		0.0, // 0
-		0.0,
-		0.0
-	]);
-	y = vector( ybuf, 3, -1, 2 );
-
-	v = scuminabs( [ x, y ] );
-
-	expected = new Float32Array([
-		1.0,  // 2
-		3.0,  // 1
-		5.0,  // 0
-		0.0,
-		0.0
-	]);
-	t.strictEqual( v, y, 'returns expected value' );
-	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
-	t.end();
-});
-
-tape( 'the function supports one-dimensional ndarrays having non-zero offsets', function test( t ) {
-	var expected;
-	var xbuf;
-	var ybuf;
-	var x;
-	var y;
-	var v;
-
-	xbuf = new Float32Array([
-		2.0,
-		1.0,  // 0
-		2.0,
-		-2.0, // 1
-		-2.0,
-		2.0,  // 2
-		3.0,
-		4.0   // 3
-	]);
-	x = vector( xbuf, 4, 2, 1 );
-
-	ybuf = new Float32Array([
-		0.0,
-		0.0,
-		0.0,  // 0
-		0.0,  // 1
-		0.0,  // 2
-		0.0,  // 3
-		0.0,
-		0.0
-	]);
-	y = vector( ybuf, 4, 1, 2 );
-
-	v = scuminabs( [ x, y ] );
-
-	expected = new Float32Array([
-		0.0,
-		0.0,
-		1.0,   // 0
-		1.0,  // 1
-		1.0,  // 2
-		1.0,  // 3
-		0.0,
-		0.0
-	]);
-	t.strictEqual( v, y, 'returns expected value' );
-	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
-	t.end();
+	function tryRequire() {
+		return new Error( 'Cannot find module' );
+	}
 });

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/test/test.main.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/test/test.main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/test/test.main.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/test/test.main.js
@@ -1,0 +1,273 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isSameFloat32Array = require( '@stdlib/assert/is-same-float32array' );
+var Float32Array = require( '@stdlib/array/float32' );
+var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var zerosLike = require( '@stdlib/ndarray/zeros-like' );
+var getData = require( '@stdlib/ndarray/data-buffer' );
+var scuminabs = require( './../lib/main.js' );
+
+
+// FUNCTIONS //
+
+/**
+* Returns a one-dimensional ndarray.
+*
+* @private
+* @param {Float32Array} buffer - underlying data buffer
+* @param {NonNegativeInteger} length - number of indexed elements
+* @param {integer} stride - stride length
+* @param {NonNegativeInteger} offset - index offset
+* @returns {ndarray} one-dimensional ndarray
+*/
+function vector( buffer, length, stride, offset ) {
+	return new ndarray( 'float32', buffer, [ length ], [ stride ], offset, 'row-major' );
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof scuminabs, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 1', function test( t ) {
+	t.strictEqual( scuminabs.length, 1, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the cumulative minimum absolute value of a one-dimensional ndarray', function test( t ) {
+	var expected;
+	var xbuf;
+	var x;
+	var y;
+	var v;
+
+	xbuf = new Float32Array( [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0 ] );
+	x = vector( xbuf, 6, 1, 0 );
+	y = zerosLike( x );
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array( [ 1.0, 1.0, 1.0, 1.0, 0.0, 0.0 ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+
+	xbuf = new Float32Array( [ -4.0, -5.0 ] );
+	x = vector( xbuf, 2, 1, 0 );
+	y = zerosLike( x );
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array( [ 4.0, 4.0 ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+
+	xbuf = new Float32Array( [ -0.0, 0.0, -0.0 ] );
+	x = vector( xbuf, 3, 1, 0 );
+	y = zerosLike( x );
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array( [ 0.0, 0.0, 0.0 ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+
+	xbuf = new Float32Array( [ NaN ] );
+	x = vector( xbuf, 1, 1, 0 );
+	y = zerosLike( x );
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array( [ NaN ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+
+	xbuf = new Float32Array( [ NaN, NaN ] );
+	x = vector( xbuf, 2, 1, 0 );
+	y = zerosLike( x );
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array( [ NaN, NaN ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an empty ndarray, the function returns the output array unchanged', function test( t ) {
+	var expected;
+	var xbuf;
+	var x;
+	var y;
+	var v;
+
+	xbuf = new Float32Array( [] );
+	x = vector( xbuf, 0, 1, 0 );
+	y = zerosLike( x );
+
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array( [] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports one-dimensional ndarrays having non-unit strides', function test( t ) {
+	var expected;
+	var xbuf;
+	var ybuf;
+	var x;
+	var y;
+	var v;
+
+	xbuf = new Float32Array([
+		1.0,  // 0
+		2.0,
+		2.0,  // 1
+		-7.0,
+		-2.0, // 2
+		3.0,
+		4.0,  // 3
+		2.0
+	]);
+	x = vector( xbuf, 4, 2, 0 );
+
+	ybuf = new Float32Array([
+		0.0,  // 0
+		0.0,
+		0.0,  // 1
+		0.0,
+		0.0,  // 2
+		0.0,
+		0.0,  // 3
+		0.0
+	]);
+	y = vector( ybuf, 4, 2, 0 );
+
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array([
+		1.0,   // 0
+		0.0,
+		1.0,   // 1
+		0.0,
+		1.0,  // 2
+		0.0,
+		1.0,  // 3
+		0.0
+	]);
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports one-dimensional ndarrays having negative strides', function test( t ) {
+	var expected;
+	var xbuf;
+	var ybuf;
+	var x;
+	var y;
+	var v;
+
+	xbuf = new Float32Array([
+		1.0,  // 2
+		-2.0,
+		3.0,  // 1
+		4.0,
+		-5.0  // 0
+	]);
+	x = vector( xbuf, 3, -2, 4 );
+
+	ybuf = new Float32Array([
+		0.0, // 2
+		0.0, // 1
+		0.0, // 0
+		0.0,
+		0.0
+	]);
+	y = vector( ybuf, 3, -1, 2 );
+
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array([
+		1.0,  // 2
+		3.0,  // 1
+		5.0,  // 0
+		0.0,
+		0.0
+	]);
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports one-dimensional ndarrays having non-zero offsets', function test( t ) {
+	var expected;
+	var xbuf;
+	var ybuf;
+	var x;
+	var y;
+	var v;
+
+	xbuf = new Float32Array([
+		2.0,
+		1.0,  // 0
+		2.0,
+		-2.0, // 1
+		-2.0,
+		2.0,  // 2
+		3.0,
+		4.0   // 3
+	]);
+	x = vector( xbuf, 4, 2, 1 );
+
+	ybuf = new Float32Array([
+		0.0,
+		0.0,
+		0.0,  // 0
+		0.0,  // 1
+		0.0,  // 2
+		0.0,  // 3
+		0.0,
+		0.0
+	]);
+	y = vector( ybuf, 4, 1, 2 );
+
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array([
+		0.0,
+		0.0,
+		1.0,   // 0
+		1.0,  // 1
+		1.0,  // 2
+		1.0,  // 3
+		0.0,
+		0.0
+	]);
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scuminabs/test/test.native.js
@@ -1,0 +1,282 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isSameFloat32Array = require( '@stdlib/assert/is-same-float32array' );
+var Float32Array = require( '@stdlib/array/float32' );
+var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var zerosLike = require( '@stdlib/ndarray/zeros-like' );
+var getData = require( '@stdlib/ndarray/data-buffer' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var scuminabs = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( scuminabs instanceof Error )
+};
+
+
+// FUNCTIONS //
+
+/**
+* Returns a one-dimensional ndarray.
+*
+* @private
+* @param {Float32Array} buffer - underlying data buffer
+* @param {NonNegativeInteger} length - number of indexed elements
+* @param {integer} stride - stride length
+* @param {NonNegativeInteger} offset - index offset
+* @returns {ndarray} one-dimensional ndarray
+*/
+function vector( buffer, length, stride, offset ) {
+	return new ndarray( 'float32', buffer, [ length ], [ stride ], offset, 'row-major' );
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof scuminabs, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 1', opts, function test( t ) {
+	t.strictEqual( scuminabs.length, 1, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the cumulative minimum absolute value of a one-dimensional ndarray', opts, function test( t ) {
+	var expected;
+	var xbuf;
+	var x;
+	var y;
+	var v;
+
+	xbuf = new Float32Array( [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0 ] );
+	x = vector( xbuf, 6, 1, 0 );
+	y = zerosLike( x );
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array( [ 1.0, 1.0, 1.0, 1.0, 0.0, 0.0 ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+
+	xbuf = new Float32Array( [ -4.0, -5.0 ] );
+	x = vector( xbuf, 2, 1, 0 );
+	y = zerosLike( x );
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array( [ 4.0, 4.0 ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+
+	xbuf = new Float32Array( [ -0.0, 0.0, -0.0 ] );
+	x = vector( xbuf, 3, 1, 0 );
+	y = zerosLike( x );
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array( [ 0.0, 0.0, 0.0 ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+
+	xbuf = new Float32Array( [ NaN ] );
+	x = vector( xbuf, 1, 1, 0 );
+	y = zerosLike( x );
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array( [ NaN ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+
+	xbuf = new Float32Array( [ NaN, NaN ] );
+	x = vector( xbuf, 2, 1, 0 );
+	y = zerosLike( x );
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array( [ NaN, NaN ] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an empty ndarray, the function returns the output array unchanged', opts, function test( t ) {
+	var expected;
+	var xbuf;
+	var x;
+	var y;
+	var v;
+
+	xbuf = new Float32Array( [] );
+	x = vector( xbuf, 0, 1, 0 );
+	y = zerosLike( x );
+
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array( [] );
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports one-dimensional ndarrays having non-unit strides', opts, function test( t ) {
+	var expected;
+	var xbuf;
+	var ybuf;
+	var x;
+	var y;
+	var v;
+
+	xbuf = new Float32Array([
+		1.0,  // 0
+		2.0,
+		2.0,  // 1
+		-7.0,
+		-2.0, // 2
+		3.0,
+		4.0,  // 3
+		2.0
+	]);
+	x = vector( xbuf, 4, 2, 0 );
+
+	ybuf = new Float32Array([
+		0.0,  // 0
+		0.0,
+		0.0,  // 1
+		0.0,
+		0.0,  // 2
+		0.0,
+		0.0,  // 3
+		0.0
+	]);
+	y = vector( ybuf, 4, 2, 0 );
+
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array([
+		1.0,  // 0
+		0.0,
+		1.0,  // 1
+		0.0,
+		1.0,  // 2
+		0.0,
+		1.0,  // 3
+		0.0
+	]);
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports one-dimensional ndarrays having negative strides', opts, function test( t ) {
+	var expected;
+	var xbuf;
+	var ybuf;
+	var x;
+	var y;
+	var v;
+
+	xbuf = new Float32Array([
+		1.0,  // 2
+		-2.0,
+		3.0,  // 1
+		4.0,
+		-5.0  // 0
+	]);
+	x = vector( xbuf, 3, -2, 4 );
+
+	ybuf = new Float32Array([
+		0.0, // 2
+		0.0, // 1
+		0.0, // 0
+		0.0,
+		0.0
+	]);
+	y = vector( ybuf, 3, -1, 2 );
+
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array([
+		1.0,  // 2
+		3.0,  // 1
+		5.0,  // 0
+		0.0,
+		0.0
+	]);
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports one-dimensional ndarrays having non-zero offsets', opts, function test( t ) {
+	var expected;
+	var xbuf;
+	var ybuf;
+	var x;
+	var y;
+	var v;
+
+	xbuf = new Float32Array([
+		2.0,
+		1.0,  // 0
+		2.0,
+		-2.0, // 1
+		-2.0,
+		2.0,  // 2
+		3.0,
+		4.0   // 3
+	]);
+	x = vector( xbuf, 4, 2, 1 );
+
+	ybuf = new Float32Array([
+		0.0,
+		0.0,
+		0.0,  // 0
+		0.0,  // 1
+		0.0,  // 2
+		0.0,  // 3
+		0.0,
+		0.0
+	]);
+	y = vector( ybuf, 4, 1, 2 );
+
+	v = scuminabs( [ x, y ] );
+
+	expected = new Float32Array([
+		0.0,
+		0.0,
+		1.0,  // 0
+		1.0,  // 1
+		1.0,  // 2
+		1.0,  // 3
+		0.0,
+		0.0
+	]);
+	t.strictEqual( v, y, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves a part of #14034 

## Description

> What is the purpose of this pull request?

This pull request:

-   adds a native C implementation for computing the cumulative minimum absolute value of a one-dimensional single-precision floating-point ndarray (`scuminabs`).
-   updates the test suite (`test.js`, `test.main.js`, `test.native.js`) and benchmarks to cover and utilize the new native C addon.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #14034 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I consulted an AI assistant to help research the `stdlib` N-API architecture, understand the `ndarray` logic, and to structure and generate the test files (`test.main.js`, `test.native.js`) and benchmark files required to test the native C addon. The core logic and implementation were authored manually by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
