### PR TITLE
test: migrate `stats/base/dists/pareto-type1/entropy` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/entropy/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/entropy/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var entropy = require( './../lib' );
 
 
@@ -96,10 +95,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the differential entropy of a Pareto (Type I) distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -108,13 +105,7 @@ tape( 'the function returns the differential entropy of a Pareto (Type I) distri
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/entropy/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/entropy/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -105,10 +104,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 
 tape( 'the function returns the differential entropy of a Pareto (Type I) distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -117,13 +114,7 @@ tape( 'the function returns the differential entropy of a Pareto (Type I) distri
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = entropy( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/pareto-type1/entropy` from a computed relative-tolerance comparison (`delta = abs( y - expected[ i ] )` / `tol = 3.0 * EPS * abs( expected[ i ] )`, asserted via `t.ok( delta <= tol, ... )`) to a ULP-difference assertion using `@stdlib/assert/is-almost-same-value`.
-   applies the migration to the single tolerance-based assertion site in each of `test/test.js` and `test/test.native.js`. The remaining assertions in both files are exact `NaN` checks for invalid `alpha`/`beta` parameters and a function-type check, which are correct as-is and are left unchanged.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires, along with the `delta` and `tol` variable declarations.
-   collapses the `if ( y === expected[i] ) { ... } else { ... }` branch in the differential-entropy test into a single ULP assertion, matching the migrated idiom.

Only test files are changed; no implementation, fixture, or documentation changes are included.

### ULP bounds

| Assertion | Previous tolerance | ULP bound |
| --- | --- | :-: |
| the function returns the differential entropy of a Pareto (Type I) distribution (`test/test.js`, 1000 fixture values) | `3.0 * EPS * abs( expected )` | `4` |
| the function returns the differential entropy of a Pareto (Type I) distribution (`test/test.native.js`, 1000 fixture values) | `3.0 * EPS * abs( expected )` | `4` |

`4` is the minimum integer bound `N` such that `isAlmostSameValue( y, expected[ i ], N )` holds at every element of the Julia fixture. It was measured by starting from a high bound (`64`, which passes) and tightening, computing the per-element ULP distance directly outside the test harness and then confirming through the test suite: at `N = 4` the suite is 1014/1014 passing, and at `N = 3` four assertions fail (1010/1014), so no tighter bound exists.

The per-element ULP differences over the 1000 fixture values are distributed as: `0` ULP for 532 values, `1` ULP for 404, `2` ULP for 58, `3` ULP for 2, and `4` ULP for 4. The worst case is `alpha = 19.87969894620201`, `beta = 10.872919216640467`, where the implementation returns `0.4468787373289458` against an expected `0.446878737328946`. The implementation evaluates `ln( ( beta/alpha ) * exp( 1.0 + ( 1.0/alpha ) ) )`, so an `exp` is composed with a `ln` and the intermediate rounding accumulates a few ULP relative to the Julia reference; the original test anticipated this by branching on `y === expected[i]` and falling back to a relative tolerance for the inexact cases.

`make test TESTS_FILTER=".*/stats/base/dists/pareto-type1/entropy/.*"` was run twice at the final bound with identical results: 1014/1014 passing on both runs, no failures, ruling out FMA/architecture-dependent flakiness on this platform. `test/test.native.js` reports 0 tests on both runs, as the native add-on is not built in this environment and `tryRequire` skips the suite; its bound mirrors the JavaScript bound, consistent with the sibling migrations in this family. `make eslint-tests TESTS_FILTER=".*/stats/base/dists/pareto-type1/entropy/.*"` is clean.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The resulting diff mirrors the already-merged migrations for the sibling distribution packages `stats/base/dists/pareto-type1/skewness` (#14955), `stats/base/dists/pareto-type1/kurtosis` (#14119), and `stats/base/dists/pareto-type1/mean` (#14763), which share the same test structure.

Two environment notes, neither of which affected verification:

-   `make install-node-modules` initially failed with `ETARGET` for `es-object-atoms@^1.1.2`. The install completed after pinning that transitive dependency to `1.1.1` for the duration of the install; `package.json` was restored to its committed state afterwards and is not part of this diff.
-   The `pre-commit` hook's `lint-editorconfig-files` step could not run, because it downloads the `editorconfig-checker` binary from a GitHub release that this environment cannot reach. The changed files were instead checked manually against `.editorconfig`: LF line endings, tab indentation, no newly introduced trailing whitespace, and a final newline.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, running as an unattended scheduled task. It selected the package, studied previously migrated packages in the same family to match the established idiom, performed the migration, and determined the minimum passing ULP bound empirically at the assertion site.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpCN8rd353ijcNsGBjPQs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpCN8rd353ijcNsGBjPQs4)_