### PR TITLE
test: migrate `simulate/iter/sine-wave` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/simulate/iter/sine-wave/test/test.js
+++ b/lib/node_modules/@stdlib/simulate/iter/sine-wave/test/test.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var proxyquire = require( 'proxyquire' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var iteratorSymbol = require( '@stdlib/symbol/iterator' );
 var sinpi = require( '@stdlib/math/base/special/sinpi' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var iterSineWave = require( './../lib' );
 
 
@@ -100,10 +99,11 @@ tape( 'the function throws an error if provided an invalid option', function tes
 tape( 'the function returns an iterator protocol-compliant object which generates a sine wave', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
+	var ULP;
 	var it;
 	var i;
+
+	ULP = 4;
 
 	expected = [
 		{
@@ -162,13 +162,7 @@ tape( 'the function returns an iterator protocol-compliant object which generate
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -176,11 +170,12 @@ tape( 'the function returns an iterator protocol-compliant object which generate
 tape( 'the function supports specifying the waveform period', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
+	var ULP;
 	var it;
 	var i;
+
+	ULP = 0;
 
 	expected = [
 		{
@@ -242,13 +237,7 @@ tape( 'the function supports specifying the waveform period', function test( t )
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -256,11 +245,12 @@ tape( 'the function supports specifying the waveform period', function test( t )
 tape( 'the function supports specifying the wave amplitude', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
+	var ULP;
 	var it;
 	var i;
+
+	ULP = 4;
 
 	expected = [
 		{
@@ -323,13 +313,7 @@ tape( 'the function supports specifying the wave amplitude', function test( t ) 
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -337,11 +321,12 @@ tape( 'the function supports specifying the wave amplitude', function test( t ) 
 tape( 'the function supports specifying the phase offset (left shift)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
+	var ULP;
 	var it;
 	var i;
+
+	ULP = 0;
 
 	expected = [
 		{
@@ -404,13 +389,7 @@ tape( 'the function supports specifying the phase offset (left shift)', function
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -418,11 +397,12 @@ tape( 'the function supports specifying the phase offset (left shift)', function
 tape( 'the function supports specifying the phase offset (left shift; mod)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
+	var ULP;
 	var it;
 	var i;
+
+	ULP = 0;
 
 	expected = [
 		{
@@ -485,13 +465,7 @@ tape( 'the function supports specifying the phase offset (left shift; mod)', fun
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -499,11 +473,12 @@ tape( 'the function supports specifying the phase offset (left shift; mod)', fun
 tape( 'the function supports specifying the phase offset (right shift)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
+	var ULP;
 	var it;
 	var i;
+
+	ULP = 0;
 
 	expected = [
 		{
@@ -566,13 +541,7 @@ tape( 'the function supports specifying the phase offset (right shift)', functio
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -580,11 +549,12 @@ tape( 'the function supports specifying the phase offset (right shift)', functio
 tape( 'the function supports specifying the phase offset (right shift; mod)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var opts;
-	var tol;
+	var ULP;
 	var it;
 	var i;
+
+	ULP = 0;
 
 	expected = [
 		{
@@ -647,13 +617,7 @@ tape( 'the function supports specifying the phase offset (right shift; mod)', fu
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = it.next();
 		t.strictEqual( actual.done, expected[ i ].done, 'returns expected value' );
-		if ( actual.value === expected[ i ].value ) {
-			t.strictEqual( actual.value, expected[ i ].value, 'returns expected value' );
-		} else {
-			delta = abs( actual.value - expected[ i ].value );
-			tol = 1.0 * EPS * abs( expected[ i ].value );
-			t.strictEqual( delta <= tol, true, 'within tolerance. i: '+i+'. actual: '+actual.value+'. expected: '+expected[ i ].value+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( actual.value, expected[ i ].value, ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `simulate/iter/sine-wave` test assertions from relative-tolerance (`delta`/`tol`/`EPS`) comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   uses a single named `ULP` constant per test body, tightened to the minimum integer value that still passes over the full fixture set (verified deterministic across two consecutive test runs):
    -   `the function returns an iterator protocol-compliant object which generates a sine wave`: `ULP = 4`
    -   `the function supports specifying the waveform period`: `ULP = 0`
    -   `the function supports specifying the wave amplitude`: `ULP = 4`
    -   `the function supports specifying the phase offset (left shift)`: `ULP = 0`
    -   `the function supports specifying the phase offset (left shift; mod)`: `ULP = 0`
    -   `the function supports specifying the phase offset (right shift)`: `ULP = 0`
    -   `the function supports specifying the phase offset (right shift; mod)`: `ULP = 0`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, which converted the test file's tolerance-based assertions to ULP-based assertions and determined the minimum ULP constants by running the test suite.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJ65DkgxuX13fo7txuU9yZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJ65DkgxuX13fo7txuU9yZ)_