### PR TITLE
fix(@stdlib/blas/ext/circshift): validate broadcast compatibility of ndarray `k`

### DIFF
--- a/lib/node_modules/@stdlib/array/float16/benchmark/benchmark.find_last_index.length.js
+++ b/lib/node_modules/@stdlib/array/float16/benchmark/benchmark.find_last_index.length.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable stdlib/jsdoc-typedef-typos */
-
 'use strict';
 
 // MODULES //

--- a/lib/node_modules/@stdlib/array/float16/benchmark/polyfill/benchmark.find_last_index.length.js
+++ b/lib/node_modules/@stdlib/array/float16/benchmark/polyfill/benchmark.find_last_index.length.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable stdlib/jsdoc-typedef-typos */
-
 'use strict';
 
 // MODULES //

--- a/lib/node_modules/@stdlib/blas/ext/circshift/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/circshift/lib/main.js
@@ -85,8 +85,8 @@ function circshift( x, k ) {
 		}
 		// Case: circshift( x, k_ndarray )
 		if ( isndarrayLike( k ) ) {
-			// As the operation is performed across all dimensions, `k` is assumed to be a zero-dimensional ndarray...
-			return base( x, k );
+			// As the operation is performed across all dimensions, `k` must be broadcast compatible with a zero-dimensional ndarray...
+			return base( x, maybeBroadcastArray( k, [] ) );
 		}
 		throw new TypeError( format( 'invalid argument. Second argument must be either an ndarray or an integer. Value: `%s`.', k ) );
 	}
@@ -104,11 +104,11 @@ function circshift( x, k ) {
 	}
 	// Case: circshift( x, k_ndarray, opts )
 	else if ( isndarrayLike( k ) ) {
-		// When not provided `dims`, the operation is performed across all dimensions and `k` is assumed to be a zero-dimensional ndarray; when `dims` is provided, we need to broadcast `k` to match the shape of the non-core dimensions...
+		// When not provided `dims`, the operation is performed across all dimensions and `k` must be broadcast compatible with a zero-dimensional ndarray; when `dims` is provided, we need to broadcast `k` to match the shape of the non-core dimensions...
 		if ( hasOwnProp( opts, 'dims' ) ) {
 			ka = maybeBroadcastArray( k, nonCoreShape( getShape( x ), opts.dims ) ); // eslint-disable-line max-len
 		} else {
-			ka = k;
+			ka = maybeBroadcastArray( k, [] );
 		}
 	} else {
 		throw new TypeError( format( 'invalid argument. Second argument must be either an ndarray or an integer. Value: `%s`.', k ) );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   removes stale `eslint-disable stdlib/jsdoc-typedef-typos` directives from two `@stdlib/array/float16` benchmark files. The directives were left over from when the files were generated (`21979acc1`), and no JSDoc typedef in either file requires suppression. This caused the `Lint JavaScript files` job in `lint_random_files` to fail with `Unused eslint-disable directive` ([run 34660299012](https://github.com/stdlib-js/stdlib/actions/runs/34660299012)). Because `lint_random_files` samples files randomly, either file would trip the same failure whenever selected.
-   validates broadcast compatibility of an ndarray `k` argument in `@stdlib/blas/ext/circshift`. When `k` is ndarray-like and either no `options` argument is provided, or an `options` argument is provided without a `dims` property, `main.js` forwarded `k` directly to `base()`, assuming in a comment that `k` was zero-dimensional without ever validating that assumption via `maybeBroadcastArray`. Both paths now call `maybeBroadcastArray( k, [] )`, matching the `dims` path and the scalar-`k` paths. This surfaced as failing `t.throws()` assertions in the `Run JavaScript tests` job of `run_affected_tests` ([run 34628158282](https://github.com/stdlib-js/stdlib/actions/runs/34628158282)); the run was triggered by an unrelated commit to `ndarray/data-buffer`, and `circshift` tests ran as "affected" via a shared dependency. The bug dates to the package's initial commit (`0cf98212`, #11189) and is not a regression.

The two fixes are independent and are bundled here only because both were found during the same audit of the last 24 hours of workflow runs on `develop`.

Verification:

-   `make lint-javascript-files ... ESLINT_CONF=.eslintrc.benchmarks.js` reports 0 problems on both benchmark files.
-   `node lib/node_modules/@stdlib/blas/ext/circshift/test/test.js` passes 270/270 (6 assertions previously failed with `actual: undefined`). ESLint reports 0 errors on the changed file (2 pre-existing, untouched warnings on unrelated lines).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   N/A

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Each fix was reviewed by three independent automated reviewers (correctness, regression scope, and style/conventions) prior to inclusion. All three approved both fixes with no blocking findings.

One non-blocking note from that review: `@stdlib/blas/ext/sort` and `@stdlib/blas/ext/sorthp` appear to share the same unbroadcast-`k` pattern as `circshift` prior to this change. Left for separate follow-up in order to keep this diff minimal and scoped.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was generated by an automated CI-monitoring routine running Claude Code. The routine identified the failing jobs, root-caused each failure, implemented the fixes, and validated them against the affected package test suites and three independent automated reviewers before opening this PR as a draft for human review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kTUruwTPH3w1B2qvRkNvB


---
_Generated by [Claude Code](https://claude.ai/code/session_016kTUruwTPH3w1B2qvRkNvB)_