### PR TITLE
test: migrate `simulate/iter/flat-top-pulse` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/simulate/iter/flat-top-pulse/test/test.js
+++ b/lib/node_modules/@stdlib/simulate/iter/flat-top-pulse/test/test.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var proxyquire = require( 'proxyquire' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var iteratorSymbol = require( '@stdlib/symbol/iterator' );
 var cospi = require( '@stdlib/math/base/special/cospi' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var iterFlatTopPulse = require( './../lib' );
 
 
@@ -160,8 +159,6 @@ tape( 'the function throws an error if provided a pulse duration which is less t
 tape( 'the function returns an iterator protocol-compliant object which generates a "flat top" pulse waveform', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var phi;
 	var tau;
 	var it;
@@ -190,13 +187,7 @@ tape( 'the function returns an iterator protocol-compliant object which generate
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -204,9 +195,7 @@ tape( 'the function returns an iterator protocol-compliant object which generate
 tape( 'the function supports specifying the pulse period', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var phi;
 	var tau;
 	var it;
@@ -238,13 +227,7 @@ tape( 'the function supports specifying the pulse period', function test( t ) {
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -252,9 +235,7 @@ tape( 'the function supports specifying the pulse period', function test( t ) {
 tape( 'the function supports specifying the pulse duration', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var phi;
 	var tau;
 	var it;
@@ -294,13 +275,7 @@ tape( 'the function supports specifying the pulse duration', function test( t ) 
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -308,9 +283,7 @@ tape( 'the function supports specifying the pulse duration', function test( t ) 
 tape( 'the function supports specifying the waveform amplitude', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var phi;
 	var tau;
 	var it;
@@ -351,13 +324,7 @@ tape( 'the function supports specifying the waveform amplitude', function test( 
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -365,9 +332,7 @@ tape( 'the function supports specifying the waveform amplitude', function test( 
 tape( 'the function supports specifying the phase offset (left shift)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var phi;
 	var tau;
 	var it;
@@ -408,13 +373,7 @@ tape( 'the function supports specifying the phase offset (left shift)', function
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -422,9 +381,7 @@ tape( 'the function supports specifying the phase offset (left shift)', function
 tape( 'the function supports specifying the phase offset (left shift; mod)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var phi;
 	var tau;
 	var it;
@@ -468,13 +425,7 @@ tape( 'the function supports specifying the phase offset (left shift; mod)', fun
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -482,9 +433,7 @@ tape( 'the function supports specifying the phase offset (left shift; mod)', fun
 tape( 'the function supports specifying the phase offset (right shift)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var phi;
 	var tau;
 	var it;
@@ -528,13 +477,7 @@ tape( 'the function supports specifying the phase offset (right shift)', functio
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -542,9 +485,7 @@ tape( 'the function supports specifying the phase offset (right shift)', functio
 tape( 'the function supports specifying the phase offset (right shift; mod)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var phi;
 	var tau;
 	var it;
@@ -588,13 +529,7 @@ tape( 'the function supports specifying the phase offset (right shift; mod)', fu
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -602,9 +537,7 @@ tape( 'the function supports specifying the phase offset (right shift; mod)', fu
 tape( 'the function supports limiting the number of iterations', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
 	var tau;
 	var it;
 	var A;
@@ -633,13 +566,7 @@ tape( 'the function supports limiting the number of iterations', function test( 
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, 0 ), true, 'returns expected value' );
 	}
 	actual = it.next();
 	t.strictEqual( actual.value, void 0, 'returns expected value' );


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `simulate/iter/flat-top-pulse` from a computed relative-tolerance comparison (`delta = abs( actual.value - expected[ i ].value )` / `tol = 1.0 * EPS * abs( expected[ i ].value )`, asserted via `t.strictEqual( delta <= tol, ... )`) to a ULP-difference assertion using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to all nine tolerance-based assertion sites in `test/test.js`: the base waveform test, the pulse period, pulse duration, and waveform amplitude tests, the four phase offset tests (left/right shift, with and without `mod`), and the iteration limit test. The package has no `test/test.native.js`.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires, along with the `delta` and `tol` variable declarations.
-   collapses each `if ( actual.value === expected[ i ].value ) { ... } else { ... }` branch into a single ULP assertion, matching the migrated idiom.

Only a test file is changed; no implementation, fixture, or documentation changes are included. The remaining assertions in the file (thrown `TypeError`s, `done` flags, arity, `return` method behavior, and `Symbol.iterator` support) are exact comparisons which are correct as-is and are left unchanged.

### ULP bounds

| Assertion | Previous tolerance | ULP bound |
| --- | --- | :-: |
| generates a "flat top" pulse waveform (200 values) | `1.0 * EPS * abs( expected )` | `0` |
| supports specifying the pulse period (200 values) | `1.0 * EPS * abs( expected )` | `0` |
| supports specifying the pulse duration (200 values) | `1.0 * EPS * abs( expected )` | `0` |
| supports specifying the waveform amplitude (200 values) | `1.0 * EPS * abs( expected )` | `0` |
| supports specifying the phase offset (left shift) (200 values) | `1.0 * EPS * abs( expected )` | `0` |
| supports specifying the phase offset (left shift; mod) (200 values) | `1.0 * EPS * abs( expected )` | `0` |
| supports specifying the phase offset (right shift) (200 values) | `1.0 * EPS * abs( expected )` | `0` |
| supports specifying the phase offset (right shift; mod) (200 values) | `1.0 * EPS * abs( expected )` | `0` |
| supports limiting the number of iterations (4 values) | `1.0 * EPS * abs( expected )` | `0` |

`0` is the minimum integer bound `N` such that `isAlmostSameValue( actual.value, expected[ i ].value, N )` holds at every compared element. It was measured by starting from a high bound and tightening: the suite was run at `N = 64, 32, 16, 8, 4, 2, 1, 0`, and all of them pass with zero failures, so `0` is the floor. Every value the iterator returns is reproduced bit-for-bit by the in-test `flatTop` reference, which applies the same coefficients and the same `cospi` calls in the same order, so no rounding divergence arises. The original test anticipated a possible divergence by branching on `actual.value === expected[ i ].value` and falling back to a relative tolerance, but that fallback branch is not exercised here.

To confirm that the bound is not vacuous at `0`, `isAlmostSameValue` was checked directly at this magnitude: `isAlmostSameValue( 0.21557895, 0.21557895000000005, 0 )` returns `false`, i.e. the assertion still fails on a value that differs in the last place. The migrated file reports the same 3281 assertions as before the change, so no assertion was dropped in the conversion.

`make test TESTS_FILTER=".*/simulate/iter/flat-top-pulse/.*"` was run twice at the final bound with identical results: 3281/3281 passing on both runs, no failures, ruling out FMA/architecture-dependent flakiness on this platform. ESLint with `etc/eslint/.eslintrc.tests.js` is clean on the changed file.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The resulting diff mirrors the already-merged migrations for the sibling waveform packages `simulate/iter/sawtooth-wave` (#15109) and `simulate/iter/bartlett-hann-pulse` (#14614), which share the same test structure and also settled on a ULP bound of `0`.

Two environment notes, neither of which affected verification:

-   `make install-node-modules` initially failed with `ETARGET` for `es-object-atoms@^1.1.2`. The version does exist in the registry; the local npm packument cache was stale and served a filtered view. After `npm cache clean --force`, the install completed and the full toolchain was available for this PR.
-   The `pre-commit` hook's `lint-editorconfig-files` step could not run, because it downloads the `editorconfig-checker` binary from a GitHub release that this environment cannot reach. The changed file was instead checked manually against `.editorconfig`: LF line endings, tab indentation, no trailing whitespace, and a final newline.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously migrated packages in the same family to match the established idiom, performed the migration, and determined the minimum passing ULP bound empirically at each assertion site.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kz58bM9SE3bSeYcDrs3cTA


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz58bM9SE3bSeYcDrs3cTA)_