### PR TITLE
test: migrate `stats/kruskal-test` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/kruskal-test/test/test.js
+++ b/lib/node_modules/@stdlib/stats/kruskal-test/test/test.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var contains = require( '@stdlib/assert/contains' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var kruskalTest = require( './../lib' );
 
 
@@ -163,8 +162,6 @@ tape( 'the function throws an error if the `groups` option array does not contai
 
 tape( 'the function correctly computes a Kruskal-Wallis test (no ties)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var out;
 
 	out = kruskalTest( noties.x, {
@@ -173,22 +170,16 @@ tape( 'the function correctly computes a Kruskal-Wallis test (no ties)', functio
 
 	// Tested against R:
 	expected = noties.pValue;
-	delta = abs( out.pValue - expected );
-	tol = 3.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. p-value: '+out.pValue+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.pValue, expected, 1 ), true, 'returns expected value' );
 
 	expected = noties.statistic;
-	delta = abs( out.statistic - expected );
-	tol = 2.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. test statistic: '+out.statistic+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.statistic, expected, 0 ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function correctly computes a Kruskal-Wallis test (ties)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var out;
 
 	out = kruskalTest( ties.x, {
@@ -197,14 +188,10 @@ tape( 'the function correctly computes a Kruskal-Wallis test (ties)', function t
 
 	// Tested against R:
 	expected = ties.pValue;
-	delta = abs( out.pValue - expected );
-	tol = 3.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. p-value: '+out.pValue+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.pValue, expected, 1 ), true, 'returns expected value' );
 
 	expected = ties.statistic;
-	delta = abs( out.statistic - expected );
-	tol = 2.0 * EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. test statistic: '+out.statistic+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( out.statistic, expected, 0 ), true, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/kruskal-test` from computed relative-tolerance comparisons (`delta = abs( out.pValue - expected )` / `tol = 3.0 * EPS * abs( expected )`, asserted via `t.ok( delta <= tol, ... )`) to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to the four tolerance-based assertions in `test/test.js`: the p-value and test statistic in each of the "no ties" and "ties" tests, which are checked against R fixtures.
-   standardizes the assertion message to `'returns expected value'`.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires and the `delta` and `tol` variable declarations.

This mirrors the already-merged migration of `stats/fligner-test`, which has the same shape (an R fixture compared against `out.pValue` and `out.statistic`) and which uses the same inline per-assertion ULP bound idiom.

The remaining assertions in the file are exact comparisons (the arity check, the `typeof table === 'string'` checks on the `.print()` method, the `contains` check, and the `t.throws` validation cases), which are correct as-is and are left unchanged. `test/test.validate.js` contains no tolerance-based assertions and is untouched.

Only a test file is changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| Test | Value | Previous tolerance | ULP bound |
| --- | --- | --- | :-: |
| correctly computes a Kruskal-Wallis test (no ties) | `out.pValue` | `3.0 * EPS * abs( expected )` | `1` |
| correctly computes a Kruskal-Wallis test (no ties) | `out.statistic` | `2.0 * EPS * abs( expected )` | `0` |
| correctly computes a Kruskal-Wallis test (ties) | `out.pValue` | `3.0 * EPS * abs( expected )` | `1` |
| correctly computes a Kruskal-Wallis test (ties) | `out.statistic` | `2.0 * EPS * abs( expected )` | `0` |

Each bound is the minimum integer `N` such that `isAlmostSameValue( actual, expected, N )` holds. The bounds were determined by measuring the ULP distance of each compared value directly (searching upward from `0` for the smallest passing `N`), and then confirmed through the test suite: at the bounds above the package is fully passing (63 assertions), and decrementing both non-zero bounds to `0` causes exactly the two corresponding p-value assertions to fail (61 passing, 2 failing), so no tighter bounds exist.

The two bounds of `0` correspond to the test statistics, which are reproduced bit-for-bit against the R fixtures (`0.7714285714285722` and `0.8308080808080898`), so those assertions reduce to `SameValue` equality. The p-values differ from the R fixtures in the final bit only (e.g. `0.6799647735788935` vs. `0.6799647735788936`). In every case the new bound is at most the relative tolerance it replaces, so this is a tightening rather than a loosening of the existing tests.

`make test TESTS_FILTER=".*/stats/kruskal-test/.*"` was run twice at the final bounds with identical results on both runs (63 passing assertions, 0 failing), ruling out FMA/architecture-dependent flakiness on this platform. The assertion count is unchanged from the pre-migration baseline. `make lint-javascript-tests TESTS_FILTER=".*/stats/kruskal-test/.*"` is clean.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

One environment note, which did not affect verification: `make install-node-modules` initially failed with `ETARGET` for `es-object-atoms@^1.1.2`. The local npm packument cache was stale and served a filtered view of the registry; after `npm cache clean --force`, the install completed and the full toolchain was available for this PR. (The same issue was noted in #15188.)

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously migrated packages in the same family to match the established idiom, performed the migration, and determined the minimum passing ULP bounds empirically.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123R7WBTkA4TCS6MFS2zLKX

---
_Generated by [Claude Code](https://claude.ai/code/session_0123R7WBTkA4TCS6MFS2zLKX)_