### PR TITLE
test: migrate `stats/base/dists/chi/cdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chi/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/cdf/test/test.cdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( './../lib' );
 
 
@@ -103,8 +102,6 @@ tape( 'if provided a `k` equal to `0`, the function evaluates a degenerate distr
 
 tape( 'the function evaluates the cdf for `x` given degrees of freedom `k`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var k;
 	var y;
@@ -115,13 +112,7 @@ tape( 'the function evaluates the cdf for `x` given degrees of freedom `k`', fun
 	k = decimalDecimal.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 70.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 122 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/cdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -129,9 +128,7 @@ tape( 'if `k` equals `0`, the created function evaluates a degenerate distributi
 
 tape( 'the created function evaluates the cdf for `x` given degrees of freedom `k`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var x;
 	var k;
 	var y;
@@ -143,13 +140,7 @@ tape( 'the created function evaluates the cdf for `x` given degrees of freedom `
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( k[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 70.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 122 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/cdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -116,8 +115,6 @@ tape( 'if provided `+infinity` for `x` and a finite positive `k`, the function r
 
 tape( 'the function evaluates the cdf for `x` given parameter `k`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var k;
 	var y;
@@ -128,13 +125,7 @@ tape( 'the function evaluates the cdf for `x` given parameter `k`', opts, functi
 	k = data.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 70.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 122 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/chi/cdf` from computed relative-tolerance comparisons (`delta = abs( y - expected[ i ] )` / `tol = 70.0 * EPS * abs( expected[ i ] )`, asserted via `t.ok( delta <= tol, ... )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to the three tolerance-based assertion sites in the package: one each in `test/test.cdf.js`, `test/test.factory.js`, and `test/test.native.js`. All three iterate over the same 5000-point `test/fixtures/julia/decimal_decimal.json` fixture.
-   collapses the `if ( y === expected[i] ) { ... } else { ... }` branch at each site into a single ULP assertion, and standardizes the assertion message to `'returns expected value'`.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires and the `delta` and `tol` variable declarations.

The remaining assertions in these files are exact comparisons (`NaN` propagation, `0.0`/`1.0` at the support boundaries, the degenerate `k = 0` case, and function types), which are correct as-is and are left unchanged. `test/test.js` contains only export-shape assertions and is unchanged.

Only test files are changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| File | Implementation | Previous tolerance | ULP bound |
| --- | --- | --- | :-: |
| `test/test.cdf.js` | JavaScript, main export | `70.0 * EPS * abs( expected )` | `122` |
| `test/test.factory.js` | JavaScript, `factory` | `70.0 * EPS * abs( expected )` | `122` |
| `test/test.native.js` | C | `70.0 * EPS * abs( expected )` | `122` |

`122` is the minimum integer bound `N` such that `isAlmostSameValue( y, expected[ i ], N )` holds at every element of the fixture. It was determined by computing the per-element ULP distance directly outside the test harness over the full 5000-point fixture (maximum: `122`) and then confirming the result through the test suite: at `N = 122` the suite is fully passing (5015 + 5015 + 3 + 5014 assertions across the four test files), and at `N = 121` an assertion fails, so no tighter bound exists.

Of the 5000 fixture points, 4089 are reproduced bit-for-bit and 911 differ from the Julia reference. The worst case is `x = 0.038000735490419935`, `k = 18.09784470239629`, where the expected value is `9.233298267696655e-35` and both implementations return `9.233298267696786e-35`. That is a relative error of roughly `1.4e-14`, accumulated in the lower incomplete gamma evaluation in the far lower tail of the CDF; the previous `70.0 * EPS` relative tolerance permitted roughly `1.6e-14`, so the new bound is slightly tighter than the tolerance it replaces rather than a loosening of the existing test.

The JavaScript and C implementations agree bit-for-bit at every fixture point, including the worst case, so all three files share the same bound.

`make test TESTS_FILTER=".*/stats/base/dists/chi/cdf/.*"` was run twice at the final bound with identical results on both runs, ruling out FMA/architecture-dependent flakiness on this platform. The native add-on was built locally (`node-gyp rebuild`) so that `test.native.js` actually executed rather than being skipped; its 5014 assertions pass. `make eslint-tests TESTS_FILTER=".*/stats/base/dists/chi/cdf/.*"` is clean, as is `make lint-license-headers-files` for the changed files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

-   Is a `122` ULP bound acceptable for this package? It is the measured minimum and is tighter than the tolerance it replaces, but it is much larger than the single-digit bounds typical of the already-migrated sibling packages, because of the far-tail fixture points noted above.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The resulting diff mirrors the already-merged migrations for the sibling distribution packages `stats/base/dists/chisquare/logpdf` (#15121), `stats/base/dists/bradford/pdf` (#15153), and `stats/base/dists/triangular/cdf` (#15112), which share the same test structure.

Two environment notes, neither of which affected verification:

-   `make install-node-modules` initially failed with `ETARGET` for `es-object-atoms@^1.1.2`. The local npm packument cache was stale and served a filtered view of the registry; after `npm cache clean --force`, the install and `make init` completed and the full toolchain was available for this PR.
-   The `pre-commit` hook's `lint-editorconfig-files` step could not run, because it downloads the `editorconfig-checker` binary from a GitHub release that this environment cannot reach. The changed files were instead checked manually against `.editorconfig`: LF line endings, tab indentation, no trailing whitespace, and a final newline.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously migrated packages in the same family to match the established idiom, performed the migration, and determined the minimum passing ULP bound empirically over the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cVyuyAYcEBqNmEw7csWD5


---
_Generated by [Claude Code](https://claude.ai/code/session_019cVyuyAYcEBqNmEw7csWD5)_