### PR TITLE
test: migrate `stats/base/dists/chi/mean` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chi/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/mean/test/test.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mean = require( './../lib' );
 
 
@@ -61,8 +60,6 @@ tape( 'if provided a degrees of freedom parameter `k` that is not a nonnegative 
 
 tape( 'the function returns the expected value of a chi distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -71,13 +68,7 @@ tape( 'the function returns the expected value of a chi distribution', function 
 	k = data.k;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = mean( k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/mean/test/test.native.js
@@ -22,10 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -69,8 +68,6 @@ tape( 'if provided a non-positive `k`, the function returns `NaN`', opts, functi
 
 tape( 'the function returns the expected value of a chi distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -79,13 +76,7 @@ tape( 'the function returns the expected value of a chi distribution', opts, fun
 	k = data.k;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = mean( k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/chi/mean` from computed relative-tolerance comparisons (`delta = abs( y - expected[ i ] )` / `tol = 3.0 * EPS * abs( expected[ i ] )`, asserted via `t.ok( delta <= tol, ... )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to the two tolerance-based assertion sites in the package: one each in `test/test.js` and `test/test.native.js`. Both iterate over the same 50-point `test/fixtures/julia/data.json` fixture.
-   collapses the `if ( y === expected[i] ) { ... } else { ... }` branch at each site into a single ULP assertion, and standardizes the assertion message to `'returns expected value'`.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires and the `delta` and `tol` variable declarations.

The remaining assertions in these files are exact comparisons (`NaN` propagation for `NaN`, negative, and non-positive `k`, and function types), which are correct as-is and are left unchanged.

Only test files are changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| File | Implementation | Previous tolerance | ULP bound |
| --- | --- | --- | :-: |
| `test/test.js` | JavaScript, main export | `3.0 * EPS * abs( expected )` | `4` |
| `test/test.native.js` | C | `3.0 * EPS * abs( expected )` | `4` |

`4` is the minimum integer bound `N` such that `isAlmostSameValue( y, expected[ i ], N )` holds at every element of the fixture. It was determined by computing the per-element ULP distance directly outside the test harness over the full 50-point fixture (maximum: `4`) and then confirming the result through the test suite: at `N = 4` the suite is fully passing (55 assertions in each of the two files), and at `N = 3` an assertion fails, so no tighter bound exists.

Of the 50 fixture points, 18 are reproduced bit-for-bit and 32 differ from the Julia reference. The worst case is `k = 12.841745593327225`, where the expected value is `3.5145180217289225` and both implementations return `3.5145180217289242`. That is a relative error of roughly `5.1e-16`, accumulated in the ratio of gamma functions used to evaluate the mean; the previous `3.0 * EPS` relative tolerance permitted roughly `6.7e-16`, so the new bound is slightly tighter than the tolerance it replaces rather than a loosening of the existing test.

The JavaScript and C implementations agree bit-for-bit at every fixture point, including the worst case, so both files share the same bound.

`make test TESTS_FILTER=".*/stats/base/dists/chi/mean/.*"` was run twice at the final bound with identical results on both runs, ruling out FMA/architecture-dependent flakiness on this platform. The native add-on was built locally (`make install-node-addons NODE_ADDONS_PATTERN="stats/base/dists/chi/mean"`) so that `test.native.js` actually executed rather than being skipped; its 55 assertions pass. `make eslint-tests TESTS_FILTER=".*/stats/base/dists/chi/mean/.*"` is clean, as is `make lint-license-headers-files` for the changed files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The resulting diff mirrors the already-merged migrations for the sibling distribution packages `stats/base/dists/chi/variance`, `stats/base/dists/chi/entropy`, and `stats/base/dists/chi/cdf` (#15178), which share the same test structure.

Two environment notes, neither of which affected verification:

-   `make install-node-modules` initially failed with `ETARGET` for `es-object-atoms@^1.1.2`. The local npm packument cache was stale and served a filtered view of the registry; after `npm cache clean --force`, the install and `make init` completed and the full toolchain was available for this PR.
-   The `pre-commit` hook's `lint-editorconfig-files` step could not run, because it downloads the `editorconfig-checker` binary from a GitHub release that this environment cannot reach. The changed files were instead checked manually against `.editorconfig`: LF line endings, tab indentation, no trailing whitespace, and a final newline.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously migrated packages in the same family to match the established idiom, performed the migration, and determined the minimum passing ULP bound empirically over the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019L4jwpaMHa2ttoZqXRjQqB

---
_Generated by [Claude Code](https://claude.ai/code/session_019L4jwpaMHa2ttoZqXRjQqB)_