### PR TITLE
style: add whitespace

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/rank-users/lib/shuffle.js
+++ b/lib/node_modules/@stdlib/_tools/github/rank-users/lib/shuffle.js
@@ -30,7 +30,7 @@ function shuffle( data, sorted ) {
 	var i;
 	out = [];
 	for ( i = 0; i < data.length; i++ ) {
-		out.push( data[ sorted[i][0] ] );
+		out.push( data[ sorted[ i ][ 0 ] ] );
 	}
 	return out;
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/test/test.factory.js
@@ -145,7 +145,7 @@ tape( 'the created function evaluates the pdf for `x` given small range `b - a`'
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( a[i], b[i] );
 		y = pdf( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -166,7 +166,7 @@ tape( 'the created function evaluates the pdf for `x` given a medium range `b - 
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( a[i], b[i] );
 		y = pdf( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -187,7 +187,7 @@ tape( 'the created function evaluates the pdf for `x` given a large range `b - a
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( a[i], b[i] );
 		y = pdf( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/test/test.native.js
@@ -106,7 +106,7 @@ tape( 'the function evaluates the pdf for `x` given a small range `b - a`', opts
 	b = smallRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], a[i], b[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -125,7 +125,7 @@ tape( 'the function evaluates the pdf for `x` given a medium range `b - a`', opt
 	b = mediumRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], a[i], b[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -144,7 +144,7 @@ tape( 'the function evaluates the pdf for `x` given a large range `b - a`', opts
 	b = largeRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], a[i], b[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/test/test.pdf.js
@@ -97,7 +97,7 @@ tape( 'the function evaluates the pdf for `x` given a small range `b - a`', func
 	b = smallRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], a[i], b[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -116,7 +116,7 @@ tape( 'the function evaluates the pdf for `x` given a medium range `b - a`', fun
 	b = mediumRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], a[i], b[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -135,7 +135,7 @@ tape( 'the function evaluates the pdf for `x` given a large range `b - a`', func
 	b = largeRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], a[i], b[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   provides follow-up fixes for commits merged to `develop` between 2026-09-11 10:23 PDT (`10a84e4`) and 2026-09-12 00:43 PDT (`c88d3f4`)
-   fixes the array-index spacing in 6224797: `expected[i]` → `expected[ i ]` across the nine new assertion lines in `stats/base/dists/uniform/pdf/test/test.factory.js`, `test/test.native.js`, and `test/test.pdf.js`, matching sibling ULP-migration commits and the style guide
-   fixes the bracket spacing in `_tools/github/rank-users/lib/shuffle.js`: `sorted[i][0]` → `sorted[ i ][ 0 ]`. 10a84e4 fixed this same pattern in `blas/base/drotg` and `stats/ttest` but missed this line

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

All 12 commits merged to `develop` in the review window were audited for bugs and stdlib style-guide compliance (independent style and bug review passes over the union and per-commit diffs; migrated tests were re-run). Only objective, in-diff issues were retained: findings on unchanged context lines, subjective suggestions, and anything reverting deliberate choices (e.g. the `[]` + `push()` rewrite in `rank-users/lib/shuffle.js`) were deliberately excluded. Affected `uniform/pdf` tests pass after the change.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code as part of an automated daily review of commits merged to `develop`; a human maintainer will audit before promoting it from draft.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Re27E1SsN9jErvG9tU8e75

---
_Generated by [Claude Code](https://claude.ai/code/session_01Re27E1SsN9jErvG9tU8e75)_