### PR TITLE
chore: fix JavaScript lint errors (issue #15176)

### DIFF
--- a/lib/node_modules/@stdlib/array/float16/benchmark/polyfill/benchmark.find_last_index.length.js
+++ b/lib/node_modules/@stdlib/array/float16/benchmark/polyfill/benchmark.find_last_index.length.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable stdlib/jsdoc-typedef-typos */
-
 'use strict';
 
 // MODULES //


### PR DESCRIPTION
Resolves #15176.

## Description

> What is the purpose of this pull request?

This pull request:

- Removed the unused `/* eslint-disable stdlib/jsdoc-typedef-typos */` directive in `benchmark.find_last_index.length.js`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- #15176

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I consulted AI assistance to understand the lint error and the contribution workflow, but the proposed code changes were fully authored manually by myself.


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
