### PR TITLE
feat: add float16 dtype support to `ndarray/empty`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/empty/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/empty/benchmark/benchmark.js
@@ -87,6 +87,26 @@ bench( format( '%s:dtype=float32', pkg ), function benchmark( b ) {
 	b.end();
 });
 
+bench( format( '%s:dtype=float16', pkg ), function benchmark( b ) {
+	var arr;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = empty( [ 0 ], {
+			'dtype': 'float16'
+		});
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( arr ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
 bench( format( '%s:dtype=complex128', pkg ), function benchmark( b ) {
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/ndarray/empty/benchmark/benchmark.size.float16.js
+++ b/lib/node_modules/@stdlib/ndarray/empty/benchmark/benchmark.size.float16.js
@@ -1,0 +1,99 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var empty = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var opts;
+		var arr;
+		var i;
+
+		opts = {
+			'dtype': 'float16'
+		};
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = empty( [ len ], opts );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:dtype=float16,size=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/empty/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/empty/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { Shape, Order, Mode, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, boolndarray, complex128ndarray, complex64ndarray, genericndarray, DataType, Float64DataType, Float32DataType, Complex128DataType, Complex64DataType, Int32DataType, Int16DataType, Int8DataType, Uint32DataType, Uint16DataType, Uint8DataType, Uint8cDataType, BooleanDataType, GenericDataType } from '@stdlib/types/ndarray';
+import { Shape, Order, Mode, typedndarray, float64ndarray, float32ndarray, float16ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, boolndarray, complex128ndarray, complex64ndarray, genericndarray, DataType, Float64DataType, Float32DataType, Float16DataType, Complex128DataType, Complex64DataType, Int32DataType, Int16DataType, Int8DataType, Uint32DataType, Uint16DataType, Uint8DataType, Uint8cDataType, BooleanDataType, GenericDataType } from '@stdlib/types/ndarray';
 
 /**
 * Interface describing function options.
@@ -72,6 +72,20 @@ interface Float32Options extends Options {
 	* -   This option overrides the input array's inferred data type.
 	*/
 	dtype: Float32DataType;
+}
+
+/**
+* Interface describing function options.
+*/
+interface Float16Options extends Options {
+	/**
+	* Underlying data type.
+	*
+	* ## Notes
+	*
+	* -   This option overrides the input array's inferred data type.
+	*/
+	dtype: Float16DataType;
 }
 
 /**
@@ -297,6 +311,34 @@ declare function empty( shape: Shape | number, options: Float64Options ): float6
 * // returns 'float32'
 */
 declare function empty( shape: Shape | number, options: Float32Options ): float32ndarray;
+
+/**
+* Creates an uninitialized array having a specified shape and data type.
+*
+* @param shape - array shape
+* @param options - options
+* @param options.dtype - underlying data type
+* @param options.order - specifies whether an array is row-major (C-style) or column-major (Fortran-style) (default: 'row-major')
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @returns output array
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+*
+* var arr = empty( [ 2, 2 ], {
+*     'dtype': 'float16'
+* });
+* // returns <ndarray>
+*
+* var sh = getShape( arr );
+* // returns [ 2, 2 ]
+*
+* var dt = String( getDType( arr ) );
+* // returns 'float16'
+*/
+declare function empty( shape: Shape | number, options: Float16Options ): float16ndarray;
 
 /**
 * Creates an uninitialized array having a specified shape and data type.

--- a/lib/node_modules/@stdlib/ndarray/empty/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/empty/docs/types/test.ts
@@ -27,6 +27,7 @@ import empty = require( './index' );
 
 	empty( [ 2, 2 ], { 'dtype': 'float64' } ); // $ExpectType float64ndarray
 	empty( [ 2, 2 ], { 'dtype': 'float32' } ); // $ExpectType float32ndarray
+	empty( [ 2, 2 ], { 'dtype': 'float16' } ); // $ExpectType float16ndarray
 	empty( [ 2, 2 ], { 'dtype': 'complex128' } ); // $ExpectType complex128ndarray
 	empty( [ 2, 2 ], { 'dtype': 'complex64' } ); // $ExpectType complex64ndarray
 	empty( [ 2, 2 ], { 'dtype': 'int32' } ); // $ExpectType int32ndarray

--- a/lib/node_modules/@stdlib/ndarray/empty/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/empty/test/test.js
@@ -23,6 +23,7 @@
 var tape = require( 'tape' );
 var Float64Array = require( '@stdlib/array/float64' );
 var Float32Array = require( '@stdlib/array/float32' );
+var Float16Array = require( '@stdlib/array/float16' );
 var Int32Array = require( '@stdlib/array/int32' );
 var Uint32Array = require( '@stdlib/array/uint32' );
 var Int16Array = require( '@stdlib/array/int16' );
@@ -406,6 +407,42 @@ tape( 'the function returns an uninitialized array (dtype=float32, order=column-
 	t.strictEqual( String( getDType( arr ) ), opts.dtype, 'returns expected value' );
 	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( getData( arr ), Float32Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), opts.order, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns an uninitialized array (dtype=float16, order=row-major)', function test( t ) {
+	var opts;
+	var arr;
+
+	opts = {
+		'dtype': 'float16',
+		'order': 'row-major'
+	};
+	arr = empty( [ 2, 2 ], opts );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), opts.dtype, 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float16Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), opts.order, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns an uninitialized array (dtype=float16, order=column-major)', function test( t ) {
+	var opts;
+	var arr;
+
+	opts = {
+		'dtype': 'float16',
+		'order': 'column-major'
+	};
+	arr = empty( [ 2, 2 ], opts );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), opts.dtype, 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float16Array ), true, 'returns expected value' );
 	t.strictEqual( getOrder( arr ), opts.order, 'returns expected value' );
 
 	t.end();


### PR DESCRIPTION
Progresses  #14240

## Description

> What is the purpose of this pull request?

This pull request:

-   add float16 dtype support to `ndarray/empty`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #14240

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
