### PR TITLE
test: migrate `stats/incr/mmeanabs2` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/mmeanabs2/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/mmeanabs2/test/test.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var incrmmeanabs2 = require( './../lib' );
 
 
@@ -73,10 +72,8 @@ tape( 'the function returns an accumulator function', function test( t ) {
 tape( 'the accumulator function computes a moving arithmetic mean of squared absolute values incrementally', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
 	var acc;
-	var tol;
 	var N;
 	var i;
 
@@ -88,13 +85,7 @@ tape( 'the accumulator function computes a moving arithmetic mean of squared abs
 	expected = [ 4.0, 6.5, 17.0/3.0, 29.0/3.0, 29.0/3.0, 41.0/3.0 ];
 	for ( i = 0; i < N; i++ ) {
 		actual = acc( data[ i ] );
-		if ( actual === expected[i] ) {
-			t.strictEqual( actual, expected[i], 'returns expected value' );
-		} else {
-			delta = abs( expected[i] - actual );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+actual+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/incr/mmeanabs2` from a computed relative-tolerance comparison (`delta = abs( expected - actual )` / `tol = 1.0 * EPS * abs( expected )`, asserted via `t.strictEqual( delta <= tol, ... )`) to a ULP-difference assertion using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to the single tolerance-based assertion site in `test/test.js`. The package has no `test/test.native.js`. The remaining assertions in the file are exact comparisons against `null`, thrown `TypeError`s, function types, `NaN`, and the exactly representable values `17.0` and `9.8596`, which are correct as-is and are left unchanged.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires, along with the `delta` and `tol` variable declarations.
-   collapses the `if ( actual === expected[i] ) { ... } else { ... }` branch in the moving-mean-of-squared-absolute-values test into a single ULP assertion, matching the migrated idiom.

Only a test file is changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| Assertion | Previous tolerance | ULP bound |
| --- | --- | :-: |
| moving arithmetic mean of squared absolute values computed incrementally (6 values) | `1.0 * EPS * abs( expected )` | `1` |

This is the minimum integer bound `N` such that `isAlmostSameValue( actual, expected[ i ], N )` holds at every element of the fixture. It was measured by starting from a high bound (`64`, which passes) and tightening, computing the per-element ULP distance directly outside the test harness and then confirming through the test suite: at `N = 1` the suite is 41/41 passing, and at `N = 0` three assertions fail (38/41), so no tighter bound exists.

The per-element ULP differences are `0, 0, 0, 1, 1, 1`. The first three expected values (`4.0`, `6.5`, `17.0/3.0`) are reproduced bit-for-bit, while the last three (`29.0/3.0`, `29.0/3.0`, `41.0/3.0`) differ by one ULP: the accumulator computes the window mean incrementally rather than as a single division, so it returns `9.666666666666668` where the literal expression `29.0/3.0` rounds to `9.666666666666666`. The original test anticipated this by branching on `actual === expected[i]` and falling back to a relative tolerance for the inexact cases.

`make test TESTS_FILTER=".*/stats/incr/mmeanabs2/.*"` was run twice at the final bound with identical results: 41/41 passing on both runs, no failures, ruling out FMA/architecture-dependent flakiness on this platform. `make eslint-tests TESTS_FILTER=".*/stats/incr/mmeanabs2/.*"` is clean.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The resulting diff mirrors the already-merged migrations for the sibling accumulator packages `stats/incr/mmape` (#15150), `stats/incr/mda` (#15142), and `stats/incr/nanmrss` (#15166), which share the same test structure.

Two environment notes, neither of which affected verification:

-   `make install-node-modules` initially failed with `ETARGET` for `es-object-atoms@^1.1.2`. The version does exist in the registry (published 2026-05-22); the local npm packument cache was stale and served a filtered view. After `npm cache clean --force`, the install completed and the full toolchain was available for this PR.
-   The `pre-commit` hook's `lint-editorconfig-files` step could not run, because it downloads the `editorconfig-checker` binary from a GitHub release that this environment cannot reach. The changed file was instead checked manually against `.editorconfig`: LF line endings, tab indentation, no trailing whitespace, and a final newline.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously migrated packages in the same family to match the established idiom, performed the migration, and determined the minimum passing ULP bound empirically at the assertion site.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhctBo3ZhP4kbZgXCWBZ7a

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhctBo3ZhP4kbZgXCWBZ7a)_