### PR TITLE
test: migrate `stats/base/dists/uniform/mgf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mgf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mgf/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -125,9 +124,7 @@ tape( 'if provided valid parameters `a` and `b`, the created function returns `1
 
 tape( 'the created function evaluates the MGF for `x` given small range `b - a`', function test( t ) {
 	var expected;
-	var delta;
 	var mgf;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -142,13 +139,7 @@ tape( 'the created function evaluates the MGF for `x` given small range `b - a`'
 		mgf = factory( a[i], b[i] );
 		y = mgf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 550.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 600 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -156,9 +147,7 @@ tape( 'the created function evaluates the MGF for `x` given small range `b - a`'
 
 tape( 'the created function evaluates the MGF for `x` given a medium range `b - a`', function test( t ) {
 	var expected;
-	var delta;
 	var mgf;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -173,13 +162,7 @@ tape( 'the created function evaluates the MGF for `x` given a medium range `b - 
 		mgf = factory( a[i], b[i] );
 		y = mgf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 300.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 355 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -187,9 +170,7 @@ tape( 'the created function evaluates the MGF for `x` given a medium range `b - 
 
 tape( 'the created function evaluates the MGF for `x` given a large range `b - a`', function test( t ) {
 	var expected;
-	var delta;
 	var mgf;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -204,13 +185,7 @@ tape( 'the created function evaluates the MGF for `x` given a large range `b - a
 		mgf = factory( a[i], b[i] );
 		y = mgf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 400.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 519 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mgf/test/test.mgf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mgf/test/test.mgf.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mgf = require( './../lib' );
 
 
@@ -89,8 +88,6 @@ tape( 'if provided valid parameters, the function returns `1` for `t = 0`', func
 
 tape( 'the function evaluates the mgf for `x` given a small range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -104,13 +101,7 @@ tape( 'the function evaluates the mgf for `x` given a small range `b - a`', func
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], a[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 550.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 600 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -118,8 +109,6 @@ tape( 'the function evaluates the mgf for `x` given a small range `b - a`', func
 
 tape( 'the function evaluates the mgf for `x` given a medium range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -133,13 +122,7 @@ tape( 'the function evaluates the mgf for `x` given a medium range `b - a`', fun
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], a[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 300.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 355 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -147,8 +130,6 @@ tape( 'the function evaluates the mgf for `x` given a medium range `b - a`', fun
 
 tape( 'the function evaluates the mgf for `x` given a large range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -162,13 +143,7 @@ tape( 'the function evaluates the mgf for `x` given a large range `b - a`', func
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], a[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 400.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 519 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mgf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mgf/test/test.native.js
@@ -24,10 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -98,8 +97,6 @@ tape( 'if provided valid parameters, the function returns `1` for `t = 0`', opts
 
 tape( 'the function evaluates the mgf for `x` given a small range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -113,13 +110,7 @@ tape( 'the function evaluates the mgf for `x` given a small range `b - a`', opts
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], a[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 550.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 600 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -127,8 +118,6 @@ tape( 'the function evaluates the mgf for `x` given a small range `b - a`', opts
 
 tape( 'the function evaluates the mgf for `x` given a medium range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -142,13 +131,7 @@ tape( 'the function evaluates the mgf for `x` given a medium range `b - a`', opt
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], a[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 300.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 355 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -156,8 +139,6 @@ tape( 'the function evaluates the mgf for `x` given a medium range `b - a`', opt
 
 tape( 'the function evaluates the mgf for `x` given a large range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -171,13 +152,7 @@ tape( 'the function evaluates the mgf for `x` given a large range `b - a`', opts
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], a[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 400.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 519 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352 

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for stats/base/dists/exponential/pdf from relative tolerance (EPS/delta/tol) assertions to ULP difference assertions using @stdlib/assert/is-almost-same-value.
updates test/test.pdf.js, test/test.factory.js, and test/test.native.js. No other files are changed.
removes the now-unused EPS and abs imports and the corresponding delta/tol variable declarations from each file.
the ULP bound was verified directly against the fixture data using a script that computes the actual ULP distance between computed and expected values for every input across all four fixtures. Verified minimums (identical across JS and native): smallRange=600, mediumRange=355, largeRange=519.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
