### PR TITLE
fix: validate fixed-endian ArrayBuffer view alignment

### DIFF
--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -235,6 +235,7 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	* @throws {TypeError} byte offset must be a nonnegative integer
 	* @throws {RangeError} must provide sufficient memory to accommodate byte offset and view length requirements
 	* @throws {RangeError} byte offset must be a multiple of the data type size
+	* @throws {RangeError} view byte length must be a multiple of the data type size
 	* @throws {TypeError} view length must be a positive multiple of the data type size
 	* @returns {TypedArray} typed array instance
 	*/
@@ -308,7 +309,14 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 			if ( !isNonNegativeInteger( byteOffset ) ) {
 				throw new TypeError( format( 'invalid argument. Byte offset must be a nonnegative integer. Value: `%s`.', byteOffset ) );
 			}
+			if ( !isInteger( byteOffset/BYTES_PER_ELEMENT ) ) {
+				throw new RangeError( format( 'invalid argument. Byte offset must be a multiple of %u. Value: `%u`.', BYTES_PER_ELEMENT, byteOffset ) );
+			}
 			if ( nargs === 2 ) {
+				len = buf.byteLength - byteOffset;
+				if ( !isInteger( len/BYTES_PER_ELEMENT ) ) {
+					throw new RangeError( format( 'invalid arguments. ArrayBuffer view byte length must be a multiple of %u. View byte length: `%u`.', BYTES_PER_ELEMENT, len ) );
+				}
 				buf = new DataView( buf, byteOffset );
 			} else {
 				len = arguments[ 3 ];

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var ArrayBuffer = require( '@stdlib/array/buffer' );
 var factory = require( './../lib' );
 
 
@@ -32,4 +33,72 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-// TODO: add tests
+tape( 'the constructor returns an array for valid aligned byte offsets and omitted lengths', function test( t ) {
+	var Float32ArrayFE = factory( 'float32' );
+	var arr;
+
+	arr = new Float32ArrayFE( 'little-endian', new ArrayBuffer( 12 ), 4 );
+	t.strictEqual( arr.length, 2, 'returns expected value' );
+
+	arr = new Float32ArrayFE( 'little-endian', new ArrayBuffer( 12 ), 12 );
+	t.strictEqual( arr.length, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor throws an error if provided a byte offset which is not a multiple of 4', function test( t ) {
+	var Float32ArrayFE = factory( 'float32' );
+	var values;
+	var i;
+
+	values = [
+		2,
+		6
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), RangeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return new Float32ArrayFE( 'little-endian', new ArrayBuffer( 12 ), value );
+		};
+	}
+});
+
+tape( 'the constructor throws an error if the remaining byte length is not a multiple of 4', function test( t ) {
+	var Float32ArrayFE = factory( 'float32' );
+
+	t.throws( function badValue() {
+		return new Float32ArrayFE( 'little-endian', new ArrayBuffer( 10 ) );
+	}, RangeError, 'throws an error when the remaining byte length is not a multiple of 4' );
+	t.end();
+});
+
+tape( 'the constructor allows trailing bytes when an explicit length fits', function test( t ) {
+	var Float32ArrayFE = factory( 'float32' );
+	var arr;
+
+	arr = new Float32ArrayFE( 'little-endian', new ArrayBuffer( 10 ), 0, 2 );
+	t.strictEqual( arr.length, 2, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the constructor throws an error if provided insufficient memory to accommodate byte offset and length arguments', function test( t ) {
+	var Float32ArrayFE = factory( 'float32' );
+
+	t.throws( function badValue() {
+		return new Float32ArrayFE( 'little-endian', new ArrayBuffer( 10 ), 4, 2 );
+	}, RangeError, 'throws an error when provided insufficient memory' );
+	t.end();
+});
+
+tape( 'the constructor throws an error if provided a fractional length', function test( t ) {
+	var Float32ArrayFE = factory( 'float32' );
+
+	t.throws( function badValue() {
+		return new Float32ArrayFE( 'little-endian', new ArrayBuffer( 12 ), 0, 1.5 );
+	}, TypeError, 'throws an error when provided a fractional length' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #15193.

## Description

> What is the purpose of this pull request?

This pull request:

* validates that an `ArrayBuffer` byte offset is aligned to the data type's `BYTES_PER_ELEMENT`
* validates that the remaining view byte length is divisible by `BYTES_PER_ELEMENT` when no explicit length is provided
* prevents the creation of fixed-endian typed arrays with fractional lengths
* adds tests covering valid aligned offsets, zero-length views, misaligned offsets, invalid remaining byte lengths, explicit lengths with trailing bytes, insufficient memory, and fractional lengths

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

* #15193

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Package tests pass successfully. `git diff --check` also passes.

Local ESLint validation could not be completed due to an existing dependency/configuration mismatch in the local development environment involving `eslint-plugin-stdlib` and the `stdlib/jsdoc-markdown-remark` rule.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

### AI Assistance

* [x] Yes

* [ ] No

* [ ] Code generation (e.g., when writing an implementation or fixing a bug)

* [x] Test/benchmark generation

* [ ] Documentation (including examples)

* [x] Research and understanding

#### Disclosure

I used AI assistance for tests and understanding the issue.

---

@stdlib-js/reviewers