### PR TITLE
test: migrate `stats/base/dists/weibull/median` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/median/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/median/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var median = require( './../lib' );
 
 
@@ -97,8 +96,6 @@ tape( 'if provided `lambda <= 0`, the function returns `NaN`', function test( t 
 tape( 'the function returns the median of a Weibull distribution', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -108,13 +105,7 @@ tape( 'the function returns the median of a Weibull distribution', function test
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = median( k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/median/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/median/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -106,8 +105,6 @@ tape( 'if provided `lambda <= 0`, the function returns `NaN`', opts, function te
 tape( 'the function returns the median of a Weibull distribution', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -117,13 +114,7 @@ tape( 'the function returns the median of a Weibull distribution', opts, functio
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = median( k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `stats/base/dists/weibull/median` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`.
-   replaces the `if ( y === expected[i] ) {...} else { delta = abs(...); tol = 1.0*EPS*abs(...); t.ok( delta <= tol, ... ) }` branch with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' )`.
-   removes the now-unused `abs` and `EPS` requires.
-   the ULP bound was found by measuring the actual ULP difference between `median()` output and the fixture-expected values (`@stdlib/number/float64/base/ulp-difference`) across all 1000 fixtures; the observed difference was 0 ULPs for every fixture (the JS implementation reproduces the fixture values exactly), so both the JavaScript and native ULP bounds are set to 0. The full suite (1014 assertions) was run twice at this bound to confirm deterministic results.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was generated autonomously by a scheduled Claude Code session, which searched the codebase for the old EPS/tolerance test idiom, selected this package, studied prior-art ULP-migration PRs in the same package family (`stats/base/dists/weibull/mean`, `stats/base/dists/rayleigh/*`), converted the tests, and empirically determined the tightest ULP bound.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERjBuh2SKRECQghKUtxJVh

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERjBuh2SKRECQghKUtxJVh)_