### PR TITLE
test: migrate `stats/base/dists/logistic/mean` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mean/test/test.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mean = require( './../lib' );
 
 
@@ -76,8 +75,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', function test
 
 tape( 'the function returns the expected value of a logistic distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var s;
 	var y;
@@ -89,13 +86,7 @@ tape( 'the function returns the expected value of a logistic distribution', func
 	for ( i = 0; i < mu.length; i++ ) {
 		y = mean( mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for `stats/base/dists/logistic/mean` from relative tolerance (EPS/delta/tol) assertions to ULP difference assertions using `@stdlib/assert/is-almost-same-value`.
-   updates `test/test.js`. No other files are changed.
-   removes the now-unused `EPS` and `abs` imports and the corresponding `delta`/`tol` variable declarations.
-   verifies that the tests still pass identically under the 1 ULP bound. `test.native.js` was already using strict equality and required no changes.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding


### Disclosure
{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers
