### PR TITLE
test: migrate `stats/base/dists/beta/kurtosis` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/beta/kurtosis/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/kurtosis/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var kurtosis = require( './../lib' );
 
 
@@ -96,10 +95,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the excess kurtosis of a beta distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -108,13 +105,7 @@ tape( 'the function returns the excess kurtosis of a beta distribution', functio
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = kurtosis( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/kurtosis/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/kurtosis/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -105,10 +104,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 
 tape( 'the function returns the excess kurtosis of a beta distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -117,13 +114,7 @@ tape( 'the function returns the excess kurtosis of a beta distribution', opts, f
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = kurtosis( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/beta/kurtosis` from computed relative-tolerance comparisons (`delta = abs( y - expected[ i ] )` / `tol = 1.0 * EPS * abs( expected[ i ] )`, asserted via `t.ok( delta <= tol, ... )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to the two tolerance-based assertion sites in the package: one in `test/test.js` (JavaScript implementation) and one in `test/test.native.js` (C implementation). Both iterate over the same 1000-point `test/fixtures/julia/data.json` fixture.
-   collapses the `if ( y === expected[i] ) { ... } else { ... }` branch at each site into a single ULP assertion, and standardizes the assertion message to `'returns expected value'`.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires and the `delta` and `tol` variable declarations.

The remaining assertions in these files are exact comparisons (`NaN` propagation for `NaN`, non-positive, and infinite parameters, along with function type checks), which are correct as-is and are left unchanged.

Only test files are changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| File | Implementation | Previous tolerance | ULP bound |
| --- | --- | --- | :-: |
| `test/test.js` | JavaScript, main export | `1.0 * EPS * abs( expected )` | `0` |
| `test/test.native.js` | C | `2.0 * EPS * abs( expected )` | `0` |

`0` is the minimum bound `N` such that `isAlmostSameValue( y, expected[ i ], N ) === true` at every element of the fixture, and is thus the tightest bound possible. It was determined by computing the per-element ULP distance directly outside the test harness over the full 1000-point fixture: every fixture point is reproduced bit-for-bit by both implementations, so the maximum ULP distance is `0` for each. The previous relative tolerances (`1.0 * EPS` and `2.0 * EPS`) permitted a non-exact result, so the new bound is tighter than the tolerance it replaces rather than a loosening of the existing test.

The excess kurtosis is evaluated as a short sequence of multiplications, additions, and a single division, and the JavaScript and C implementations perform those operations in the same order, which is why both agree exactly with the Julia reference across the fixture.

`make test TESTS_FILTER=".*/stats/base/dists/beta/kurtosis/.*"` was run twice at the final bound with identical results on both runs (1014 assertions in each of the two test files, 2028 in total, no failures and no skips), ruling out FMA/architecture-dependent flakiness on this platform. The native add-on was built locally (`node-gyp rebuild`) so that `test.native.js` actually executed rather than being skipped. `make eslint-tests TESTS_FILTER=".*/stats/base/dists/beta/kurtosis/.*"` is clean, as is `make lint-license-headers-files` for the changed files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The resulting diff mirrors the already-merged migrations for the sibling distribution packages `stats/base/dists/beta/skewness`, `stats/base/dists/beta/variance`, and `stats/base/dists/beta/stdev`, which share the same test structure and, in the first two cases, the same `0` ULP bound.

Two environment notes, neither of which affected verification:

-   `make install-node-modules` initially failed with `ETARGET` for `es-object-atoms@^1.1.2`. The local npm packument cache was stale and served a filtered view of the registry; after `npm cache clean --force`, the install and `make init` completed and the full toolchain was available for this PR.
-   The `pre-commit` hook's `lint-editorconfig-files` step could not run, because it downloads the `editorconfig-checker` binary from a GitHub release that this environment cannot reach. The changed files were instead checked manually against `.editorconfig`: LF line endings, tab indentation, no trailing whitespace, and a final newline.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously migrated packages in the same family to match the established idiom, performed the migration, and determined the minimum passing ULP bound empirically over the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pww2eTE6dBtB2G1jEpVDr


---
_Generated by [Claude Code](https://claude.ai/code/session_018pww2eTE6dBtB2G1jEpVDr)_