### PR TITLE
chore: fix JavaScript lint errors (issue #15176)

### DIFF
--- a/lib/node_modules/@stdlib/array/float16/benchmark/polyfill/benchmark.find_last_index.length.js
+++ b/lib/node_modules/@stdlib/array/float16/benchmark/polyfill/benchmark.find_last_index.length.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable stdlib/jsdoc-typedef-typos */
-
 'use strict';
 
 // MODULES //


### PR DESCRIPTION
Resolves #15176.

## Description

This pull request:

-   Removes the unused `stdlib/jsdoc-typedef-typos` disable directive reported by the JavaScript lint workflow.

## Related Issues

This pull request has the following related issues:

-   #15176

## Questions

No.

## Other

Verified the benchmark file with `node --check`.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation
-   [ ] Test/benchmark generation
-   [ ] Documentation
-   [x] Research and understanding

#### Disclosure

I used Codex to locate the automated lint failure, remove the reported unused directive, and verify the resulting file's syntax.

* * *

@stdlib-js/reviewers
